### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following minimal example evaluates the hugging face model `sbintuitions/tin
 flexeval_lm \
   --language_model HuggingFaceLM \
   --language_model.model_name "sbintuitions/tiny-lm" \
+  --language_model.tokenizer_kwargs '{use_fast: false}' \
   --eval_setup "commonsense_qa" \
   --save_dir "results/commonsense_qa"
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -41,6 +41,7 @@ pip install flexeval
 flexeval_lm \
   --language_model HuggingFaceLM \
   --language_model.model_name "sbintuitions/tiny-lm" \
+  --language_model.tokenizer_kwargs '{use_fast: false}' \
   --eval_setup "aio" \
   --save_dir "results/aio"
 ```


### PR DESCRIPTION
I think that the `sbintuitions/tiny-lm` model requires the tokenizer option `use_fast: false`, but it's missing.
I confirmed that using `use_fast: false` improves the exact_match score.