### PR TITLE
Fixed a bug where `config.json` was not overwritten

### DIFF
--- a/flexeval/scripts/flexeval_lm.py
+++ b/flexeval/scripts/flexeval_lm.py
@@ -320,6 +320,8 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
                     f"Overwriting the existing file: {save_dir / CONFIG_FILE_NAME}",
                 )
 
+                save_json(task_config, save_dir / CONFIG_FILE_NAME)
+
         try:
             with Timer() as timer:
                 metrics, outputs = eval_setup.evaluate_lm(


### PR DESCRIPTION
I think `config.json` should be overwritten when running `flexeval_lm ... --force true`, but it seems that the overwrite process was missing, so I suggest adding it.
