### PR TITLE
`ChatResponse` の評価時に `few_shot_generator` を指定できるようにする

### DIFF
--- a/flexeval/core/chat_dataset/base.py
+++ b/flexeval/core/chat_dataset/base.py
@@ -43,6 +43,15 @@ class ChatInstance:
             msg = "extra_info cannot contain a key named 'messages'. It will conflict with the 'messages' attribute."
             raise ValueError(msg)
 
+    @property
+    def inputs(self) -> list[dict[str, str]]:
+        """
+        Alias for `messages`.
+        This is used in `FewShotGenerator` so that it can access the inputs with the same attribute name as
+        `GenerationInstance` and `MultipleChoiceInstance`.
+        """
+        return self.messages
+
 
 class ChatDataset(ABC):
     """A dataset holding `ChatInstance`."""

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -39,7 +39,8 @@ def evaluate_chat_response(  # noqa: C901,PLR0912
                     if not isinstance(few_shot_instances[0], ChatInstance):
                         msg = f"Invalid instance type: {type(few_shot_instances[0])}"
                         raise TypeError(msg)
-                    input_messages_list[input_id] += [*few_shot_instances, *input_messages_list[input_id]]
+                    few_shot_messages = [m for instance in few_shot_instances for m in instance.messages]
+                    input_messages_list[input_id] += [*few_shot_messages, *input_messages_list[input_id]]
 
             if not eval_dataset.require_incremental_response():
                 lm_outputs = language_model.batch_generate_chat_response(

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -6,6 +6,7 @@ from typing import Any
 from tqdm import tqdm
 
 from .chat_dataset import ChatDataset, ChatInstance
+from .few_shot_generator import FewShotGenerator
 from .language_model import LanguageModel
 from .metric import Metric
 from .utils.data_util import batch_iter
@@ -13,12 +14,13 @@ from .utils.data_util import batch_iter
 logger = logging.getLogger(__name__)
 
 
-def evaluate_chat_response(
+def evaluate_chat_response(  # noqa: C901,PLR0912
     language_model: LanguageModel,
     gen_kwargs: dict[str, Any],
     eval_dataset: ChatDataset,
     metrics: list[Metric],
     batch_size: int,
+    few_shot_generator: FewShotGenerator | None = None,
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     logger.info(f"Evaluate the model with gen_kwargs: {gen_kwargs}")
 
@@ -26,10 +28,19 @@ def evaluate_chat_response(
     references_list: list[list[str]] = []
     extra_info_list: list[dict[str, Any]] = []
     with tqdm(total=len(eval_dataset)) as pbar:
-        for i, batch in enumerate(batch_iter(eval_dataset, batch_size)):
+        for batch_id, batch in enumerate(batch_iter(eval_dataset, batch_size)):
             batch: list[ChatInstance]
 
             input_messages_list = [chat_instance.messages for chat_instance in batch]
+
+            if few_shot_generator is not None:
+                for input_id in range(len(input_messages_list)):
+                    few_shot_instances = few_shot_generator(eval_inputs=input_messages_list[input_id])
+                    if not isinstance(few_shot_instances[0], ChatInstance):
+                        msg = f"Invalid instance type: {type(few_shot_instances[0])}"
+                        raise TypeError(msg)
+                    input_messages_list[input_id] += [*few_shot_instances, *input_messages_list[input_id]]
+
             if not eval_dataset.require_incremental_response():
                 lm_outputs = language_model.batch_generate_chat_response(
                     input_messages_list,
@@ -65,7 +76,7 @@ def evaluate_chat_response(
             references_list += [chat_instance.references for chat_instance in batch]
             extra_info_list += [chat_instance.extra_info for chat_instance in batch]
 
-            if i == 0:
+            if batch_id == 0:
                 logger.info("Example of the conversation")
                 logger.info(f"{all_messages_list[0]}")
 

--- a/flexeval/core/few_shot_generator/balanced.py
+++ b/flexeval/core/few_shot_generator/balanced.py
@@ -38,7 +38,10 @@ class BalancedFewShotGenerator(FewShotGenerator):
             label_to_ids[instance.references[0]].append(i)
         self._label_to_ids = label_to_ids
 
-    def _sample_instances(self, eval_inputs: dict[str, Any] | None = None) -> list[GenerationInstance]:
+    def _sample_instances(
+        self,
+        eval_inputs: list[dict[str, Any]] | dict[str, Any] | None = None,
+    ) -> list[GenerationInstance]:
         # Shuffle labels
         labels = list(self._label_to_ids.keys())
         self._rnd.shuffle(labels)

--- a/flexeval/core/few_shot_generator/base.py
+++ b/flexeval/core/few_shot_generator/base.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Union
 
+from flexeval.core.chat_dataset import ChatDataset, ChatInstance
 from flexeval.core.generation_dataset import GenerationDataset, GenerationInstance
 from flexeval.core.multiple_choice_dataset import MultipleChoiceDataset, MultipleChoiceInstance
 
-Dataset = Union[GenerationDataset, MultipleChoiceDataset]
-Instance = Union[GenerationInstance, MultipleChoiceInstance]
+Dataset = Union[GenerationDataset, MultipleChoiceDataset, ChatDataset]
+Instance = Union[GenerationInstance, MultipleChoiceInstance, ChatInstance]
 
 
 class FewShotGenerator(ABC):
@@ -15,10 +16,27 @@ class FewShotGenerator(ABC):
         self._num_trials_to_avoid_leak = num_trials_to_avoid_leak
 
     @abstractmethod
-    def _sample_instances(self, eval_inputs: dict[str, Any] | None = None) -> list[Instance]:
+    def _sample_instances(self, eval_inputs: list[dict[str, Any]] | dict[str, Any] | None = None) -> list[Instance]:
+        """
+        Sample instances for few-shot learning.
+        This method should be implemented in the derived class.
+        """
         raise NotImplementedError
 
-    def __call__(self, eval_inputs: dict[str, Any] | None = None) -> list[Instance]:
+    def __call__(self, eval_inputs: list[dict[str, Any]] | dict[str, Any] | None = None) -> list[Instance]:
+        """
+        Sample instances for few-shot learning.
+        This method calls `_sample_instances` and
+        checks if the sampled instances have the same inputs as the evaluation instance.
+
+        Args:
+            eval_inputs: The inputs of the evaluation instance.
+                This is used to avoid data leakage
+                by checking if the sampled instances have the same inputs as the evaluation instance.
+
+        Returns:
+            A list of instances for few-shot learning.
+        """
         sampled_instances = self._sample_instances(eval_inputs=eval_inputs)
 
         # check if the sampled instances are the same as the eval_instance

--- a/flexeval/core/few_shot_generator/rand.py
+++ b/flexeval/core/few_shot_generator/rand.py
@@ -27,6 +27,6 @@ class RandomFewShotGenerator(FewShotGenerator):
         self._num_shots = num_shots
         self._rnd = random.Random(seed)
 
-    def _sample_instances(self, eval_inputs: dict[str, Any] | None = None) -> list[Instance]:
+    def _sample_instances(self, eval_inputs: list[dict[str, Any]] | dict[str, Any] | None = None) -> list[Instance]:
         sampled_indices = self._rnd.sample(range(len(self._dataset)), self._num_shots)
         return [self._dataset[i] for i in sampled_indices]

--- a/flexeval/scripts/flexeval_lm.py
+++ b/flexeval/scripts/flexeval_lm.py
@@ -66,6 +66,7 @@ class EvalSetup(ABC):
 class ChatResponse(EvalSetup):
     eval_dataset: ChatDataset
     gen_kwargs: dict[str, Any]
+    few_shot_generator: FewShotGenerator | None = None
     metrics: list[Metric] | Metric | None = None
     batch_size: int = 4
 
@@ -83,6 +84,7 @@ class ChatResponse(EvalSetup):
             eval_dataset=self.eval_dataset,
             metrics=metrics,
             batch_size=self.batch_size,
+            few_shot_generator=self.few_shot_generator,
         )
 
 

--- a/flexeval/scripts/flexeval_lm.py
+++ b/flexeval/scripts/flexeval_lm.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sys
+import traceback
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
@@ -345,7 +346,10 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
                     save_jsonl(outputs, save_dir / OUTPUTS_FILE_NAME)
 
         except Exception as e:  # noqa: BLE001
-            logger.warning(f"Error in evaluation:\n{e}")
+            stack_trace_str = "".join(traceback.format_exception(None, e, e.__traceback__))
+            logger.warning(
+                f"Error in evaluation:\n{e}\n{stack_trace_str}",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/core/few_show_generator/test_rand.py
+++ b/tests/core/few_show_generator/test_rand.py
@@ -1,6 +1,7 @@
 import pytest
 
 from flexeval.core.few_shot_generator.rand import Dataset, RandomFewShotGenerator
+from tests.dummy_modules.chat_dataset import DummyChatDataset
 from tests.dummy_modules.generation_dataset import DummyGenerationDataset
 from tests.dummy_modules.multiple_choice_dataset import DummyMultipleChoiceDataset
 
@@ -10,6 +11,7 @@ from tests.dummy_modules.multiple_choice_dataset import DummyMultipleChoiceDatas
     [
         (1, DummyGenerationDataset()),
         (2, DummyMultipleChoiceDataset()),
+        (2, DummyChatDataset()),
     ],
 )
 def test_random_few_shot_generator(num_shots: int, dataset: Dataset) -> None:
@@ -27,6 +29,7 @@ def test_random_few_shot_generator(num_shots: int, dataset: Dataset) -> None:
     [
         (42, DummyMultipleChoiceDataset()),
         (777, DummyGenerationDataset()),
+        (0, DummyChatDataset()),
     ],
 )
 def test_if_random_seed_is_consistent(seed: int, dataset: Dataset) -> None:
@@ -40,6 +43,7 @@ def test_if_random_seed_is_consistent(seed: int, dataset: Dataset) -> None:
     [
         DummyMultipleChoiceDataset(),
         DummyGenerationDataset(),
+        DummyChatDataset(),
     ],
 )
 def test_if_results_are_random(dataset: Dataset) -> None:
@@ -49,8 +53,15 @@ def test_if_results_are_random(dataset: Dataset) -> None:
     assert sampled_instances_1 != sampled_instances_2
 
 
-def test_if_few_show_sampler_avoids_leak() -> None:
-    dataset = DummyGenerationDataset()
+@pytest.mark.parametrize(
+    "dataset",
+    [
+        DummyMultipleChoiceDataset(),
+        DummyGenerationDataset(),
+        DummyChatDataset(),
+    ],
+)
+def test_if_few_show_sampler_avoids_leak(dataset: Dataset) -> None:
     eval_inputs = dataset[0].inputs
 
     # First check if the eval_instance may be in the sampled instances with `num_trials_to_avoid_leak=0`

--- a/tests/dummy_modules/chat_dataset.py
+++ b/tests/dummy_modules/chat_dataset.py
@@ -8,6 +8,7 @@ class DummyChatDataset(ChatDataset):
         self._data = [
             [{"role": "sysmtem", "text": "You are a helpful assistant."}, {"role": "user", "text": "Help me!"}],
             [{"role": "user", "text": "Hello, world!"}],
+            [{"role": "user", "text": "I'd like to book a flight to Paris."}],
         ]
         self._require_incremental_response = require_incremental_response
 

--- a/tests/dummy_modules/lm.py
+++ b/tests/dummy_modules/lm.py
@@ -25,4 +25,6 @@ class DummyLanguageModel(LanguageModel):
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
     ) -> list[str]:
-        return ["This is response."] * len(chat_messages_list)
+        messages_as_text = [json.dumps(messages) for messages in chat_messages_list]
+        kwargs_as_text = json.dumps(kwargs)
+        return [m + kwargs_as_text for m in messages_as_text]

--- a/tests/dummy_modules/multiple_choice_dataset.py
+++ b/tests/dummy_modules/multiple_choice_dataset.py
@@ -7,15 +7,11 @@ class DummyMultipleChoiceDataset(MultipleChoiceDataset):
     def __init__(self) -> None:
         self._data = [
             MultipleChoiceInstance(
-                inputs={"text": "This is"},
+                inputs={"text": f"{i}: This is"},
                 choices=["a test", "not a test"],
-                answer_index=0,
-            ),
-            MultipleChoiceInstance(
-                inputs={"text": "That is"},
-                choices=["a test", "not a test"],
-                answer_index=0,
-            ),
+                answer_index=i % 2,
+            )
+            for i in range(5)
         ]
 
     def __len__(self) -> int:


### PR DESCRIPTION
## 目的
チャット形式の評価時に、Few-Shot 学習用のメッセージを入れられるようにします。
これにより、以下のような形式で few-shot サンプル付きのメッセージ入力を `LanguageModel.batch_generate_chat_response` に入れることができます。


```python
# 英日翻訳の例
[
  {"role": "user", "content": "This is a dog."},
  {"role": "assistant", "content": "これは犬です。"},
  {"role": "user", "content": "This is a cat."},
  {"role": "assistant", "content": "これは猫です。"},
# ↑ここまで few-shot 事例↑
# ↓ここから評価データセットの入力↓
  {"role": "user", "content": This is a pig.}
]
```

## 実装の詳細
* `FewShotGenerator` に `ChatDataset` を渡して `ChatInstance` をサンプルできるように拡張
* `evaluate_chat_response` に `FewShotGenerator` を組み込んで入力メッセージに few-shot 事例を追加するロジックを実装
* 上記に関連するテストの拡充

## 動作確認
- [x] テストに通ることを確認した
- [x] 手動での動作確認した