### PR TITLE
Refactor `CodeEval` for enhanced flexibility

### DIFF
--- a/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval.jsonnet
@@ -26,7 +26,7 @@ References:
       },
     },
     metrics: [
-      { class_path: 'CodeEval', init_args: { code_prompt_template: '{{ prompt }}' } },
+      { class_path: 'CodeEval', init_args: { code_template: '{{ prompt }}{{ lm_output }}' } },
     ],
     gen_kwargs: { max_new_tokens: 512, stop_sequences: ['\nclass', '\ndef', '\n#', '\n@', '\nprint', '\nif', '\n```'] },
     batch_size: 4,

--- a/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval_tab_indent.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval_tab_indent.jsonnet
@@ -21,7 +21,7 @@ original_config {
       },
     },
     metrics: [
-      { class_path: 'CodeEval', init_args: { code_prompt_template: '{{ prompt | replace("    ", "\t") }}' } },
+      { class_path: 'CodeEval', init_args: { code_template: '{{ prompt | replace("    ", "\t") }}{{ lm_output }}' } },
     ],
   },
 }

--- a/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval.jsonnet
@@ -26,7 +26,7 @@ References:
       },
     },
     metrics: [
-      { class_path: 'CodeEval', init_args: { code_prompt_template: '{{ prompt }}' } },
+      { class_path: 'CodeEval', init_args: { code_template: '{{ prompt }}{{ lm_output }}' } },
     ],
     gen_kwargs: { max_new_tokens: 512, stop_sequences: ['\nclass', '\ndef', '\n#', '\n@', '\nprint', '\nif', '\n```'] },
     batch_size: 4,

--- a/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval_tab_indent.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval_tab_indent.jsonnet
@@ -21,7 +21,7 @@ original_config {
       },
     },
     metrics: [
-      { class_path: 'CodeEval', init_args: { code_prompt_template: '{{ prompt | replace("    ", "\t") }}' } },
+      { class_path: 'CodeEval', init_args: { code_template: '{{ prompt | replace("    ", "\t") }}{{ lm_output }}' } },
     ],
   },
 }

--- a/tests/core/metric/test_code_eval.py
+++ b/tests/core/metric/test_code_eval.py
@@ -56,7 +56,7 @@ def test_incorrect_code(code: str, test_case: str) -> None:
     ],
 )
 def test_correct_code_with_prompt(prompt: str, code: str, test_case: str) -> None:
-    code_eval = CodeEval(code_prompt_template="{{ prompt }}")
+    code_eval = CodeEval(code_template="{{ prompt }}{{ lm_output }}")
     metric_result = code_eval.evaluate([code], references_list=[[test_case]], task_inputs_list=[{"prompt": prompt}])
     assert metric_result.summary == {"pass@1": 1.0}
     assert metric_result.instance_details[0]["passed"]


### PR DESCRIPTION
Enhance the flexibility of the code snippet to be evaluated by embedding `lm_output` into the template