### PR TITLE
Refactor `flexeval_file`

### DIFF
--- a/flexeval/__init__.py
+++ b/flexeval/__init__.py
@@ -1,7 +1,7 @@
 from .core.chat_dataset import *
 from .core.eval_setups import ChatResponse, EvalSetup, Generation, MultipleChoice, Perplexity
 from .core.evaluate_chat_response import evaluate_chat_response
-from .core.evaluate_from_file import evaluate_from_file
+from .core.evaluate_from_data import evaluate_from_data
 from .core.evaluate_generation import evaluate_generation
 from .core.evaluate_multiple_choice import evaluate_multiple_choice
 from .core.evaluate_pairwise import evaluate_pairwise

--- a/flexeval/core/evaluate_from_data.py
+++ b/flexeval/core/evaluate_from_data.py
@@ -9,7 +9,7 @@ from .generation_dataset import GenerationDataset
 from .metric import Metric
 
 
-def evaluate_from_file(
+def evaluate_from_data(
     eval_data: Iterable[dict[str, Any]],
     metrics: list[Metric],
     eval_dataset: GenerationDataset | ChatDataset | None = None,

--- a/flexeval/core/evaluate_from_file.py
+++ b/flexeval/core/evaluate_from_file.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import json
-from os import PathLike
-from typing import Any
+from typing import Any, Iterable
 
 from loguru import logger
 
@@ -12,25 +10,21 @@ from .metric import Metric
 
 
 def evaluate_from_file(
-    eval_file: str | PathLike[str],
+    eval_data: Iterable[dict[str, Any]],
     metrics: list[Metric],
     eval_dataset: GenerationDataset | ChatDataset | None = None,
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     task_inputs_list: list[dict[str, Any]] = []
     lm_output_list: list[str] = []
     references_list: list[list[str]] = []
-    logger.info(f"Evaluating the outputs in {eval_file}")
-    with open(eval_file) as f:
-        for line in f:
-            item = json.loads(line)
-
-            # ignore task inputs if empty for backward compatibility
-            # it is OK with some metrics that do not require task inputs
-            if "task_inputs" not in item:
-                item["task_inputs"] = {}
-            task_inputs_list.append(item["task_inputs"])
-            lm_output_list.append(item["lm_output"])
-            references_list.append(item["references"])
+    for item in eval_data:
+        # ignore task inputs if empty for backward compatibility
+        # it is OK with some metrics that do not require task inputs
+        if "task_inputs" not in item:
+            item["task_inputs"] = {}
+        task_inputs_list.append(item["task_inputs"])
+        lm_output_list.append(item["lm_output"])
+        references_list.append(item["references"])
 
     if eval_dataset is not None:
         if len(eval_dataset) != len(task_inputs_list):

--- a/flexeval/scripts/flexeval_file.py
+++ b/flexeval/scripts/flexeval_file.py
@@ -12,7 +12,7 @@ import _jsonnet
 from jsonargparse import ActionConfigFile, ArgumentParser
 from loguru import logger
 
-from flexeval import ChatDataset, GenerationDataset, LocalRecorder, Metric, ResultRecorder, evaluate_from_file
+from flexeval import ChatDataset, GenerationDataset, LocalRecorder, Metric, ResultRecorder, evaluate_from_data
 from flexeval.utils.module_utils import ConfigNameResolver
 
 from .common import (
@@ -150,7 +150,7 @@ def main() -> None:  # noqa: C901
         result_recorder.record_config(args_as_dict)
 
     with Timer() as timer:
-        metrics_summary_dict, instance_metrics_list = evaluate_from_file(
+        metrics_summary_dict, instance_metrics_list = evaluate_from_data(
             eval_data=JsonlEvalDataLoader(args.eval_file).load(),
             metrics=args.metrics,
             eval_dataset=args.eval_dataset,

--- a/flexeval/scripts/flexeval_file.py
+++ b/flexeval/scripts/flexeval_file.py
@@ -6,7 +6,7 @@ import sys
 from abc import ABC, abstractmethod
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Dict, List, Union
 
 import _jsonnet
 from jsonargparse import ActionConfigFile, ArgumentParser
@@ -31,7 +31,7 @@ class EvalDataLoader(ABC):
     """
 
     @abstractmethod
-    def load(self) -> Iterable[dict[str, Any]]:
+    def load(self) -> list[dict[str, Any]]:
         pass
 
 
@@ -43,10 +43,13 @@ class JsonlEvalDataLoader(EvalDataLoader):
     def __init__(self, eval_file: str) -> None:
         self.eval_file = eval_file
 
-    def load(self) -> Iterable[dict[str, Any]]:
+    def load(self) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
         with open(self.eval_file) as f:
             for line in f:
-                yield json.loads(line)
+                item = json.loads(line)
+                items.append(item)
+        return items
 
 
 def main() -> None:  # noqa: C901, PLR0912, PLR0915

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -5,7 +5,7 @@ import itertools
 import pytest
 
 from flexeval.core.evaluate_chat_response import evaluate_chat_response
-from flexeval.core.evaluate_from_file import evaluate_from_file
+from flexeval.core.evaluate_from_data import evaluate_from_data
 from flexeval.core.evaluate_generation import evaluate_generation
 from flexeval.core.evaluate_multiple_choice import evaluate_multiple_choice
 from flexeval.core.evaluate_pairwise import Match, evaluate_pairwise
@@ -112,12 +112,12 @@ def test_evaluate_perplexity(max_instances: int) -> None:
     assert isinstance(metrics, dict)
 
 
-def test_evaluate_from_file() -> None:
+def test_evaluate_from_data() -> None:
     items = [
         {"lm_output": "This is test", "references": "This is test"},
         {"lm_output": "This is test", "references": "This is not test"},
     ]
-    metrics_summary_dict, instance_metrics_list = evaluate_from_file(
+    metrics_summary_dict, instance_metrics_list = evaluate_from_data(
         eval_data=items,
         metrics=[ExactMatch()],
     )

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import itertools
-import json
-import tempfile
 
 import pytest
 
@@ -119,18 +117,13 @@ def test_evaluate_from_file() -> None:
         {"lm_output": "This is test", "references": "This is test"},
         {"lm_output": "This is test", "references": "This is not test"},
     ]
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-        for output_item in items:
-            f.write(json.dumps(output_item) + "\n")
-        f.flush()
+    metrics_summary_dict, instance_metrics_list = evaluate_from_file(
+        eval_data=items,
+        metrics=[ExactMatch()],
+    )
 
-        metrics_summary_dict, instance_metrics_list = evaluate_from_file(
-            eval_file=f.name,
-            metrics=[ExactMatch()],
-        )
-
-        assert metrics_summary_dict == {"exact_match": 0.5}
-        assert instance_metrics_list == [{"exact_match": 1.0}, {"exact_match": 0.0}]
+    assert metrics_summary_dict == {"exact_match": 0.5}
+    assert instance_metrics_list == [{"exact_match": 1.0}, {"exact_match": 0.0}]
 
 
 @pytest.mark.parametrize(

--- a/tests/dummy_modules/eval_data_loader.py
+++ b/tests/dummy_modules/eval_data_loader.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+from flexeval.scripts.flexeval_file import EvalDataLoader
+
+
+class DummyEvalDataLoader(EvalDataLoader):
+    def load(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "task_inputs": {"input": f"dummy_input{i}"},
+                "lm_output": f"dummy_output{i}",
+                "references": [f"dummy_reference{i}"],
+            }
+            for i in range(4)
+        ]

--- a/tests/scripts/test_flexeval_file.py
+++ b/tests/scripts/test_flexeval_file.py
@@ -60,6 +60,27 @@ def test_if_outputs_from_flexval_lm_can_be_passed_to_flexeval_file(
         check_if_eval_results_are_correctly_saved(save_path_flexeval_file)
 
 
+def test_with_eval_data_loader() -> None:
+    os.environ["PRESET_CONFIG_DIR"] = str(Path(__file__).parent.parent / "dummy_modules" / "configs")
+
+    with tempfile.TemporaryDirectory() as f:
+        save_path_flexeval_file = Path(f) / "flexeval_file"
+        # fmt: off
+        result_from_flexeval_file = subprocess.run(
+            [  # noqa: S607
+                "flexeval_file",
+                "--eval_data_loader", "tests.dummy_modules.eval_data_loader.DummyEvalDataLoader",
+                "--metrics", "ExactMatch",
+                "--save_dir", str(save_path_flexeval_file),
+            ],
+            check=False,
+        )
+        # fmt: on
+        assert result_from_flexeval_file.returncode == os.EX_OK
+
+        check_if_eval_results_are_correctly_saved(save_path_flexeval_file)
+
+
 def test_if_flexeval_file_loads_custom_module() -> None:
     custom_metric_code = """\
 from flexeval import Metric, MetricResult

--- a/tests/scripts/test_flexeval_file.py
+++ b/tests/scripts/test_flexeval_file.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import os
 import subprocess
 import tempfile
@@ -14,18 +13,20 @@ from .test_flexeval_lm import CHAT_RESPONSE_CMD, GENERATION_CMD, check_if_eval_r
 
 
 @pytest.mark.parametrize(
-    ("flexeval_lm_command", "metrics_args", "override_args"),
-    list(
-        itertools.product(
-            [CHAT_RESPONSE_CMD, GENERATION_CMD],
-            [
-                ["--metrics", "ExactMatch"],
-                ["--metrics", "exact_match"],
-                ["--metrics", "ExactMatch", "--metrics+=CharF1"],
-            ],
-            [[], ["--metrics.processor", "AIONormalizer"]],
-        ),
-    ),
+    "flexeval_lm_command",
+    [CHAT_RESPONSE_CMD, GENERATION_CMD],
+)
+@pytest.mark.parametrize(
+    "metrics_args",
+    [
+        ["--metrics", "ExactMatch"],
+        ["--metrics", "exact_match"],
+        ["--metrics", "ExactMatch", "--metrics+=CharF1"],
+    ],
+)
+@pytest.mark.parametrize(
+    "override_args",
+    [[], ["--metrics.processor", "AIONormalizer"]],
 )
 def test_if_outputs_from_flexval_lm_can_be_passed_to_flexeval_file(
     flexeval_lm_command: list[str],


### PR DESCRIPTION
`flexeval_file` をファイルの入力以外にも拡張するための準備です。
まずは、外から見た挙動を変えずに、中のロジックを整理しました。

- `evaluate_from_file` -> `evaluate_from_data` に変え、関数の入力をファイルではなく、データにしました
- `EvalDataLoader` という抽象クラスを作り、そこを差し替えることでファイル以外からでも評価用のデータを読み込めるようにしました
