### PR TITLE
`HF*Dataset` の references 指定方法を変更

### DIFF
--- a/flexeval/core/multiple_choice_dataset/hf_dataset.py
+++ b/flexeval/core/multiple_choice_dataset/hf_dataset.py
@@ -74,9 +74,6 @@ class HFMultipleChoiceDataset(MultipleChoiceDataset):
         inputs.update({k: v.render(**item) for k, v in self._input_templates.items()})
 
         choices = [t.render(**item) for t in self._choices_templates]
-        if not isinstance(choices, list):
-            msg = f"choices must be list, but got {type(choices)}"
-            raise TypeError(msg)
         if any(len(c) == 0 for c in choices):
             msg = f"choices must be non-empty, but got {choices}"
             raise ValueError(msg)

--- a/flexeval/preset_configs/EvalSetup/code_chat/mbpp_chat.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_chat/mbpp_chat.jsonnet
@@ -27,11 +27,11 @@ local dataset_base_args = {
 {
   class_path: 'ChatResponse',
   init_args: {
-    eval_dataset: dataset_base_args { init_args+: { split: 'test', references_template: '{{ test_list | join("\n") }}' } },
+    eval_dataset: dataset_base_args { init_args+: { split: 'test', reference_list_template: '{{ test_list | join("\n") }}' } },
     few_shot_generator: {
       class_path: 'RandomFewShotGenerator',
       init_args: {
-        dataset: dataset_base_args { init_args+: { split: 'prompt', references_template: '```python\n{{ code }}\n```' } },
+        dataset: dataset_base_args { init_args+: { split: 'prompt', reference_template: '```python\n{{ code }}\n```' } },
         num_shots: 3,
       },
     },

--- a/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval.jsonnet
@@ -14,7 +14,7 @@ References:
       init_args: {
         path: 'kogi-jwu/jhumaneval',
         split: 'test',
-        references_template: '{{ test }}\n\ncheck({{ entry_point }})\n',
+        reference_template: '{{ test }}\n\ncheck({{ entry_point }})\n',
       },
     },
     prompt_template: {

--- a/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval_tab_indent.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval_tab_indent.jsonnet
@@ -10,7 +10,7 @@ original_config {
   init_args+: {
     eval_dataset+: {
       init_args+: {
-        references_template: '{{ test | replace("    ", "\t") }}\n\ncheck({{ entry_point }})\n',
+        reference_template: '{{ test | replace("    ", "\t") }}\n\ncheck({{ entry_point }})\n',
       },
     },
     prompt_template+: {

--- a/flexeval/preset_configs/EvalSetup/code_generation/mbpp.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/mbpp.jsonnet
@@ -11,7 +11,7 @@ local dataset_base_args = {
   init_args: {
     path: 'mbpp',
     subset: 'sanitized',
-    references_template: '{{ test_list }}',
+    reference_list_template: '{{ test_list }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval.jsonnet
@@ -14,7 +14,7 @@ References:
       init_args: {
         path: 'openai_humaneval',
         split: 'test',
-        references_template: '{{ test }}\n\ncheck({{ entry_point }})\n',
+        reference_template: '{{ test }}\n\ncheck({{ entry_point }})\n',
       },
     },
     prompt_template: {

--- a/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval_tab_indent.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval_tab_indent.jsonnet
@@ -10,7 +10,7 @@ original_config {
   init_args+: {
     eval_dataset+: {
       init_args+: {
-        references_template: '{{ test | replace("    ", "\t") }}\n\ncheck({{ entry_point }})\n',
+        reference_template: '{{ test | replace("    ", "\t") }}\n\ncheck({{ entry_point }})\n',
       },
     },
     prompt_template+: {

--- a/flexeval/preset_configs/EvalSetup/en_generation/babi.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/babi.jsonnet
@@ -10,7 +10,7 @@ local dataset_base_args = {
   class_path: 'HFGenerationDataset',
   init_args: {
     path: 'Muennighoff/babi',
-    references_template: '["{{ answer }}"]',
+    reference_template: '{{ answer }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/en_generation/commonsense_qa.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/commonsense_qa.jsonnet
@@ -11,7 +11,7 @@ local dataset_base_args = {
   class_path: 'HFGenerationDataset',
   init_args: {
     path: 'tau/commonsense_qa',
-    references_template: '{% set answer_index = choices.label.index(answerKey) %}["{{ choices.text[answer_index] }}"]',
+    reference_template: '{% set answer_index = choices.label.index(answerKey) %}{{ choices.text[answer_index] }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/en_generation/gsm8k.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/gsm8k.jsonnet
@@ -12,7 +12,7 @@ local dataset_base_args = {
   init_args: {
     path: 'gsm8k',
     subset: 'main',
-    references_template: '{{ answer | regex_replace("<<.*?>>", "") }}',
+    reference_template: '{{ answer | regex_replace("<<.*?>>", "") }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/en_generation/squad_v1.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/squad_v1.jsonnet
@@ -11,7 +11,7 @@ local dataset_base_args = {
   class_path: 'HFGenerationDataset',
   init_args: {
     path: 'rajpurkar/squad',
-    references_template: '{{ answers.text }}',
+    reference_list_template: '{{ answers.text }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/en_generation/trivia_qa.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/trivia_qa.jsonnet
@@ -12,7 +12,7 @@ local dataset_base_args = {
   init_args: {
     path: 'trivia_qa',
     subset: 'rc.nocontext',
-    references_template: '{{ answer.aliases }}',
+    reference_list_template: '{{ answer.aliases }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/en_generation/twitter_sentiment.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/twitter_sentiment.jsonnet
@@ -12,7 +12,7 @@ local dataset_base_args = {
   class_path: 'HFGenerationDataset',
   init_args: {
     path: 'carblacac/twitter-sentiment-analysis',
-    references_template: "{{ ['Positive', 'Negative'][feeling] }}",
+    reference_template: "{{ ['Positive', 'Negative'][feeling] }}",
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_chat/aio_chat.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_chat/aio_chat.jsonnet
@@ -13,7 +13,7 @@ local dataset_base_args = {
   init_args: {
     path: 'llm-book/aio',
     input_template: '{{ question }}',
-    references_template: '{{ answers }}',
+    reference_list_template: '{{ answers }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_chat/elyza_tasks_100.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_chat/elyza_tasks_100.jsonnet
@@ -15,7 +15,7 @@ References:
         path: 'elyza/ELYZA-tasks-100',
         split: 'test',
         input_template: '{{ input }}',
-        references_template: '{{ output }}',
+        reference_template: '{{ output }}',
         extra_info_templates: { eval_aspect: '{{ eval_aspect }}' },
       },
     },

--- a/flexeval/preset_configs/EvalSetup/ja_chat/mgsm_ja_chat.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_chat/mgsm_ja_chat.jsonnet
@@ -13,7 +13,7 @@ local dataset_base_args = {
   init_args: {
     path: 'juletxara/mgsm',
     subset: 'ja',
-    references_template: '{{ answer }}',
+    reference_template: '{{ answer }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_generation/aio.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/aio.jsonnet
@@ -11,7 +11,7 @@ local dataset_base_args = {
   class_path: 'HFGenerationDataset',
   init_args: {
     path: 'llm-book/aio',
-    references_template: '{{ answers }}',
+    reference_list_template: '{{ answers }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_generation/jcommonsenseqa.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/jcommonsenseqa.jsonnet
@@ -15,7 +15,7 @@ local dataset_base_args = {
   init_args: {
     path: 'llm-book/JGLUE',
     subset: 'JCommonsenseQA',
-    references_template: '{% set choices = [choice0, choice1, choice2, choice3, choice4] %}{{ choices[label] }}',
+    reference_template: '{% set choices = [choice0, choice1, choice2, choice3, choice4] %}{{ choices[label] }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_generation/jnli.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/jnli.jsonnet
@@ -14,7 +14,7 @@ local dataset_base_args = {
   init_args: {
     path: 'llm-book/JGLUE',
     subset: 'JNLI',
-    references_template: "{{ ['\"含意\"', '\"矛盾\"', '\"中立\"'][label] }}",
+    reference_template: "{{ ['\"含意\"', '\"矛盾\"', '\"中立\"'][label] }}",
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_generation/jsquad.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/jsquad.jsonnet
@@ -14,7 +14,7 @@ local dataset_base_args = {
   init_args: {
     path: 'llm-book/JGLUE',
     subset: 'JSQuAD',
-    references_template: '{{ answers.text }}',
+    reference_list_template: '{{ answers.text }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_generation/mgsm_ja.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/mgsm_ja.jsonnet
@@ -12,7 +12,7 @@ local dataset_base_args = {
   init_args: {
     path: 'juletxara/mgsm',
     subset: 'ja',
-    references_template: '["{{ answer_number }}"]',
+    reference_template: '{{ answer_number }}',
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_generation/wrime_pos_neg.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/wrime_pos_neg.jsonnet
@@ -13,7 +13,7 @@ local dataset_base_args = {
   class_path: 'HFGenerationDataset',
   init_args: {
     path: 'llm-book/wrime-sentiment',
-    references_template: "{{ ['\"ポジティブ\"', '\"ネガティブ\"'][label] }}",
+    reference_template: "{{ ['\"ポジティブ\"', '\"ネガティブ\"'][label] }}",
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/ja_generation/xlsum_ja.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/xlsum_ja.jsonnet
@@ -13,7 +13,7 @@ local dataset_base_args = {
   init_args: {
     path: 'csebuetnlp/xlsum',
     subset: 'japanese',
-    references_template: '{{ summary }}',
+    reference_template: '{{ summary }}',
   },
 };
 

--- a/tests/core/chat_dataset/test_hf_chat.py
+++ b/tests/core/chat_dataset/test_hf_chat.py
@@ -1,13 +1,37 @@
 from flexeval.core.chat_dataset import HFChatDataset
 
 
-def test_hf_dataset() -> None:
+def test_hf_dataset_with_reference() -> None:
+    system_message = "You are a quiz player."
+    chat_dataset = HFChatDataset(
+        path="tests/dummy_modules/hf_dataset",
+        split="train",
+        input_template="{{ question }}",
+        reference_template="{{ answers[0] }}",
+        extra_info_templates={"question_as_extra_info": "{{ question }}"},
+        system_message_template=system_message,
+    )
+
+    assert len(chat_dataset) == 10
+
+    assert chat_dataset[0].messages == [
+        {"role": "system", "content": system_message},
+        {
+            "role": "user",
+            "content": "What is the highest mountain in the world.",
+        },
+    ]
+    assert chat_dataset[0].references == ["Mount Everest"]
+    assert chat_dataset[0].extra_info["question"] == "What is the highest mountain in the world."
+
+
+def test_hf_dataset_with_reference_list() -> None:
     system_message = "You are a quiz player."
     chat_dataset = HFChatDataset(
         path="tests/dummy_modules/hf_dataset",
         split="train",
         input_template="{{question}}",
-        references_template="{{ answers }}",
+        reference_list_template="{{ answers }}",
         extra_info_templates={"question_as_extra_info": "{{ question }}"},
         system_message_template=system_message,
     )
@@ -30,14 +54,14 @@ def test_test_template_filters() -> None:
         path="tests/dummy_modules/hf_dataset",
         split="train",
         input_template="{{question}}",
-        references_template="{{ answers }}",
+        reference_list_template="{{ answers }}",
     )
 
     filtered_dataset = HFChatDataset(
         path="tests/dummy_modules/hf_dataset",
         split="train",
         input_template="{{question}}",
-        references_template="{{ answers }}",
+        reference_list_template="{{ answers }}",
         template_filters={
             "{{ answers | length }}": "1",
         },

--- a/tests/core/generation_dataset/test_hf_generation.py
+++ b/tests/core/generation_dataset/test_hf_generation.py
@@ -1,12 +1,31 @@
 from flexeval.core.generation_dataset import HFGenerationDataset
 
 
-def test_hf_dataset() -> None:
+def test_hf_dataset_with_reference() -> None:
     dataset = HFGenerationDataset(
         path="tests/dummy_modules/hf_dataset",
         split="train",
         input_templates={"additional_input": "added_question: {{question}}"},
-        references_template="{{ answers }}",
+        reference_template="{{ answers[0] }}",
+    )
+
+    assert len(dataset) > 0
+
+    item = dataset[0]
+    assert item.inputs == {
+        "question": "What is the highest mountain in the world.",
+        "answers": ["Mount Everest", "Everest"],
+        "additional_input": "added_question: What is the highest mountain in the world.",
+    }
+    assert item.references == ["Mount Everest"]
+
+
+def test_hf_dataset_with_reference_list() -> None:
+    dataset = HFGenerationDataset(
+        path="tests/dummy_modules/hf_dataset",
+        split="train",
+        input_templates={"additional_input": "added_question: {{question}}"},
+        reference_list_template="{{ answers }}",
     )
 
     assert len(dataset) > 0
@@ -24,13 +43,11 @@ def test_test_template_filters() -> None:
     original_dataset = HFGenerationDataset(
         path="tests/dummy_modules/hf_dataset",
         split="train",
-        references_template="",
     )
 
     filtered_dataset = HFGenerationDataset(
         path="tests/dummy_modules/hf_dataset",
         split="train",
-        references_template="",
         template_filters={
             "{{ answers | length }}": "1",
         },


### PR DESCRIPTION
従来の references_template では、与えられた文字列が文字列のリストであるか、単一の文字列であるかが区別できない場合があった。

例えば、`references_template: "['A', 'B', 'C']"` とした場合に、これが `references = ['A', 'B', 'C']` か、`references = ["['A', 'B', 'C']"]` なのかが区別できない。

変更後では、明示的に `reference_template` か `reference_list_template` かで、明示的に引数を分けることで、この問題を解決する。