### PR TITLE
Deal with trailing newline

### DIFF
--- a/flexeval/core/utils/jinja2_utils.py
+++ b/flexeval/core/utils/jinja2_utils.py
@@ -14,6 +14,7 @@ def regex_replace(s: str, pattern: str, replace: str) -> str:
 JINJA2_ENV = jinja2.Environment(
     undefined=jinja2.StrictUndefined,
     autoescape=False,  # noqa: S701
+    keep_trailing_newline=True,
 )
 JINJA2_ENV.filters["regex_replace"] = regex_replace
 

--- a/flexeval/preset_configs/EvalSetup/code_chat/mbpp_chat.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_chat/mbpp_chat.jsonnet
@@ -12,7 +12,7 @@ local dataset_base_args = {
   init_args: {
     path: 'mbpp',
     subset: 'sanitized',
-    input_template: |||
+    input_template: std.stripChars(|||
       Generate a Python function that satisfies the following question and test cases.
       ## Question
       {{ prompt }}
@@ -20,7 +20,7 @@ local dataset_base_args = {
       ```python
       {{ test_list | join('\n') }}
       ```
-    |||,
+    |||, '\n'),
   },
 };
 

--- a/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval.jsonnet
@@ -20,9 +20,7 @@ References:
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
-          {{ prompt }}
-        |||,
+        template: '{{ prompt }}',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval_tab_indent.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/jhumaneval_tab_indent.jsonnet
@@ -15,9 +15,7 @@ original_config {
     },
     prompt_template+: {
       init_args+: {
-        template: |||
-          {{ prompt | replace("    ", "\t") }}
-        |||,
+        template: "{{ prompt | replace('    ', '\t') }}",
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/code_generation/mbpp.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/mbpp.jsonnet
@@ -50,7 +50,6 @@ local dataset_base_args = {
           ```
           ## Code
           ```python
-
         |||,
       },
     },

--- a/flexeval/preset_configs/EvalSetup/code_generation/mbpp_tab_indent.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/mbpp_tab_indent.jsonnet
@@ -31,7 +31,6 @@ original_config {
           ```
           ## Code
           ```python
-
         |||,
       },
     },

--- a/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval.jsonnet
@@ -20,9 +20,7 @@ References:
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
-          {{ prompt }}
-        |||,
+        template: '{{ prompt }}',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval_tab_indent.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_generation/openai_humaneval_tab_indent.jsonnet
@@ -15,9 +15,7 @@ original_config {
     },
     prompt_template+: {
       init_args+: {
-        template: |||
-          {{ prompt | replace("    ", "\t") }}
-        |||,
+        template: '{{ prompt | replace("    ", "\t") }}',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/en_generation/babi.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/babi.jsonnet
@@ -36,8 +36,7 @@ local dataset_base_args = {
           {% endfor %}
           Passage: {{ passage | trim }}
           Question: {{ question }}
-          Answer: "
-        |||,
+        ||| + 'Answer: "',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/en_generation/commonsense_qa.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/commonsense_qa.jsonnet
@@ -48,8 +48,7 @@ local dataset_base_args = {
           3. "{{ choices.text[3] }}"
           4. "{{ choices.text[4] }}"
           Question: {{question}}
-          Answer: "
-        |||,
+        ||| + 'Answer: "',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/en_generation/gsm8k.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/gsm8k.jsonnet
@@ -36,8 +36,7 @@ local dataset_base_args = {
           A: {{ item.references[0] }}
           {% endfor %}
           Q: {{ question }}
-          A:
-        |||,
+        ||| + 'A:',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/en_generation/squad_v1.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/squad_v1.jsonnet
@@ -38,8 +38,7 @@ local dataset_base_args = {
           {% endfor %}
           Context: {{ context | trim }}
           Question: {{ question }}
-          Answer: "
-        |||,
+        ||| + 'Answer: "',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/en_generation/trivia_qa.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/trivia_qa.jsonnet
@@ -38,8 +38,7 @@ local dataset_base_args = {
           Answer: "{{ item.references[0] }}"
           {% endfor %}
           Question: {{ question }}
-          Answer: "
-        |||,
+        ||| + 'Answer: "',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/en_generation/twitter_sentiment.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/twitter_sentiment.jsonnet
@@ -37,8 +37,7 @@ local dataset_base_args = {
           Sentiment: `{{ item.references[0] }}`
           {% endfor %}
           Tweet: {{ text }}
-          Sentiment: `
-        |||,
+        ||| + 'Sentiment: `',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/en_multiple_choice/commonsense_qa_mc.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_multiple_choice/commonsense_qa_mc.jsonnet
@@ -41,8 +41,7 @@ local dataset_base_args = {
           Answer:{{ item.choices[item.answer_index] }}
           {% endfor %}
           Question: {{ question }}
-          Answer:
-        |||,
+        ||| + 'Answer:',
       },
     },
   },

--- a/flexeval/preset_configs/EvalSetup/en_multiple_choice/hellaswag.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_multiple_choice/hellaswag.jsonnet
@@ -35,13 +35,11 @@ local dataset_base_args = {
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-
         template: |||
           {% for item in few_shot_data %}
           {{ item.ctx }} {{ item.choices[item.answer_index] }}
           {% endfor %}
-          {{ ctx }}
-        |||,
+        ||| + '{{ ctx }}',
       },
     },
   },

--- a/flexeval/preset_configs/EvalSetup/en_multiple_choice/openbookqa.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_multiple_choice/openbookqa.jsonnet
@@ -41,8 +41,7 @@ local dataset_base_args = {
           Answer:{{ item.choices[item.answer_index] }}
           {% endfor %}
           Question: {{ question_stem }}
-          Answer:
-        |||,
+        ||| + 'Answer:',
       },
     },
   },

--- a/flexeval/preset_configs/EvalSetup/en_multiple_choice/xwinograd_en.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_multiple_choice/xwinograd_en.jsonnet
@@ -27,9 +27,7 @@ References:
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
-          {{ context }}
-        |||,
+        template: '{{ context }}',
       },
     },
   },

--- a/flexeval/preset_configs/EvalSetup/ja_generation/aio.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/aio.jsonnet
@@ -33,8 +33,7 @@ local dataset_base_args = {
           {% for item in few_shot_data -%}
           {{ item.question }}答えは「{{ item.references[0] }}」
           {% endfor -%}
-          {{ question }}答えは「
-        |||,
+        ||| + '{{ question }}答えは「',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/ja_generation/jcommonsenseqa.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/jcommonsenseqa.jsonnet
@@ -50,8 +50,7 @@ local dataset_base_args = {
           3.「{{ choice3 }}」
           4.「{{ choice4 }}」
           問題：{{question}}
-          回答：「
-        |||,
+        ||| + '回答：「',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/ja_generation/jnli.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/jnli.jsonnet
@@ -41,8 +41,7 @@ local dataset_base_args = {
           {% endfor %}
           前提：「{{ sentence1 }}」
           仮説：「{{ sentence2 }}」
-          関係：「
-        |||,
+        ||| + '関係：「',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/ja_generation/jsquad.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/jsquad.jsonnet
@@ -46,8 +46,7 @@ local dataset_base_args = {
           {{ title }}
           {{ context }}
           質問：「{{ question }}」
-          回答：「
-        |||,
+        ||| + '回答：「',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/ja_generation/mgsm_ja.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/mgsm_ja.jsonnet
@@ -36,8 +36,7 @@ local dataset_base_args = {
           {{ item.answer }}
           {% endfor %}
           問題: {{ question }}
-          ステップごとの答え:
-        |||,
+        ||| + 'ステップごとの答え:',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/ja_generation/wrime_pos_neg.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/wrime_pos_neg.jsonnet
@@ -38,8 +38,7 @@ local dataset_base_args = {
           極性：「{{ item.references[0] }}」
           {% endfor %}
           文：{{sentence}}
-          極性：「
-        |||,
+        ||| + '極性：「',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/ja_generation/xlsum_ja.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/xlsum_ja.jsonnet
@@ -36,11 +36,10 @@ local dataset_base_args = {
           文章を１〜３文で要約してください。
           {% for item in few_shot_data %}
           文章: {{ item.text }}
-          要約: {{ item.references[0] }}」
+          要約: {{ item.references[0] }}
           {% endfor %}
           文章: {{ text }}
-          要約:
-        |||,
+        ||| + '要約:',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/ja_multiple_choice/jcommonsenseqa_mc.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_multiple_choice/jcommonsenseqa_mc.jsonnet
@@ -43,8 +43,7 @@ local dataset_base_args = {
           回答：「{{ item.choices[item.answer_index] }}」
           {% endfor %}
           問題：{{question}}
-          回答：「
-        |||,
+        ||| + '回答：「',
       },
     },
   },

--- a/flexeval/preset_configs/EvalSetup/ja_multiple_choice/xwinograd_ja.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_multiple_choice/xwinograd_ja.jsonnet
@@ -27,9 +27,7 @@ References:
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
-          {{ context }}
-        |||,
+        template: '{{ context }}',
       },
     },
   },

--- a/flexeval/preset_configs/EvalSetup/translation/wmt20_en_ja.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/translation/wmt20_en_ja.jsonnet
@@ -34,8 +34,7 @@ local dataset = {
           Ja: `{{ item.references[0] }}`
           {% endfor %}
           En: `{{ source }}`
-          Ja: `
-        |||,
+        ||| + 'Ja: `',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/EvalSetup/translation/wmt20_ja_en.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/translation/wmt20_ja_en.jsonnet
@@ -34,8 +34,7 @@ local dataset = {
           En: `{{ item.references[0] }}`
           {% endfor %}
           Ja: `{{ source }}`
-          En: `
-        |||,
+        ||| + 'En: `',
       },
     },
     metrics: [

--- a/flexeval/preset_configs/Metric/assistant_eval_en_single_turn.jsonnet
+++ b/flexeval/preset_configs/Metric/assistant_eval_en_single_turn.jsonnet
@@ -12,7 +12,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
+        template: std.stripChars(|||
           [Instruction]
           {% if references|length > 0 -%}
           Please act as an impartial judge and evaluate the quality of the response provided by an AI assistant to the user question displayed below. Your evaluation should consider correctness and helpfulness. You will be given a reference answer and the assistant's answer. Begin your evaluation by comparing the assistant's answer with the reference answer. Identify and correct any mistakes. Be as objective as possible. After providing your explanation, you must rate the response on a scale of 1 to 10 by strictly following this format: "[[rating]]", for example: "Rating: [[5]]".
@@ -31,7 +31,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
           [The Start of Assistant's Answer]
           {% if messages|length == 1 %}{{ lm_output }}{% else %}{{ messages[1]["content"] }}{% endif %}
           [The End of Assistant's Answer]
-        |||,
+        |||, '\n'),
       },
     },
   },

--- a/flexeval/preset_configs/Metric/assistant_eval_ja_single_turn.jsonnet
+++ b/flexeval/preset_configs/Metric/assistant_eval_ja_single_turn.jsonnet
@@ -12,7 +12,7 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
+        template: std.stripChars(|||
           [指示]
           {% if references|length > 0 -%}
           以下に表示されるユーザの質問に対するアシスタントの応答の品質を評価してください。評価は正確さと有用性を考慮すべきです。アシスタントの回答の言語は、ユーザが使用している言語と一致しているべきで、そうでない場合は減点されるべきです。参照回答とアシスタントの回答が与えられます。あなたの評価は、アシスタントの回答と参照回答を比較することから始めてください。ミスを特定し、訂正してください。できるだけ客観的であること。評価の説明をした後、"[[rating]]"という形式で、1から10までの整数の評価値を出力してください（例 "rating：[[5]]"）。
@@ -31,9 +31,9 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
           [アシスタントの回答開始]
           {% if messages|length == 1 %}{{ lm_output }}{% else %}{{ messages[1]["content"] }}{% endif %}
           [アシスタントの回答終了]
-        |||,
+        |||, '\n'),
       },
     },
-    system_message: "あなたは優秀な助手です。",
+    system_message: 'あなたは優秀な助手です。',
   },
 }

--- a/flexeval/preset_configs/Metric/elyza_tasks_100_eval.jsonnet
+++ b/flexeval/preset_configs/Metric/elyza_tasks_100_eval.jsonnet
@@ -10,7 +10,7 @@ The template is adapted from the blog post [ELYZAが公開した日本語LLM「E
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
+        template: std.stripChars(|||
           あなたは採点者です。
 
           問題, 正解例, 採点基準, 回答 が与えられます。
@@ -41,7 +41,7 @@ The template is adapted from the blog post [ELYZAが公開した日本語LLM「E
 
           # 回答
           {{ lm_output }}
-        |||,
+        |||, '\n'),
       },
     },
   },

--- a/flexeval/preset_configs/PairwiseJudge/assistant_judge_en_single_turn.jsonnet
+++ b/flexeval/preset_configs/PairwiseJudge/assistant_judge_en_single_turn.jsonnet
@@ -11,7 +11,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
+        template: std.stripChars(|||
           {% set question = model1_item["task_inputs"]["messages"][0]["content"] -%}
           {% set model1_messages = model1_item["task_inputs"]["messages"] -%}
           {% set model2_messages = model2_item["task_inputs"]["messages"] -%}
@@ -36,7 +36,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
           [The Start of Assistant 2's Answer]
           {% if model2_messages|length == 1 %}{{ model2_item["lm_output"] }}{% else %}{{ model2_messages[1]["content"] }}{% endif %}
           [The End of Assistant's Answer]
-        |||,
+        |||, '\n'),
       },
     },
   },

--- a/flexeval/preset_configs/PairwiseJudge/assistant_judge_ja_single_turn.jsonnet
+++ b/flexeval/preset_configs/PairwiseJudge/assistant_judge_ja_single_turn.jsonnet
@@ -11,7 +11,7 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
     prompt_template: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
+        template: std.stripChars(|||
           {% set question = model1_item["task_inputs"]["messages"][0]["content"] -%}
           {% set model1_messages = model1_item["task_inputs"]["messages"] -%}
           {% set model2_messages = model2_item["task_inputs"]["messages"] -%}
@@ -30,19 +30,19 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
           [アシスタント2の回答開始]
           {% if model2_messages|length == 1 %}{{ model2_item["lm_output"] }}{% else %}{{ model2_messages[1]["content"] }}{% endif %}
           [アシスタント2の回答終了]
-        |||,
+        |||, '\n'),
       },
     },
     system_message: {
       class_path: 'Jinja2PromptTemplate',
       init_args: {
-        template: |||
+        template: std.stripChars(|||
           {% if references|length > 0 -%}
           あなたは、回答の質をチェックするための審判員です。以下に示されるユーザーの質問に対する2つのAIアシスタントの応答の品質を評価してください。回答の内容がユーザーの指示に従っており、ユーザーの質問によりよく答えているアシスタントを選んでください。参照回答、アシスタント1の回答、アシスタント2の回答が与えられるので、どちらのアシスタントの回答が優れているかを評価してください。評価の際には、まずそれぞれのアシスタントの回答を参照回答と比較し、回答の誤りを見つけて修正してください。立場が偏らないようにし、回答の提示順があなたの判断に影響しないようにしてください。回答の長さが評価に影響しないこと、特定のアシスタントの名前を好まないこと、できるだけ客観的であること、に気をつけてください。説明の後に、最終的な判断を以下の形式に従って出力してください：アシスタント1が優れていれば[[1]]、アシスタント2が優れていれば[[2]]、同点の場合は[[3]]
           {%- else -%}
           あなたは、回答の質をチェックするための審判員です。以下に示されるユーザーの質問に対する2つのAIアシスタントの応答の品質を評価してください。回答の内容がユーザーの指示に従っており、ユーザーの質問によりよく答えているアシスタントを選んでください。具体的には、回答の有用性、関連性、正確性、深さ、創造性、詳細レベルなどの要素を考慮する必要があります。評価の際には、まず2つの回答を比較し、簡単な説明をしてください。立場が偏らないようにし、回答の提示順があなたの判断に影響しないようにしてください。回答の長さが評価に影響しないこと、特定のアシスタントの名前を好まないこと、できるだけ客観的であること、に気をつけてください。説明の後に、最終的な判断を以下の形式に従って出力してください：アシスタント1が優れていれば[[1]]、アシスタント2が優れていれば[[2]]、同点の場合は[[3]]
           {%- endif %}
-        |||,
+        |||, '\n'),
       },
     },
   },

--- a/tests/core/prompt_template/test_jinja2.py
+++ b/tests/core/prompt_template/test_jinja2.py
@@ -1,4 +1,7 @@
+import tempfile
+
 from flexeval.core.prompt_template.jinja2 import Jinja2PromptTemplate
+from flexeval.utils import instantiate_from_config
 from tests.dummy_modules.generation_dataset import DummyGenerationDataset
 
 
@@ -7,3 +10,23 @@ def test_jinja2_template() -> None:
 
     inputs = dummy_dataset[0].inputs
     assert Jinja2PromptTemplate(template="{{ text }}").embed_inputs(inputs) == inputs["text"]
+
+
+def test_if_jinja2_template_keep_trailing_newline() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonnet") as f:
+        f.write("""
+{
+  class_path: 'Jinja2PromptTemplate',
+  init_args: {
+    template: |||
+      Hello World!
+    |||
+  }
+}
+""")
+        f.flush()
+
+        prompt_template = instantiate_from_config(f.name)
+
+        # not that the text block (||| ... |||) in the jsonnet file adds a newline at the end
+        assert prompt_template.embed_inputs({}) == "Hello World!\n"

--- a/tests/core/prompt_template/test_jinja2.py
+++ b/tests/core/prompt_template/test_jinja2.py
@@ -28,5 +28,5 @@ def test_if_jinja2_template_keep_trailing_newline() -> None:
 
         prompt_template = instantiate_from_config(f.name)
 
-        # not that the text block (||| ... |||) in the jsonnet file adds a newline at the end
+        # note that the text block (||| ... |||) in the jsonnet file adds a newline at the end
         assert prompt_template.embed_inputs({}) == "Hello World!\n"


### PR DESCRIPTION
A trailing newline has been silently ignored by Jinja2 template.
However, this produces inconsistency between the template on json/jsonnet files and the actual template.

For example,
jsonnet
```
{
  template: |||
    Hello world!
  |||
}
```
↓
json
```
{
  template: "Hello world!\n"
}
```
↓
Embedded by Jinja2
```
"Hello world!"
```

After this PR, Jinja2 templates no longer strip trailing newlines.
We need to write templates in Jsonnet faithfully to what is actually intended.