### PR TITLE
Introduce `default_gen_kwargs` to `LanguageModel`

### DIFF
--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -29,7 +29,8 @@ class LanguageModel:
                 The acceptable keys depend on the specific implementation of the model.
                 These arguments override corresponding values in the model's default_gen_kwargs.
                 Special cases:
-                - 'stop_sequences': Merged with default_gen_kwargs instead of overriding.
+                - 'stop_sequences' or any similar model-specific kwargs:
+                    Merged with default_gen_kwargs instead of overriding.
         """
         msg = f"{self.__class__.__name__} cannot generate text."
         raise NotImplementedError(msg)

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -22,7 +22,9 @@ class LanguageModel:
         Args:
             text_list: A list of input texts.
             stop_sequences: A string or a list of strings that will stop the generation when they are generated.
+                This argument exists to give a common interface to various models that have different names for it.
             max_new_tokens: The maximum number of tokens to generate for each text.
+                This argument exists to give a common interface to various models that have different names for it.
         """
         msg = f"{self.__class__.__name__} cannot generate text."
         raise NotImplementedError(msg)
@@ -109,3 +111,29 @@ class LanguageModel:
         if isinstance(text_list, str):
             return self.batch_compute_log_probs([text_list], prefix_list, stride)[0]
         return self.batch_compute_log_probs(text_list, prefix_list, stride)
+
+
+def normalize_stop_sequences(
+    stop_sequences_list: list[str | list[str] | None],
+    eos_token: str | None = None,
+    ignore_eos: bool = False,
+) -> list[str]:
+    """
+    This function absorb stop sequences specified in various ways into a list of strings.
+    """
+    normalized_stop_sequences: list[str] = []
+    # collect stop sequences from `stop_sequences_list`
+    for stop_sequences in stop_sequences_list:
+        if stop_sequences is None:
+            pass
+        elif isinstance(stop_sequences, str):
+            normalized_stop_sequences.append(stop_sequences)
+        elif isinstance(stop_sequences, list):
+            normalized_stop_sequences.extend(stop_sequences)
+        else:
+            msg = f"Invalid type of stop_sequences: {type(stop_sequences)}"
+            raise ValueError(msg)
+
+    if eos_token and not ignore_eos:
+        normalized_stop_sequences.append(eos_token)
+    return normalized_stop_sequences

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -25,6 +25,8 @@ class LanguageModel:
                 This argument exists to give a common interface to various models that have different names for it.
             max_new_tokens: The maximum number of tokens to generate for each text.
                 This argument exists to give a common interface to various models that have different names for it.
+            **kwargs: Additional keyword arguments for the generation.
+                If the default generation kwargs set to the model, this will override them.
         """
         msg = f"{self.__class__.__name__} cannot generate text."
         raise NotImplementedError(msg)

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -25,8 +25,11 @@ class LanguageModel:
                 This argument exists to give a common interface to various models that have different names for it.
             max_new_tokens: The maximum number of tokens to generate for each text.
                 This argument exists to give a common interface to various models that have different names for it.
-            **kwargs: Additional keyword arguments for the generation.
-                If the default generation kwargs set to the model, this will override them.
+            **kwargs: Additional keyword arguments for text generation.
+                The acceptable keys depend on the specific implementation of the model.
+                These arguments override corresponding values in the model's default_gen_kwargs.
+                Special cases:
+                - 'stop_sequences': Merged with default_gen_kwargs instead of overriding.
         """
         msg = f"{self.__class__.__name__} cannot generate text."
         raise NotImplementedError(msg)

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -141,4 +141,4 @@ def normalize_stop_sequences(
 
     if eos_token and not ignore_eos:
         normalized_stop_sequences.append(eos_token)
-    return normalized_stop_sequences
+    return list(set(normalized_stop_sequences))

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -5,8 +5,7 @@ from typing import Any
 import torch
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
-from .base import LanguageModel
-from .hf_lm import normalize_stop_sequences
+from .base import LanguageModel, normalize_stop_sequences
 
 
 class VLLM(LanguageModel):
@@ -21,6 +20,7 @@ class VLLM(LanguageModel):
             Note that whether BOS or EOS tokens are added depends on the tokenizer.
         custom_chat_template: A custom chat template for chatbot models.
             If specified, this overrides the default chat template of the tokenizer.
+        default_gen_kwargs: Default generation kwargs to use when calling the model.
     """
 
     def __init__(
@@ -31,6 +31,7 @@ class VLLM(LanguageModel):
         tokenizer_kwargs: dict[str, Any] | None = None,
         add_special_tokens: bool = False,
         custom_chat_template: str | None = None,
+        default_gen_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self.model_name = model
         tokenizer = tokenizer if tokenizer else model
@@ -38,6 +39,11 @@ class VLLM(LanguageModel):
         self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(tokenizer, **tokenizer_kwargs)
         self.custom_chat_template = custom_chat_template
         self.add_special_tokens = add_special_tokens
+        # use greedy decoding by default to make it consistent with `HuggingFaceLM`
+        self.default_gen_kwargs = default_gen_kwargs or {"temperature": 0.0}
+        # convert the flexeval-specific argument name to the vllm-specific name
+        if "max_new_tokens" in self.default_gen_kwargs:
+            self.default_gen_kwargs["max_tokens"] = self.default_gen_kwargs.pop("max_new_tokens")
 
         # import from vllm here because it is an extra dependency
         from vllm import LLM
@@ -55,27 +61,19 @@ class VLLM(LanguageModel):
         max_new_tokens: int | None = None,
         **kwargs,
     ) -> list[str]:
-        kwargs = kwargs.copy()  # avoid modifying the original kwargs
-
-        # use greedy decoding by default
-        if "temperature" not in kwargs:
-            kwargs["temperature"] = 0.0
-
-        # absorb the stop_sequences and max_new_tokens into the kwargs
+        gen_kwargs = self.default_gen_kwargs.copy()
+        gen_kwargs.update(kwargs)
         if max_new_tokens is not None:
-            if "max_tokens" in kwargs:
-                msg = (
-                    "`max_new_tokens` will be normalized to `max_tokens` before fed into the VLLM module."
-                    "You can not specify both."
-                )
-                raise ValueError(msg)
-            kwargs["max_tokens"] = max_new_tokens
+            gen_kwargs["max_tokens"] = max_new_tokens
 
         stop_sequences = normalize_stop_sequences(
-            stop_sequences=stop_sequences,
-            stop_from_kwargs=kwargs.pop("stop", None),
+            stop_sequences_list=[
+                stop_sequences,
+                gen_kwargs.pop("stop", None),  # This is used in the vllm `SamplingParams`
+                gen_kwargs.pop("stop_sequences", None),  # This is a common variable name used in flexeval
+            ],
             eos_token=self.tokenizer.eos_token,
-            ignore_eos=kwargs.get("ignore_eos", False),
+            ignore_eos=gen_kwargs.get("ignore_eos", False),
         )
 
         model_inputs = self.tokenizer(
@@ -88,14 +86,14 @@ class VLLM(LanguageModel):
 
         vllm_outputs = self.llm.generate(
             prompt_token_ids=model_inputs.input_ids,
-            sampling_params=SamplingParams(**kwargs, stop=stop_sequences),
+            sampling_params=SamplingParams(**gen_kwargs, stop=stop_sequences),
             use_tqdm=False,
         )
         generated_texts = [self.tokenizer.decode(outputs.outputs[0].token_ids) for outputs in vllm_outputs]
 
         # The `include_stop_str_in_output` option does not work, because we let llm generate tokens, not strings.
         # We manually remove the stop sequences from the generated texts.
-        if not kwargs.get("include_stop_str_in_output", False):
+        if not gen_kwargs.get("include_stop_str_in_output", False):
             for stop in stop_sequences:
                 for i, gen_text in enumerate(generated_texts):
                     stop_index = gen_text.find(stop)

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -266,7 +266,7 @@ def test_if_stop_sequences_work_as_expected(chat_lm: HuggingFaceLM) -> None:
     assert eos_token in response[: -len(eos_token)]
 
 
-def test_if_gen_kwargs_work_as_expected():
+def test_if_gen_kwargs_work_as_expected() -> None:
     lm = HuggingFaceLM(model="sbintuitions/tiny-lm", default_gen_kwargs={"max_new_tokens": 1})
     # check if the default gen_kwargs is used and the max_new_tokens is 1
     text = lm.complete_text("000000")

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -264,3 +264,14 @@ def test_if_stop_sequences_work_as_expected(chat_lm: HuggingFaceLM) -> None:
     # check if ignore_eos=True works
     response = chat_lm.batch_generate_chat_response(test_inputs, max_new_tokens=50, ignore_eos=True)[0]
     assert eos_token in response[: -len(eos_token)]
+
+
+def test_if_gen_kwargs_work_as_expected():
+    lm = HuggingFaceLM(model="sbintuitions/tiny-lm", default_gen_kwargs={"max_new_tokens": 1})
+    # check if the default gen_kwargs is used and the max_new_tokens is 1
+    text = lm.complete_text("000000")
+    assert len(text) == 1
+
+    # check if the gen_kwargs will be overwritten by the given gen_kwargs
+    text = lm.complete_text("000000", max_new_tokens=10)
+    assert len(text) > 1

--- a/tests/core/language_model/test_vllm_model.py
+++ b/tests/core/language_model/test_vllm_model.py
@@ -127,7 +127,7 @@ def test_if_stop_sequences_work_as_expected(chat_lm: VLLM) -> None:
 
 
 @pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
-def test_if_gen_kwargs_work_as_expected():
+def test_if_gen_kwargs_work_as_expected() -> None:
     lm = VLLM(model="sbintuitions/tiny-lm", default_gen_kwargs={"max_new_tokens": 1})
     # check if the default gen_kwargs is used and the max_new_tokens is 1
     text = lm.complete_text("000000")

--- a/tests/core/language_model/test_vllm_model.py
+++ b/tests/core/language_model/test_vllm_model.py
@@ -124,3 +124,15 @@ def test_if_stop_sequences_work_as_expected(chat_lm: VLLM) -> None:
     # check if ignore_eos=True works
     response = chat_lm.batch_generate_chat_response(test_inputs, max_new_tokens=50, ignore_eos=True)[0]
     assert eos_token in response[: -len(eos_token)]
+
+
+@pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
+def test_if_gen_kwargs_work_as_expected():
+    lm = VLLM(model="sbintuitions/tiny-lm", default_gen_kwargs={"max_new_tokens": 1})
+    # check if the default gen_kwargs is used and the max_new_tokens is 1
+    text = lm.complete_text("000000")
+    assert len(text) == 1
+
+    # check if the gen_kwargs will be overwritten by the given gen_kwargs
+    text = lm.complete_text("000000", max_new_tokens=10)
+    assert len(text) > 1


### PR DESCRIPTION
Sometimes we need to set model-specific generation kwargs to the model.
It is convenient to specify them from `LanguageModel` rather than `gen_kwargs` in `EvalSetup`.

With this PR, now we can write a config like this.
```jsonnet
{
    class_path: "HuggingFaceLM",
    init_args: {
        model: "sbintuitions/sarashina2-7b",
        default_gen_kwargs: {top_p: 0.9, temperature: 0.7}
    }
}
```
Note that when the same parameters are specified in `gen_kwargs` from `EvalSetup`, `default_gen_kwargs` will be overridden.