### PR TITLE
Set the default value of `disable_sliding_window` to `True` in `VLLM` class

### DIFF
--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -109,6 +109,7 @@ class VLLM(LanguageModel):
             model_kwargs["tensor_parallel_size"] = torch.cuda.device_count()
         if "enable_chunked_prefill" not in model_kwargs:
             model_kwargs["enable_chunked_prefill"] = True
+            model_kwargs["disable_sliding_window"] = True
         self.llm = LLM(model, **model_kwargs)
 
     def batch_complete_text(


### PR DESCRIPTION
In #75, enable_chunked_prefill was set to True for VLLM initialization, but chunked prefill and sliding window can't be enabled together, causing errors for some models.
cf. https://github.com/vllm-project/vllm/blob/main/vllm/engine/arg_utils.py#L1078-L1083
This update sets disable_sliding_window to True by default.
