### PR TITLE
Check if temp file exists before close it in `OpenAIChatBatchAPI`

### DIFF
--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -198,6 +198,10 @@ class OpenAIChatBatchAPI(LanguageModel):
         return self._execute_batch_requests(chat_messages_list, **kwargs)
 
     def close(self) -> None:
+        # in case that the program fails before the file is initialized in __init__
+        if not hasattr(self, "temp_jsonl_file"):
+            return
+
         try:
             self.temp_jsonl_file.close()
             os.unlink(self.temp_jsonl_file.name)  # noqa: PTH108


### PR DESCRIPTION
This will make stack traces a bit cleaner.

Otherwise, we get this.
```bash
Exception ignored in: <function OpenAIChatBatchAPI.__del__ at 0x143efa820>
Traceback (most recent call last):
  File ".../.venv/lib/python3.9/site-packages/flexeval/core/language_model/openai_batch_api.py", line 209, in __del__
    self.close()
  File ".../.venv/lib/python3.9/site-packages/flexeval/core/language_model/openai_batch_api.py", line 202, in close
    self.temp_jsonl_file.close()
AttributeError: 'OpenAIChatBatchAPI' object has no attribute 'temp_jsonl_file'
```