### PR TITLE
Fix bug related to `category_key` in `LLMScore` and `ChatLLMScore`

### DIFF
--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -49,7 +49,7 @@ def summarize_evaluator_scores(
         if score is None or category_key is None:
             continue
         if category_key in task_inputs:
-            category2valid_scores[task_inputs["category"]].append(score)
+            category2valid_scores[task_inputs[category_key]].append(score)
 
     category2mean_score: dict[str, float] = {}
     for category, valid_scores in category2valid_scores.items():


### PR DESCRIPTION
In the `LLMScore` and `ChatLLMScore` classes, I found instances where the hard-coded string "category" was used as a key, instead of the string specified by `category_key`. I fixed it.