### PR TITLE
Classification-based evaluation using `LanguageModel`

### DIFF
--- a/flexeval/core/metric/__init__.py
+++ b/flexeval/core/metric/__init__.py
@@ -5,6 +5,7 @@ from .code_eval import CodeEval
 from .common_prefix_length import CommonPrefixLength
 from .common_string_length import CommonStringLength
 from .exact_match import ExactMatch
+from .llm_label import ChatLLMLabel, LLMLabel
 from .llm_score import ChatLLMScore, LLMScore
 from .output_length_stats import OutputLengthStats
 from .perspective_api import PerspectiveAPI

--- a/flexeval/core/metric/base.py
+++ b/flexeval/core/metric/base.py
@@ -11,7 +11,7 @@ class MetricResult:
     A dataclass representing the result of a metric evaluation.
     """
 
-    summary: dict[str, float]
+    summary: dict[str, Any]
     """
     Summary containing aggregated metric values.
     """

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -251,7 +251,7 @@ class ChatLLMLabel(Metric):
         >>> label_points = [1.0, 0.0]
         >>> llm_label = ChatLLMLabel(language_model, prompt_template, label_names, label_points)
         >>> lm_outputs = ["Hello, world!", "Good morning!"]
-        >>> result = llm_score.evaluate(lm_outputs)
+        >>> result = llm_label.evaluate(lm_outputs)
         >>> print(result)
         MetricResult(
             summary={'llm_score': 0.5, 'llm_label_distribution': {'Good': 0.5, 'Bad': 0.5}, 'num_failed_score_parses': 0},

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -104,8 +104,7 @@ class LLMLabel(Metric):
             The category key is expected to be in task inputs.
 
     Examples:
-        >>> from flexeval_instruction.plugins.llm_label import LLMLabel
-        >>> from flexeval import OpenAIChatAPI, Jinja2PromptTemplate
+        >>> from flexeval import OpenAIChatAPI, Jinja2PromptTemplate, LLMLabel
         >>> language_model = OpenAIChatAPI(model="gpt-3.5-turbo")
         >>> template = "Evaluate the quality of this text on a scale of Good/Bad.\\n`{{ lm_output }}`\\nPut the label at the end like [[Good]]."
         >>> prompt_template = Jinja2PromptTemplate(template)

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -90,6 +90,8 @@ class LLMLabel(Metric):
 
     You can specify the evaluation criteria in `PromptTemplate`.
     The last label value found in the output of the evaluator is used to compute the evaluation score.
+    You can assign a score to each label.
+    The final output is the average score and the distribution of the labels.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+
+import tqdm
+from loguru import logger
+
+from flexeval.core.language_model import LanguageModel
+from flexeval.core.prompt_template import PromptTemplate
+from flexeval.core.utils.data_util import batch_iter
+
+from .base import Metric, MetricResult
+
+
+def parse_label_from_evaluator_output(evaluator_output: str, label_names: list[str]) -> str | None:
+    """Extract the last label from the evaluator output.
+
+    Return None if parsing fails.
+    """
+    pattern = rf"({'|'.join(label_names)})"
+    matched = re.findall(pattern, evaluator_output)
+    if not matched:
+        return None
+
+    parsed_label = matched[-1]
+    if parsed_label not in set(label_names):
+        return None
+    return parsed_label
+
+
+def calc_label_dist(valid_labels: list[int], label_names: list[str]) -> dict[str, float]:
+    counter = Counter(valid_labels)
+    dist_dict: dict[str, float] = {}
+    for label in label_names:
+        dist_dict[label] = counter.get(label, 0.0) / len(valid_labels)
+    return dist_dict
+
+
+def summarize_evaluator_labels(
+    evaluator_label_list: list[int | None],
+    task_inputs_list: list[dict[str, str]],
+    label_names: list[str],
+    weights: list[float],
+    category_key: str | None = None,
+) -> dict[str, float]:
+    """Summarize evaluator_score_list. If category_key is given, return
+    category-wise mean score as well as overall mean score.
+    """
+    score_key = "llm_score"
+    dist_key = "llm_label_distribution"
+
+    label2point = dict(zip(label_names, weights))
+    # compute overall mean score and label distribution
+    all_valid_labels: list[int] = [label for label in evaluator_label_list if label is not None]
+    score = sum([label2point[label] for label in all_valid_labels])
+    score /= len(all_valid_labels)
+    dist = calc_label_dist(all_valid_labels, label_names)
+    num_failed_score_parses = len(evaluator_label_list) - len(all_valid_labels)
+    summary = {score_key: score, dist_key: dist, "num_failed_score_parses": num_failed_score_parses}
+
+    # compute category-wise stats if category_key is given
+    category2valid_labels: dict[str, list[str]] = defaultdict(list)
+    for label, task_inputs in zip(evaluator_label_list, task_inputs_list):
+        if label is None or category_key is None:
+            continue
+        if category_key in task_inputs:
+            category2valid_labels[task_inputs[category_key]].append(label)
+
+    category2mean_score: dict[str, float] = {}
+    category2dist: dict[str, float] = {}
+    for category, valid_labels in category2valid_labels.items():
+        score = sum([label2point[label] for label in valid_labels])
+        score /= len(valid_labels)
+        category2mean_score[category] = score
+        category2dist[category] = calc_label_dist(valid_labels, label_names)
+
+    for category in category2mean_score:
+        summary[f"{score_key}/{category}"] = category2mean_score[category]
+        summary[f"{dist_key}/{category}"] = category2dist[category]
+
+    return summary
+
+
+class LLMLabel(Metric):
+    """Let LanguageModel to evaluate the output of another LanguageModel.
+
+    You can specify the evaluation criteria in `PromptTemplate`.
+    The last label value found in the output of the evaluator is used to compute the evaluation score.
+
+    Args:
+        language_model: An instance of `LanguageModel` to evaluate the output of the model.
+        prompt_template: An instance of `PromptTemplate` to embed the input for the evaluator.
+        label_names: A list of valid label names.
+        label_points: A list of points for each label specified in label_names.
+        batch_size: The batch size for the evaluator.
+        disable_tqdm: Whether to disable the progress bar.
+        category_key: A key to create category-wise mean score.
+            The category key is expected to be in task inputs.
+
+    Examples:
+        >>> from flexeval_instruction.plugins.llm_label import LLMLabel
+        >>> from flexeval import OpenAIChatAPI, Jinja2PromptTemplate
+        >>> language_model = OpenAIChatAPI(model="gpt-3.5-turbo")
+        >>> template = "Evaluate the quality of this text on a scale of Good/Bad.\\n`{{ lm_output }}`\\nPut the label at the end like [[Good]]."
+        >>> prompt_template = Jinja2PromptTemplate(template)
+        >>> label_names = ["Good", "Bad"]
+        >>> label_points = [1.0, 0.0]
+        >>> llm_label = LLMLabel(language_model, prompt_template, label_names, label_points)
+        >>> lm_outputs = ["Hello, world!", "Good mrrrning!"]
+        >>> result = llm_label.evaluate(lm_outputs)
+        >>> print(result)
+        MetricResult(
+            summary={'llm_score': 0.5, 'llm_label_distribution': {'Good': 0.5, 'Bad': 0.5}, 'num_failed_score_parses': 0},
+            instance_details=[
+                {
+                    'llm_label': 'Good',
+                    'llm_score': 1.0,
+                    'llm_label_input': 'Evaluate the quality of this text...',
+                    'llm_label_output': 'This text is natural, ... [[Good]]'
+                },
+                {
+                    'llm_label': 'Bad',
+                    'llm_score': 0.0,
+                    'llm_label_input': 'Evaluate the quality of this text on a scale of Good/Bad.\\n`Good mrrrning!`\\nPut the label at the end like [[Good]].',
+                    'llm_label_output': 'This text contains a spelling error, ... [[Bad]]'
+                }
+            ]
+        )
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        language_model: LanguageModel,
+        prompt_template: PromptTemplate,
+        label_names: list[str],
+        label_points: list[float | int] | None = None,
+        batch_size: int = 4,
+        disable_tqdm: bool = False,
+        valid_score_range: tuple[int, int] | None = None,
+        category_key: str | None = None,
+    ) -> None:
+        self.language_model = language_model
+        self.prompt_template = prompt_template
+        self.label_names = [re.escape(label) for label in label_names]
+
+        if label_points:
+            if len(self.label_names) != len(label_points):
+                msg = "The lengths of label_names and weights do not match."
+                raise ValueError(msg)
+            label_points: list[float] = list(map(float, label_points))
+        else:
+            label_points = [0.0] * len(label_names)
+            label_points[0] = 1.0
+
+        self.weights = label_points
+        self.batch_size = batch_size
+        self.disable_tqdm = disable_tqdm
+        self.valid_score_range = valid_score_range
+        self.category_key = category_key
+
+    def evaluate(
+        self,
+        lm_outputs: list[str],
+        references_list: list[list[str]] | None = None,
+        task_inputs_list: list[dict[str, str]] | None = None,
+    ) -> MetricResult:
+        if task_inputs_list is None:
+            task_inputs_list = [{} for _ in lm_outputs]
+        if references_list is None:
+            references_list = [[] for _ in lm_outputs]
+
+        evaluator_input_list: list[str] = []
+        for lm_output, task_input, references in zip(
+            lm_outputs,
+            task_inputs_list,
+            references_list,
+        ):
+            prompt_inputs = {
+                "lm_output": lm_output,
+                "references": references,
+                **task_input,
+            }
+            evaluator_input = self.prompt_template.embed_inputs(prompt_inputs)
+            evaluator_input_list.append(evaluator_input)
+
+        with tqdm.tqdm(
+            total=len(evaluator_input_list),
+            disable=self.disable_tqdm,
+            desc="Calculating LLM score",
+        ) as pbar:
+            evaluator_output_list: list[str] = []
+            for batch_evaluator_input in batch_iter(
+                evaluator_input_list,
+                batch_size=self.batch_size,
+            ):
+                evaluator_outputs = self.language_model.batch_complete_text(
+                    batch_evaluator_input,
+                )
+                evaluator_output_list += evaluator_outputs
+                pbar.update(len(batch_evaluator_input))
+
+        evaluator_label_list: list[int | None] = []
+        for evaluator_output in evaluator_output_list:
+            evaluator_label = parse_label_from_evaluator_output(
+                evaluator_output,
+                label_names=self.label_names,
+            )
+            if evaluator_label is None:
+                logger.warning(f"Failed to parse label from evaluator output: {evaluator_output}")
+            evaluator_label_list.append(evaluator_label)
+
+        label2point = dict(zip(self.label_names, self.weights))
+        evaluator_score_list: list[float | None] = [label2point.get(label) for label in evaluator_label_list]
+
+        summary = summarize_evaluator_labels(
+            evaluator_label_list,
+            task_inputs_list,
+            self.label_names,
+            self.weights,
+            self.category_key,
+        )
+
+        return MetricResult(
+            summary,
+            instance_details=[
+                {
+                    "llm_label": eval_label,
+                    "llm_score": eval_score,
+                    "llm_label_input": eval_in,
+                    "llm_label_output": eval_out,
+                }
+                for eval_label, eval_score, eval_in, eval_out in zip(
+                    evaluator_label_list,
+                    evaluator_score_list,
+                    evaluator_input_list,
+                    evaluator_output_list,
+                )
+            ],
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(language_model={self.language_model}, prompt_template={self.prompt_template})"
+        )
+
+
+class ChatLLMLabel(Metric):
+    """
+    A metric that evaluates the output of `LanguageModel.batch_generate_chat_response`.
+
+    Args:
+        language_model: An instance of `LanguageModel` to evaluate the output of the model.
+        prompt_template: An instance of `PromptTemplate` to embed the input for the evaluator.
+        label_names: A list of valid label names.
+        label_points: A list of points for each label specified in label_names.
+        system_message: A system message to be prepended to the input for the evaluator.
+        batch_size: The batch size for the evaluator.
+        disable_tqdm: Whether to disable the progress bar.
+        valid_score_range: A tuple of two integers representing the valid score range.
+            If the parsed score is out of the range, it will be ignored.
+        category_key: A key to create category-wise mean score.
+            The category key is expected to be in task inputs.
+
+    Examples:
+        >>> from flexeval import ChatLLMScore, OpenAIChatAPI, Jinja2PromptTemplate
+        >>> language_model = OpenAIChatAPI(model_name="gpt-3.5-turbo")
+        >>> template = "Evaluate the quality of this text on a scale of Good/Bad.\\n`{{ lm_output }}`\\nPut the label at the end like [[Good]]."
+        >>> prompt_template = Jinja2PromptTemplate(template)
+        >>> system_message = "This is the system message."
+        >>> label_names = ["Good", "Bad"]
+        >>> label_points = [1.0, 0.0]
+        >>> llm_label = ChatLLMLabel(language_model, prompt_template, label_names, label_points)
+        >>> lm_outputs = ["Hello, world!", "Good morning!"]
+        >>> result = llm_score.evaluate(lm_outputs)
+        >>> print(result)
+        MetricResult(
+            summary={'llm_score': 0.5, 'llm_label_distribution': {'Good': 0.5, 'Bad': 0.5}, 'num_failed_score_parses': 0},
+            instance_details=[
+                {
+                    'llm_label': 'Good',
+                    'llm_score': 1.0,
+                    'llm_label_input': 'Evaluate the quality of this text...',
+                    'llm_label_output': 'This text is natural, ... [[Good]]'
+                },
+                {
+                    'llm_label': 'Bad',
+                    'llm_score': 0.0,
+                    'llm_label_input': 'Evaluate the quality of this text on a scale of Good/Bad.\\n`Good mrrrning!`\\nPut the label at the end like [[Good]].',
+                    'llm_label_output': 'This text contains a spelling error, ... [[Bad]]'
+                }
+            ]
+        )
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        language_model: LanguageModel,
+        prompt_template: PromptTemplate,
+        label_names: list[str],
+        label_points: list[float | int] | None = None,
+        system_message: str | PromptTemplate | None = None,
+        batch_size: int = 4,
+        disable_tqdm: bool = False,
+        category_key: str | None = None,
+    ) -> None:
+        self.language_model = language_model
+        self.prompt_template = prompt_template
+        self.label_names = [re.escape(label) for label in label_names]
+
+        if label_points:
+            if len(self.label_names) != len(label_points):
+                msg = "The lengths of label_names and weights do not match."
+                raise ValueError(msg)
+            label_points: list[float] = list(map(float, label_points))
+        else:
+            label_points = [0.0] * len(label_names)
+            label_points[0] = 1.0
+
+        self.weights = label_points
+        self.system_message = system_message
+        self.batch_size = batch_size
+        self.disable_tqdm = disable_tqdm
+        self.category_key = category_key
+
+    def evaluate(
+        self,
+        lm_outputs: list[str],
+        references_list: list[list[str]] | None = None,
+        task_inputs_list: list[dict[str, str]] | None = None,
+    ) -> MetricResult:
+        if task_inputs_list is None:
+            task_inputs_list = [{} for _ in lm_outputs]
+        if references_list is None:
+            references_list = [[] for _ in lm_outputs]
+        evaluator_input_list: list[list[dict[str, str]]] = []
+        for lm_output, task_input, references in zip(
+            lm_outputs,
+            task_inputs_list,
+            references_list,
+        ):
+            prompt_inputs = {
+                "lm_output": lm_output,
+                "references": references,
+                **task_input,
+            }
+            evaluator_input = self.prompt_template.embed_inputs(prompt_inputs)
+            input_chat_messages = [{"role": "user", "content": evaluator_input}]
+            if self.system_message:
+                if isinstance(self.system_message, str):
+                    system_message = self.system_message
+                else:
+                    system_message = self.system_message.embed_inputs(prompt_inputs)
+                input_chat_messages.insert(
+                    0,
+                    {"role": "system", "content": system_message},
+                )
+            evaluator_input_list.append(input_chat_messages)
+
+        with tqdm.tqdm(
+            total=len(evaluator_input_list),
+            disable=self.disable_tqdm,
+            desc="Calculating ChatLLM score",
+        ) as pbar:
+            evaluator_output_list: list[str] = []
+            for batch_inputs in batch_iter(
+                evaluator_input_list,
+                batch_size=self.batch_size,
+            ):
+                evaluator_outputs = self.language_model.batch_generate_chat_response(
+                    batch_inputs,
+                )
+                evaluator_output_list += evaluator_outputs
+                pbar.update(len(batch_inputs))
+
+        evaluator_label_list: list[str] = []
+        for evaluator_output in evaluator_output_list:
+            evaluator_label = parse_label_from_evaluator_output(
+                evaluator_output,
+                label_names=self.label_names,
+            )
+            if evaluator_label is None:
+                logger.warning(f"Failed to parse label from evaluator output: {evaluator_output}")
+            evaluator_label_list.append(evaluator_label)
+
+        label2point = dict(zip(self.label_names, self.weights))
+        evaluator_score_list: list[float | None] = [label2point.get(label) for label in evaluator_label_list]
+
+        summary = summarize_evaluator_labels(
+            evaluator_label_list,
+            task_inputs_list,
+            self.label_names,
+            self.weights,
+            self.category_key,
+        )
+
+        return MetricResult(
+            summary,
+            instance_details=[
+                {
+                    "llm_label": eval_label,
+                    "llm_score": eval_score,
+                    "llm_label_input": eval_in,
+                    "llm_label_output": eval_out,
+                }
+                for eval_label, eval_score, eval_in, eval_out in zip(
+                    evaluator_label_list,
+                    evaluator_score_list,
+                    evaluator_input_list,
+                    evaluator_output_list,
+                )
+            ],
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(language_model={self.language_model}, prompt_template={self.prompt_template})"
+        )

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -238,8 +238,6 @@ class ChatLLMLabel(Metric):
         system_message: A system message to be prepended to the input for the evaluator.
         batch_size: The batch size for the evaluator.
         disable_tqdm: Whether to disable the progress bar.
-        valid_score_range: A tuple of two integers representing the valid score range.
-            If the parsed score is out of the range, it will be ignored.
         category_key: A key to create category-wise mean score.
             The category key is expected to be in task inputs.
 

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -66,6 +66,10 @@ def prepare_text_input_for_evaluator(
         task_inputs_list: list[dict[str, str]],
         prompt_template: PromptTemplate,
     ) -> list[str]:
+    """Create input texts for the evaluator
+    by integrating the task inputs, the model outputs, and the prompt template for evaluator.
+    """
+
     evaluator_input_list: list[str] = []
     for lm_output, task_input, references in zip(
         lm_outputs,
@@ -89,6 +93,10 @@ def prepare_chat_input_for_evaluator(
         prompt_template: PromptTemplate,
         system_message: str | PromptTemplate | None = None,
     ) -> list[list[dict[str, str]]]:
+    """Create input chat messages for the evaluator
+    by integrating the task inputs, the model outputs, and the prompt template for evaluator.
+    """
+
     evaluator_input_list: list[list[dict[str, str]]] = []
     for lm_output, task_input, references in zip(
         lm_outputs,
@@ -120,6 +128,14 @@ def generate_evaluations(
         disable_tqdm: bool = False,
         desc_for_tqdm: str | None = None,
     ) -> list[str]:
+    """Generate evaluation texts for each input in evaluator_input_list.
+
+    - If evaluator_input_list contains a list of plain texts, use
+      language_model.batch_complete_text() to generate evaluation outputs.
+    - If evaluator_input_list contains a list of chat message dictionaries,
+      use language_model.batch_generate_chat_response().
+    """
+
     with tqdm.tqdm(
         total=len(evaluator_input_list),
         disable=disable_tqdm,
@@ -130,7 +146,7 @@ def generate_evaluations(
             evaluator_input_list,
             batch_size=batch_size,
         ):
-            if isinstance(batch_inputs[0], str):
+            if all(isinstance(elem, str) for elem in batch_inputs):
                 evaluator_outputs = language_model.batch_complete_text(
                     batch_inputs,
                 )

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -61,11 +61,11 @@ def summarize_evaluator_scores(
 
 
 def prepare_text_input_for_evaluator(
-        lm_outputs: list[str],
-        references_list: list[list[str]],
-        task_inputs_list: list[dict[str, str]],
-        prompt_template: PromptTemplate,
-    ) -> list[str]:
+    lm_outputs: list[str],
+    references_list: list[list[str]],
+    task_inputs_list: list[dict[str, str]],
+    prompt_template: PromptTemplate,
+) -> list[str]:
     """Create input texts for the evaluator
     by integrating the task inputs, the model outputs, and the prompt template for evaluator.
     """
@@ -87,12 +87,12 @@ def prepare_text_input_for_evaluator(
 
 
 def prepare_chat_input_for_evaluator(
-        lm_outputs: list[str],
-        references_list: list[list[str]],
-        task_inputs_list: list[dict[str, str]],
-        prompt_template: PromptTemplate,
-        system_message: str | PromptTemplate | None = None,
-    ) -> list[list[dict[str, str]]]:
+    lm_outputs: list[str],
+    references_list: list[list[str]],
+    task_inputs_list: list[dict[str, str]],
+    prompt_template: PromptTemplate,
+    system_message: str | PromptTemplate | None = None,
+) -> list[list[dict[str, str]]]:
     """Create input chat messages for the evaluator
     by integrating the task inputs, the model outputs, and the prompt template for evaluator.
     """
@@ -122,12 +122,12 @@ def prepare_chat_input_for_evaluator(
 
 
 def generate_evaluations(
-        evaluator_input_list: list[str] | list[list[dict[str, str]]],
-        language_model: LanguageModel,
-        batch_size: int,
-        disable_tqdm: bool = False,
-        desc_for_tqdm: str | None = None,
-    ) -> list[str]:
+    evaluator_input_list: list[str] | list[list[dict[str, str]]],
+    language_model: LanguageModel,
+    batch_size: int,
+    disable_tqdm: bool = False,
+    desc_for_tqdm: str | None = None,
+) -> list[str]:
     """Generate evaluation texts for each input in evaluator_input_list.
 
     - If evaluator_input_list contains a list of plain texts, use

--- a/tests/core/metric/test_llm_label.py
+++ b/tests/core/metric/test_llm_label.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import pytest
+
+from flexeval import Jinja2PromptTemplate, LanguageModel
+from flexeval.core.metric.llm_label import ChatLLMLabel, LLMLabel, parse_label_from_evaluator_output
+
+
+class EchoBackLanguageModel(LanguageModel):
+    def batch_complete_text(
+        self,
+        text_list: list[str],
+        stop_sequences: str | list[str] | None = None,
+        max_new_tokens: int | None = None,
+        **kwargs,
+    ) -> list[str]:
+        return text_list
+
+    def batch_generate_chat_response(
+        self,
+        chat_messages_list: list[list[dict[str, str]]],
+        **kwargs,
+    ) -> list[str]:
+        return [chat_messages[-1]["content"] for chat_messages in chat_messages_list]
+
+
+@pytest.mark.parametrize(
+    ("evaluator_output", "label_names", "expected_label"),
+    [
+        ("The label is A.", ["A", "B", "C"], "A"),
+        ("The label is Z.", ["A", "B", "C"], None),
+    ],
+)
+def test_parse_label_from_evaluator_output(
+    evaluator_output: str,
+    label_names: tuple[int, int] | None,
+    expected_label: str | None,
+) -> None:
+    label = parse_label_from_evaluator_output(evaluator_output, label_names)
+    assert label == expected_label
+
+
+def test_llm_label() -> None:
+    metric = LLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+    )
+    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
+    metric_output = metric.evaluate(
+        lm_outputs=lm_outputs,
+    )
+
+    assert metric_output.summary == {
+        "llm_score": 0.5,
+        "num_failed_score_parses": 1,
+        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+    }
+
+    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
+        assert instance_detail["llm_label_input"] == lm_output
+        assert instance_detail["llm_label_output"] == lm_output
+
+
+def test_llm_label_with_category() -> None:
+    metric = LLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+        category_key="category",
+    )
+    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
+    task_inputs_list = [
+        {"category": "category-0"},
+        {"category": "category-0"},
+        {"category": "category-1"},
+        {"category": "category-2"},
+    ]
+    metric_output = metric.evaluate(
+        lm_outputs=lm_outputs,
+        task_inputs_list=task_inputs_list,
+    )
+
+    assert metric_output.summary == {
+        "llm_score": 0.5,
+        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+        "num_failed_score_parses": 1,
+        "llm_score/category-0": 0.75,
+        "llm_label_distribution/category-0": {"Good": 1 / 2, "Neutral": 1 / 2, "Bad": 0 / 2},
+        "llm_score/category-1": 0.0,
+        "llm_label_distribution/category-1": {"Good": 0 / 1, "Neutral": 0 / 1, "Bad": 1 / 1},
+    }
+
+    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
+        assert instance_detail["llm_label_input"] == lm_output
+        assert instance_detail["llm_label_output"] == lm_output
+
+
+def test_chat_llm_label() -> None:
+    metric = ChatLLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+    )
+    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
+    metric_output = metric.evaluate(
+        lm_outputs=lm_outputs,
+    )
+
+    assert metric_output.summary == {
+        "llm_score": 0.5,
+        "num_failed_score_parses": 1,
+        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+    }
+
+    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
+        assert instance_detail["llm_label_input"] == [{"role": "user", "content": lm_output}]
+        assert instance_detail["llm_label_output"] == lm_output
+
+
+def test_chat_llm_label_with_category() -> None:
+    metric = ChatLLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+        category_key="category",
+    )
+    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
+    task_inputs_list = [
+        {"category": "category-0"},
+        {"category": "category-0"},
+        {"category": "category-1"},
+        {"category": "category-2"},
+    ]
+    metric_output = metric.evaluate(
+        lm_outputs=lm_outputs,
+        task_inputs_list=task_inputs_list,
+    )
+
+    assert metric_output.summary == {
+        "llm_score": 0.5,
+        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+        "num_failed_score_parses": 1,
+        "llm_score/category-0": 0.75,
+        "llm_label_distribution/category-0": {"Good": 1 / 2, "Neutral": 1 / 2, "Bad": 0 / 2},
+        "llm_score/category-1": 0.0,
+        "llm_label_distribution/category-1": {"Good": 0 / 1, "Neutral": 0 / 1, "Bad": 1 / 1},
+    }
+
+    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
+        assert instance_detail["llm_label_input"] == [{"role": "user", "content": lm_output}]
+        assert instance_detail["llm_label_output"] == lm_output


### PR DESCRIPTION
Add `LLMLabel` and `ChatLLMLabel`.
Different from `LLMScore` and `ChatLLMScore`, they deal with labels on a non-Likert scale.
You can define label names and assign a score to each label. The mean score and the label distribution are output.