### PR TITLE
hellaswagの few-shot examples を修正

### DIFF
--- a/flexeval/preset_configs/EvalSetup/en_multiple_choice/hellaswag.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_multiple_choice/hellaswag.jsonnet
@@ -37,7 +37,7 @@ local dataset_base_args = {
       init_args: {
         template: |||
           {% for item in few_shot_data %}
-          {{ item.ctx }} {{ item.choices[item.answer_index] }}
+          {{ item.ctx }}{{ item.choices[item.answer_index] }}
           {% endfor %}
         ||| + '{{ ctx }}',
       },


### PR DESCRIPTION
今のhellaswagの few-shot examples はcontextとcontinuationの間にスペースが2つ含まれていそうです
```
例1: woman<space><space>stands
A man in a black vest is standing in a room. He throws darts at a dart board on the wall. a woman  stands next to him watching.
例2: shaper<space><space>is
Several food items and dishes are laid out on a table. Meat product and other items are used to create a sandwich. then a bento shaper  is used to create an image in the sandwich.
```
whilte_space_before_choiceによって追加される一つと
https://github.com/sbintuitions/flexeval/blob/fb507d88c351394d0e8a41ed9d42b3e4fd4cbc0f/flexeval/preset_configs/EvalSetup/en_multiple_choice/hellaswag.jsonnet#L15
prompt_templateによって追加される一つの合計2つです。

前者は必要だと思うので、後者を削除します。