### PR TITLE
Add default values for instance classes

### DIFF
--- a/flexeval/core/chat_dataset/base.py
+++ b/flexeval/core/chat_dataset/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Sequence
 
 
@@ -29,12 +29,12 @@ class ChatInstance:
     ]
     ```
     """
-    references: list[str]
+    references: list[str] = field(default_factory=list)
     """
     A list of reference responses to the user's last message.
     The model's response will be evaluated against these references.
     """
-    extra_info: dict[str, Any]
+    extra_info: dict[str, Any] = field(default_factory=dict)
     """
     Extra information that can be used by passing to `Metric`.
     """

--- a/flexeval/core/generation_dataset/base.py
+++ b/flexeval/core/generation_dataset/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Sequence
+from typing import Any, Sequence
 
 
 @dataclass
@@ -11,7 +11,7 @@ class GenerationInstance:
     A dataclass representing a single input-output pair of a generation task.
     """
 
-    inputs: dict[str, str]
+    inputs: dict[str, Any]
     """
     Inputs of the generation task.
     This will be embedded into the prompt for the language model in `PromptTemplate`.

--- a/flexeval/core/generation_dataset/base.py
+++ b/flexeval/core/generation_dataset/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Sequence
 
 
@@ -16,7 +16,7 @@ class GenerationInstance:
     Inputs of the generation task.
     This will be embedded into the prompt for the language model in `PromptTemplate`.
     """
-    references: list[str]
+    references: list[str] = field(default_factory=list)
     """
     Reference outputs for the generation task.
     The model's output will be evaluated against these references in `Metric`.


### PR DESCRIPTION
Sometimes, we do not need references (and extra_info) for inputs.
Make them optional to enhance usability.