### PR TITLE
Set `require_incremental_response` to `False` by default

### DIFF
--- a/flexeval/core/chat_dataset/base.py
+++ b/flexeval/core/chat_dataset/base.py
@@ -76,14 +76,13 @@ class ChatDataset(Sequence[ChatInstance], ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
     def require_incremental_response(self) -> bool:
         """If true, the inputs consist of multiple user utterances and the
         model should generate responses for each utterance incrementally.
 
         Otherwise, the model just has to continue the conversation from the last user utterance.
         """
-        raise NotImplementedError
+        return False
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(num_instances={len(self)})"


### PR DESCRIPTION
Most chat datasets do not require incremental response generation, so set it False in the abstract class.