### PR TITLE
Update `RewardBenchInstance` to handle a list of messages

### DIFF
--- a/flexeval/core/reward_bench_dataset/base.py
+++ b/flexeval/core/reward_bench_dataset/base.py
@@ -13,7 +13,7 @@ class RewardBenchInstance:
     prompt: list[dict[str, str]]
     """
     The prompt for chosen/rejected responses.
-    The format is a list of dictionaries, where each dictionary represents a OpenAI-format chat message,
+    The format is a list of dictionaries, where each dictionary represents an OpenAI-format chat message,
     such as `{"role": "user", "content": "Hello!"}`.
     """
     chosen: list[dict[str, str]]

--- a/flexeval/core/reward_bench_dataset/base.py
+++ b/flexeval/core/reward_bench_dataset/base.py
@@ -10,17 +10,21 @@ class RewardBenchInstance:
     """A dataclass representing a triplet (prompt, chosen, rejected) of a
     reward bench task."""
 
-    prompt: str
+    prompt: list[dict[str, str]]
     """
     The prompt for chosen/rejected responses.
+    The format is a list of dictionaries, where each dictionary represents a OpenAI-format chat message,
+    such as `{"role": "user", "content": "Hello!"}`.
     """
-    chosen: str
+    chosen: list[dict[str, str]]
     """
     The chosen response to the prompt.
+    The format is the same as `prompt`.
     """
-    rejected: str
+    rejected: list[dict[str, str]]
     """
     The rejected response to the prompt.
+    The format is the same as `prompt`.
     """
     extra_info: dict[str, Any]
     """

--- a/flexeval/core/reward_bench_dataset/template_based.py
+++ b/flexeval/core/reward_bench_dataset/template_based.py
@@ -81,9 +81,9 @@ class TemplateRewardBenchDataset(RewardBenchDataset):
         extra_info.update(extra_info_from_templates)
 
         return RewardBenchInstance(
-            prompt=prompt,
-            chosen=chosen,
-            rejected=rejected,
+            prompt=[{"role": "user", "content": prompt}],
+            chosen=[{"role": "assistant", "content": chosen}],
+            rejected=[{"role": "assistant", "content": rejected}],
             extra_info=extra_info,
         )
 

--- a/flexeval/core/reward_model/pairwise_judge_reward_model.py
+++ b/flexeval/core/reward_model/pairwise_judge_reward_model.py
@@ -17,9 +17,15 @@ class PairwiseChoice(str, Enum):
 
 @dataclass
 class PairwiseInstance:
-    prompt: str
-    answer_a: str
-    answer_b: str
+    """
+    A dataclass representing a pairwise instance for a reward bench task.
+    Unlike RewardBenchInstance, this class represents the chosen instance (answer) by answer label,
+    in order to make the order insensitive input for the language model.
+    """
+
+    prompt: list[dict[str, str]]
+    answer_a: list[dict[str, str]]
+    answer_b: list[dict[str, str]]
     answer_label: PairwiseChoice
 
 
@@ -57,8 +63,11 @@ class PairwiseJudgeRewardModel(RewardModel):
         if self.system_message:
             if isinstance(self.system_message, str):
                 system_message = self.system_message
-            else:
+            elif isinstance(self.system_message, PromptTemplate):
                 system_message = self.system_message.embed_inputs(pairwise_instance_asdict)
+            else:
+                msg = "system_message should be str or PromptTemplate."
+                raise ValueError(msg)
             input_chat_messages.insert(
                 0,
                 {"role": "system", "content": system_message},

--- a/tests/core/reward_bench_dataset/test_template_based.py
+++ b/tests/core/reward_bench_dataset/test_template_based.py
@@ -45,19 +45,19 @@ def test_template_multiple_choice_dataset(
     assert len(dataset) > 0
 
     item = dataset[0]
-    assert item.prompt == "What is the highest mountain in the world."
-    assert item.chosen == "Mount Everest"
-    assert item.rejected == "Everest"
+    assert item.prompt == [{"role": "user", "content": "What is the highest mountain in the world."}]
+    assert item.chosen == [{"role": "assistant", "content": "Mount Everest"}]
+    assert item.rejected == [{"role": "assistant", "content": "Everest"}]
 
     item = dataset[1]
-    assert item.prompt == "What is the chemical symbol for water?"
-    assert item.chosen == "H2O"
-    assert item.rejected == "H2O"
+    assert item.prompt == [{"role": "user", "content": "What is the chemical symbol for water?"}]
+    assert item.chosen == [{"role": "assistant", "content": "H2O"}]
+    assert item.rejected == [{"role": "assistant", "content": "H2O"}]
 
     item = dataset[4]
-    assert item.prompt == "Who wrote 'Romeo and Juliet'?"
-    assert item.chosen == "William Shakespeare"
-    assert item.rejected == "Shakespeare"
+    assert item.prompt == [{"role": "user", "content": "Who wrote 'Romeo and Juliet'?"}]
+    assert item.chosen == [{"role": "assistant", "content": "William Shakespeare"}]
+    assert item.rejected == [{"role": "assistant", "content": "Shakespeare"}]
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -165,7 +165,14 @@ def test_evaluate_pairwise(cached_matches: list[Match] | None) -> None:
 
 
 def test_evaluate_reward_model() -> None:
-    template = "## prompt\n{{ prompt }}\n\n## answer A\n{{ answer_a }}\n\n## answer B\n{{ answer_b }}"
+    template = (
+        "## prompt\n"
+        "{{ prompt[0].content }}\n\n"
+        "## answer A\n"
+        "{{ answer_a[0].content }}\n\n"
+        "## answer B\n"
+        "{{ answer_b[0].content }}"
+    )
 
     reward_model = PairwiseJudgeRewardModel(
         language_model=DummyRewardLanguageModel(),
@@ -181,9 +188,9 @@ def test_evaluate_reward_model() -> None:
 
     assert metrics["accuracy"] == 0.5
     assert outputs[0] == {
-        "prompt": "prompt_text_0",
-        "chosen": "chosen_text_0",
-        "rejected": "rejected_text_0",
+        "prompt": [{"role": "user", "content": "prompt_text_0"}],
+        "chosen": [{"role": "user", "content": "chosen_text_0"}],
+        "rejected": [{"role": "user", "content": "rejected_text_0"}],
         "llm_inputs": [
             # A is chosen text
             [
@@ -220,9 +227,9 @@ def test_evaluate_reward_model() -> None:
 
     assert metrics["accuracy"] == 0.5
     assert outputs[0] == {
-        "prompt": "prompt_text_0",
-        "chosen": "chosen_text_0",
-        "rejected": "rejected_text_0",
+        "prompt": [{"role": "user", "content": "prompt_text_0"}],
+        "chosen": [{"role": "user", "content": "chosen_text_0"}],
+        "rejected": [{"role": "user", "content": "rejected_text_0"}],
         "llm_inputs": [
             [
                 # A is chosen text

--- a/tests/dummy_modules/reward_bench_dataset.py
+++ b/tests/dummy_modules/reward_bench_dataset.py
@@ -7,9 +7,9 @@ class DummyRewardBenchDataset(RewardBenchDataset):
     def __init__(self) -> None:
         self.items = [
             RewardBenchInstance(
-                prompt=f"prompt_text_{i}",
-                chosen=f"chosen_text_{i}",
-                rejected=f"rejected_text_{i}",
+                prompt=[{"role": "user", "content": f"prompt_text_{i}"}],
+                chosen=[{"role": "user", "content": f"chosen_text_{i}"}],
+                rejected=[{"role": "user", "content": f"rejected_text_{i}"}],
                 extra_info={"id": i},
             )
             for i in range(100)
@@ -18,5 +18,5 @@ class DummyRewardBenchDataset(RewardBenchDataset):
     def __len__(self) -> int:
         return len(self.items)
 
-    def __getitem__(self, i: int) -> RewardBenchDataset:
+    def __getitem__(self, i: int) -> RewardBenchInstance:
         return self.items[i]


### PR DESCRIPTION
Generalize the data structure of `RewardBenchInstance` so that it can handle multi-turn prompts.