### PR TITLE
Debug `SequenceClassificationRewardModel`

### DIFF
--- a/tests/core/reward_model/test_sequence_classification.py
+++ b/tests/core/reward_model/test_sequence_classification.py
@@ -10,19 +10,23 @@ def reward_model() -> SequenceClassificationRewardModel:
 
 
 def test_batch_judge(reward_model: SequenceClassificationRewardModel) -> None:
-    num_instances = 4
     instances = [
         RewardBenchInstance(
             prompt=[{"role": "user", "content": "Hello!"}],
             chosen=[{"role": "assistant", "content": "Hi!"}],
             rejected=[{"role": "assistant", "content": "Hello!"}],
-            extra_info={"id": i},
-        )
-        for i in range(num_instances)
+            extra_info={"id": 1},
+        ),
+        RewardBenchInstance(
+            prompt=[{"role": "user", "content": "1 + 1 = ?"}],
+            chosen=[{"role": "assistant", "content": "2"}],
+            rejected=[{"role": "assistant", "content": "3"}],
+            extra_info={"id": 2},
+        ),
     ]
 
     chosen_is_better, outputs = reward_model.batch_judge(instances)
 
-    assert len(chosen_is_better) == num_instances
-    assert len(outputs) == num_instances
+    assert len(chosen_is_better) == len(instances)
+    assert len(outputs) == len(instances)
     assert outputs[0].keys() == {"chosen_reward", "rejected_reward"}

--- a/tests/core/reward_model/test_sequence_classification.py
+++ b/tests/core/reward_model/test_sequence_classification.py
@@ -14,13 +14,13 @@ def test_batch_judge(reward_model: SequenceClassificationRewardModel) -> None:
         RewardBenchInstance(
             prompt=[{"role": "user", "content": "Hello!"}],
             chosen=[{"role": "assistant", "content": "Hi!"}],
-            rejected=[{"role": "assistant", "content": "Hello!"}],
+            rejected=[{"role": "assistant", "content": "Colorless green sleeps furiously."}],
             extra_info={"id": 1},
         ),
         RewardBenchInstance(
-            prompt=[{"role": "user", "content": "1 + 1 = ?"}],
-            chosen=[{"role": "assistant", "content": "2"}],
-            rejected=[{"role": "assistant", "content": "3"}],
+            prompt=[{"role": "user", "content": "Hello! How are you?"}],
+            chosen=[{"role": "assistant", "content": "Hi! I am good."}],
+            rejected=[{"role": "assistant", "content": "Colorless green sleeps furiously."}],
             extra_info={"id": 2},
         ),
     ]


### PR DESCRIPTION
The previous implementation assumed that all inputs in the batch had the same length, which caused failures when they did not.
This PR addresses and resolves that issue by adding `padding=True` to `apply_chat_template`.

This PR also specify `return_dict=True` in `apply_chat_template` to explicitly  get `attention_mask` for the input.

