### PR TITLE
Move `vllm` import inside function to avoid `ImportError`

### DIFF
--- a/tests/core/language_model/vllm/test_vllm_chat_lm.py
+++ b/tests/core/language_model/vllm/test_vllm_chat_lm.py
@@ -1,5 +1,4 @@
 import pytest
-from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
 
 from flexeval.core.language_model.vllm_model import VLLM, LanguageModel
 from tests.conftest import is_vllm_enabled
@@ -18,6 +17,8 @@ def chat_lm() -> VLLM:
         tokenizer_kwargs={"use_fast": False},
     )
     yield llm
+    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
     cleanup_dist_env_and_memory()
 
 

--- a/tests/core/language_model/vllm/test_vllm_custom_chat_template.py
+++ b/tests/core/language_model/vllm/test_vllm_custom_chat_template.py
@@ -1,5 +1,4 @@
 import pytest
-from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
 
 from flexeval.core.language_model.vllm_model import VLLM
 from tests.conftest import is_vllm_enabled
@@ -31,6 +30,8 @@ def chat_lm_with_custom_chat_template() -> VLLM:
         custom_chat_template=custom_chat_template,
     )
     yield llm
+    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
     cleanup_dist_env_and_memory()
 
 

--- a/tests/core/language_model/vllm/test_vllm_gen_kwargs.py
+++ b/tests/core/language_model/vllm/test_vllm_gen_kwargs.py
@@ -1,5 +1,4 @@
 import pytest
-from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
 
 from flexeval.core.language_model.vllm_model import VLLM, LanguageModel
 from tests.conftest import is_vllm_enabled
@@ -18,6 +17,8 @@ def lm_with_default_kwargs() -> VLLM:
         },
     )
     yield llm
+    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
     cleanup_dist_env_and_memory()
 
 

--- a/tests/core/language_model/vllm/test_vllm_lm.py
+++ b/tests/core/language_model/vllm/test_vllm_lm.py
@@ -1,5 +1,4 @@
 import pytest
-from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
 
 from flexeval.core.language_model.hf_lm import HuggingFaceLM
 from flexeval.core.language_model.vllm_model import VLLM, LanguageModel
@@ -19,6 +18,8 @@ def lm() -> VLLM:
         tokenizer_kwargs={"use_fast": False},
     )
     yield llm
+    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
     cleanup_dist_env_and_memory()
 
 


### PR DESCRIPTION
Some environments (e.g., my laptop) cannot install `vllm` but still want to run `pytest tests`.
For such cases, `vllm` can be moved inside the function to avoid `ImportError`.