### PR TITLE
Introduce `category_key` for `flexeval_reward`

### DIFF
--- a/flexeval/core/reward_bench_dataset/base.py
+++ b/flexeval/core/reward_bench_dataset/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Sequence
 
 
@@ -26,7 +26,11 @@ class RewardBenchInstance:
     The rejected response to the prompt.
     The format is the same as `prompt`.
     """
-    extra_info: dict[str, Any]
+    category_key: str | None = None
+    """
+    A key to compute category-wise average accuracies.
+    """
+    extra_info: dict[str, Any] = field(default_factory=dict)
     """
     Extra information that can be used by passing to `Metric`.
     """

--- a/flexeval/core/reward_bench_dataset/template_based.py
+++ b/flexeval/core/reward_bench_dataset/template_based.py
@@ -35,6 +35,7 @@ class TemplateRewardBenchDataset(RewardBenchDataset):
         prompt_template: str,
         chosen_template: str,
         rejected_template: str,
+        category_template: str | None = None,
         extra_info_templates: dict[str, str] | None = None,
         data_range: tuple[int, int] | None = None,
         keep_conditions: dict[str, str] | None = None,
@@ -58,6 +59,9 @@ class TemplateRewardBenchDataset(RewardBenchDataset):
         self.prompt_template = JINJA2_ENV.from_string(prompt_template)
         self.chosen_template = JINJA2_ENV.from_string(chosen_template)
         self.rejected_template = JINJA2_ENV.from_string(rejected_template)
+        self.category_template = None
+        if category_template:
+            self.category_template = JINJA2_ENV.from_string(category_template)
 
         extra_info_templates = extra_info_templates or {}
         self._extra_info_templates: dict[str, Template] = {
@@ -84,6 +88,7 @@ class TemplateRewardBenchDataset(RewardBenchDataset):
             prompt=[{"role": "user", "content": prompt}],
             chosen=[{"role": "assistant", "content": chosen}],
             rejected=[{"role": "assistant", "content": rejected}],
+            category_key=self.category_template.render(**item) if self.category_template else None,
             extra_info=extra_info,
         )
 
@@ -108,6 +113,7 @@ class HFRewardBenchDataset(TemplateRewardBenchDataset):
         prompt_template: str = "{{ prompt }}",
         chosen_template: str = "{{ chosen }}",
         rejected_template: str = "{{ rejected }}",
+        category_template: str | None = None,
         extra_info_templates: dict[str, str] | None = None,
         data_range: tuple[int, int] | None = None,
         keep_conditions: dict[str, str] | None = None,
@@ -122,6 +128,7 @@ class HFRewardBenchDataset(TemplateRewardBenchDataset):
             prompt_template=prompt_template,
             chosen_template=chosen_template,
             rejected_template=rejected_template,
+            category_template=category_template,
             extra_info_templates=extra_info_templates,
             data_range=data_range,
             keep_conditions=keep_conditions,
@@ -143,6 +150,7 @@ class JsonlRewardBenchDataset(TemplateRewardBenchDataset):
         prompt_template: str = "{{ prompt }}",
         chosen_template: str = "{{ chosen }}",
         rejected_template: str = "{{ rejected }}",
+        category_template: str | None = None,
         extra_info_templates: dict[str, str] | None = None,
         data_range: tuple[int, int] | None = None,
         keep_conditions: dict[str, str] | None = None,
@@ -156,6 +164,7 @@ class JsonlRewardBenchDataset(TemplateRewardBenchDataset):
             prompt_template=prompt_template,
             chosen_template=chosen_template,
             rejected_template=rejected_template,
+            category_template=category_template,
             extra_info_templates=extra_info_templates,
             data_range=data_range,
             keep_conditions=keep_conditions,

--- a/tests/core/reward_bench_dataset/test_template_based.py
+++ b/tests/core/reward_bench_dataset/test_template_based.py
@@ -131,3 +131,20 @@ def test_remove_conditions(dataset_class: type[TemplateRewardBenchDataset], kwar
     assert 0 < len(filtered_dataset) < len(original_dataset)
     for item in filtered_dataset:
         assert len(item.extra_info["answers"]) > 1
+
+
+@pytest.mark.parametrize(
+    ("dataset_class", "kwargs"),
+    DATASETS_TO_TEST,
+)
+def test_category_key(dataset_class: type[TemplateRewardBenchDataset], kwargs: dict[str, Any]) -> None:
+    original_dataset = dataset_class(
+        **kwargs,
+        prompt_template="{{ question }}",
+        chosen_template="{{ answers[0] }}",
+        rejected_template="{{ answers[-1] }}",
+        category_template="{{ id }}",
+    )
+
+    for item in original_dataset:
+        assert item.category_key == str(item.extra_info["id"])

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -187,6 +187,7 @@ def test_evaluate_reward_model() -> None:
     )
 
     assert metrics["accuracy"] == 0.5
+    assert metrics["accuracy-dummy"] == 0.5  # the score computed with the category key
     assert outputs[0] == {
         "prompt": [{"role": "user", "content": "prompt_text_0"}],
         "chosen": [{"role": "user", "content": "chosen_text_0"}],

--- a/tests/dummy_modules/reward_bench_dataset.py
+++ b/tests/dummy_modules/reward_bench_dataset.py
@@ -10,6 +10,7 @@ class DummyRewardBenchDataset(RewardBenchDataset):
                 prompt=[{"role": "user", "content": f"prompt_text_{i}"}],
                 chosen=[{"role": "user", "content": f"chosen_text_{i}"}],
                 rejected=[{"role": "user", "content": f"rejected_text_{i}"}],
+                category_key="dummy",
                 extra_info={"id": i},
             )
             for i in range(100)


### PR DESCRIPTION
Some datasets such as [reward-bench](https://huggingface.co/spaces/allenai/reward-bench) has a category (or subset) to allow detailed analysis of model performance.
To compute average scores for each category, introduce `category_key` to `RewardBenchInstance`.