### PR TITLE
Set `self.model.config.pad_token_id` from tokenizer if not set in `SequenceClassificationRewardModel`

### DIFF
--- a/flexeval/core/reward_model/sequence_classification.py
+++ b/flexeval/core/reward_model/sequence_classification.py
@@ -28,6 +28,10 @@ class SequenceClassificationRewardModel(RewardModel):
 
         model_kwargs = get_default_model_kwargs(model_kwargs)
         self.model = AutoModelForSequenceClassification.from_pretrained(model, **model_kwargs)
+        # Set pad_token_id if not set
+        # to avoid "ValueError: Cannot handle batch sizes > 1 if no padding token is defined." in self.model()
+        if self.model.config.pad_token_id is None:
+            self.model.config.pad_token_id = self.tokenizer.pad_token_id
         self.model.eval()
 
     @torch.inference_mode()

--- a/tests/dummy_modules/llama-seq-classification-tiny/config.json
+++ b/tests/dummy_modules/llama-seq-classification-tiny/config.json
@@ -6,7 +6,6 @@
   "attention_dropout": 0.0,
   "bos_token_id": 1,
   "eos_token_id": 2,
-  "pad_token_id": 3,
   "hidden_act": "silu",
   "hidden_size": 64,
   "id2label": {


### PR DESCRIPTION
Some models do not have `"pad_token_id"` in their config and it cannot perform batch inference.
In that case, the tokenizer often has `"pad_token_id"` so we set it to the model.