### PR TITLE
Replace Deprecated parameter `max_tokens` with `max_completion_tokens` for OpenAI API

### DIFF
--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -81,7 +81,7 @@ class OpenAIChatAPI(LanguageModel):
         self.default_gen_kwargs = default_gen_kwargs or {}
         # convert the flexeval-specific argument name to the OpenAI-specific name
         if "max_new_tokens" in self.default_gen_kwargs:
-            self.default_gen_kwargs["max_tokens"] = self.default_gen_kwargs.pop("max_new_tokens")
+            self.default_gen_kwargs["max_completion_tokens"] = self.default_gen_kwargs.pop("max_new_tokens")
 
     async def _async_batch_run_chatgpt(
         self,
@@ -95,7 +95,7 @@ class OpenAIChatAPI(LanguageModel):
         gen_kwargs = self.default_gen_kwargs.copy()
         gen_kwargs.update(kwargs)
         if max_new_tokens is not None:
-            gen_kwargs["max_tokens"] = max_new_tokens
+            gen_kwargs["max_completion_tokens"] = max_new_tokens
 
         stop_sequences = normalize_stop_sequences(
             stop_sequences_list=[

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -90,14 +90,14 @@ class OpenAIChatBatchAPI(LanguageModel):
             kwargs["stop"] = stop_sequences
 
         if max_new_tokens is not None:
-            if "max_tokens" in kwargs:
+            if "max_completion_tokens" in kwargs:
                 msg = (
-                    "You specified both `max_new_tokens` and `max_tokens` in generation kwargs. "
-                    "However, `max_new_tokens` will be normalized into `max_tokens`. "
+                    "You specified both `max_new_tokens` and `max_completion_tokens` in generation kwargs. "
+                    "However, `max_new_tokens` will be normalized into `max_completion_tokens`. "
                     "Please specify only one of them."
                 )
                 raise ValueError(msg)
-            kwargs["max_tokens"] = max_new_tokens
+            kwargs["max_completion_tokens"] = max_new_tokens
 
         self.create_batch_file(custom_id_2_message, **kwargs)
 


### PR DESCRIPTION
With the recent update of OpenAI's chat completion API, the `max_tokens` parameter has been deprecated. 
cf. https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens
We need update our implementation to use the replacement parameter, `max_completion_tokens`.

For previous models like `gpt-4o`, there is no change in behavior. However, the `o1` series models do not accept the `max_tokens` parameter and requires `max_completion_tokens`, making this update essential.

The following models have been verified to generate responses successfully using the `mt-ja` benchmark data:
* o1-mini-2024-09-12 (via `OpenAIChatAPI` class, `max_new_tokens=10000`)
* gpt-4o-2024-08-06 (via `OpenAIChatAPI` class)
* gpt-4o-2024-08-06 (via `OpenAIChatBatchAPI` class)

Related issue: https://github.com/sbintuitions/flexeval/issues/111