### PR TITLE
Read prefix in perplexity evaluation

### DIFF
--- a/flexeval/core/text_dataset/__init__.py
+++ b/flexeval/core/text_dataset/__init__.py
@@ -1,3 +1,3 @@
-from .base import TextDataset
+from .base import TextDataset, TextInstance
 from .hf import HFTextDataset
 from .jsonl import JsonlTextDataset

--- a/flexeval/core/text_dataset/base.py
+++ b/flexeval/core/text_dataset/base.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Sequence
 
 
-class TextDataset(Sequence[str], ABC):
+@dataclass
+class TextInstance:
+    text: str
+    prefix: str = ""
+
+
+class TextDataset(Sequence[TextInstance], ABC):
     """
     This class represents a dataset of text examples.
     """
@@ -14,7 +21,7 @@ class TextDataset(Sequence[str], ABC):
         pass
 
     @abstractmethod
-    def __getitem__(self, item: int) -> str:
+    def __getitem__(self, item: int) -> TextInstance:
         pass
 
     def __repr__(self) -> str:

--- a/flexeval/core/text_dataset/hf.py
+++ b/flexeval/core/text_dataset/hf.py
@@ -30,6 +30,7 @@ class HFTextDataset(TextDataset):
         path: str,
         split: str,
         text_template: str,
+        prefix_template: str | None = None,
         subset: str | None = None,
         keep_conditions: dict[str, str] | None = None,
         remove_conditions: dict[str, str] | None = None,
@@ -48,10 +49,17 @@ class HFTextDataset(TextDataset):
             self.dataset = self.dataset.filter(lambda x, t=filter_template, v=value_to_remove: t.render(**x) != v)
 
         self.text_template = JINJA2_ENV.from_string(text_template)
+        self.prefix_template = None
+        if prefix_template:
+            self.prefix_template = JINJA2_ENV.from_string(prefix_template)
 
     def __len__(self) -> int:
         return len(self.dataset)
 
     def __getitem__(self, i: int) -> TextInstance:
         item = self.dataset[i]
-        return TextInstance(self.text_template.render(**item))
+        text = self.text_template.render(**item)
+        prefix = ""
+        if self.prefix_template:
+            prefix = self.prefix_template.render(**item)
+        return TextInstance(text=text, prefix=prefix)

--- a/flexeval/core/text_dataset/hf.py
+++ b/flexeval/core/text_dataset/hf.py
@@ -6,7 +6,7 @@ import datasets
 
 from flexeval.core.utils.jinja2_utils import JINJA2_ENV
 
-from .base import TextDataset
+from .base import TextDataset, TextInstance
 
 
 class HFTextDataset(TextDataset):
@@ -52,6 +52,6 @@ class HFTextDataset(TextDataset):
     def __len__(self) -> int:
         return len(self.dataset)
 
-    def __getitem__(self, i: int) -> str:
+    def __getitem__(self, i: int) -> TextInstance:
         item = self.dataset[i]
-        return self.text_template.render(**item)
+        return TextInstance(self.text_template.render(**item))

--- a/flexeval/core/text_dataset/jsonl.py
+++ b/flexeval/core/text_dataset/jsonl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from os import PathLike
 
-from .base import TextDataset
+from .base import TextDataset, TextInstance
 
 
 class JsonlTextDataset(TextDataset):
@@ -25,5 +25,5 @@ class JsonlTextDataset(TextDataset):
     def __len__(self) -> int:
         return len(self._text_list)
 
-    def __getitem__(self, item: int) -> str:
-        return self._text_list[item]
+    def __getitem__(self, item: int) -> TextInstance:
+        return TextInstance(self._text_list[item])

--- a/tests/core/text_dataset/test_hf.py
+++ b/tests/core/text_dataset/test_hf.py
@@ -6,11 +6,13 @@ def test_hf_text_dataset() -> None:
         path="tests/dummy_modules/hf_dataset",
         split="train",
         text_template="{{ question }}",
+        prefix_template="THIS IS PREFIX\n",
     )
 
     texts = list(dataset)
     assert len(texts) == 10
     assert isinstance(texts[0].text, str)
+    assert texts[0].prefix == "THIS IS PREFIX\n"
 
 
 def test_keep_conditions() -> None:

--- a/tests/core/text_dataset/test_hf.py
+++ b/tests/core/text_dataset/test_hf.py
@@ -10,7 +10,7 @@ def test_hf_text_dataset() -> None:
 
     texts = list(dataset)
     assert len(texts) == 10
-    assert isinstance(texts[0], str)
+    assert isinstance(texts[0].text, str)
 
 
 def test_keep_conditions() -> None:

--- a/tests/dummy_modules/text_dataset.py
+++ b/tests/dummy_modules/text_dataset.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from flexeval.core.text_dataset import TextDataset
+from flexeval.core.text_dataset import TextDataset, TextInstance
 
 
 class DummyTextDataset(TextDataset):
@@ -13,5 +13,5 @@ class DummyTextDataset(TextDataset):
     def __len__(self) -> int:
         return len(self._text_list)
 
-    def __getitem__(self, item: int) -> str:
-        return self._text_list[item]
+    def __getitem__(self, item: int) -> TextInstance:
+        return TextInstance(self._text_list[item])


### PR DESCRIPTION
With this PR, we can compute perplexity scores of continuation texts given their prefixes.

Changes:
* `TextDataset` outputs `TextInstance` instead of `str`
* Now, we can read out `prefix` from `HFTextDataset` and `HFJsonlDataset`