### PR TITLE
Quit sharing `StringProcessor` between lm_output and reference

### DIFF
--- a/examples/sarashina_evaluation/eval_setups/aio.jsonnet
+++ b/examples/sarashina_evaluation/eval_setups/aio.jsonnet
@@ -16,8 +16,20 @@
       },
     },
     metrics: [
-      { class_path: 'CharF1', init_args: { processor: { class_path: 'AIONormalizer' } } },
-      { class_path: 'ExactMatch', init_args: { processor: { class_path: 'AIONormalizer' } } },
+      {
+        class_path: 'CharF1',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
+      {
+        class_path: 'ExactMatch',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
     ],
     gen_kwargs: { max_new_tokens: 64, stop_sequences: ['」'], do_sample: false },
     batch_size: 1,

--- a/examples/sarashina_evaluation/eval_setups/jemhopqa.jsonnet
+++ b/examples/sarashina_evaluation/eval_setups/jemhopqa.jsonnet
@@ -135,14 +135,14 @@ local template_compositioal = |||
       {
         class_path: 'CharF1',
         init_args: {
-          processor: [{ class_path: 'LastLineExtractor' }, { class_path: 'AIONormalizer' }],
+          lm_output_processor: [{ class_path: 'LastLineExtractor' }, { class_path: 'AIONormalizer' }],
           reference_processor: { class_path: 'AIONormalizer' },
         },
       },
       {
         class_path: 'ExactMatch',
         init_args: {
-          processor: [{ class_path: 'LastLineExtractor' }, { class_path: 'AIONormalizer' }],
+          lm_output_processor: [{ class_path: 'LastLineExtractor' }, { class_path: 'AIONormalizer' }],
           reference_processor: { class_path: 'AIONormalizer' },
         },
       },

--- a/examples/sarashina_evaluation/eval_setups/jsquad.jsonnet
+++ b/examples/sarashina_evaluation/eval_setups/jsquad.jsonnet
@@ -50,8 +50,20 @@
       },
     },
     metrics: [
-      { class_path: 'CharF1', init_args: { processor: { class_path: 'AIONormalizer' } } },
-      { class_path: 'ExactMatch', init_args: { processor: { class_path: 'AIONormalizer' } } },
+      {
+        class_path: 'CharF1',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
+      {
+        class_path: 'ExactMatch',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
     ],
     gen_kwargs: { max_new_tokens: 64, stop_sequences: ['\n\n'], do_sample: false },
     batch_size: 1,

--- a/examples/sarashina_evaluation/eval_setups/niilcqa.jsonnet
+++ b/examples/sarashina_evaluation/eval_setups/niilcqa.jsonnet
@@ -45,8 +45,20 @@
       },
     },
     metrics: [
-      { class_path: 'CharF1', init_args: { processor: { class_path: 'AIONormalizer' } } },
-      { class_path: 'ExactMatch', init_args: { processor: { class_path: 'AIONormalizer' } } },
+      {
+        class_path: 'CharF1',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
+      {
+        class_path: 'ExactMatch',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
     ],
     gen_kwargs: { max_new_tokens: 256, stop_sequences: ['\n\n'], do_sample: false },
     batch_size: 1,

--- a/flexeval/core/metric/char_f1.py
+++ b/flexeval/core/metric/char_f1.py
@@ -15,8 +15,7 @@ class CharF1(Metric):
     If there are multiple expected outputs, the highest score is adopted.
 
     Args:
-        processor: StringProcessor or list of Normalizers to apply to the model outputs before comparison.
-            Unless reference_processor is specified, this processor will be applied to the references as well.
+        lm_output_processor: StringProcessor or list of Normalizers to apply to the model outputs before comparison.
         reference_processor: StringProcessor or list of Normalizers to apply to the references before comparison.
 
 
@@ -32,16 +31,16 @@ class CharF1(Metric):
 
     def __init__(
         self,
-        processor: StringProcessor | list[StringProcessor] | None = None,
+        lm_output_processor: StringProcessor | list[StringProcessor] | None = None,
         reference_processor: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
-        if isinstance(processor, StringProcessor):
-            processor = [processor]
+        if isinstance(lm_output_processor, StringProcessor):
+            lm_output_processor = [lm_output_processor]
         if isinstance(reference_processor, StringProcessor):
             reference_processor = [reference_processor]
 
-        self.processors = processor
-        self.reference_processors = reference_processor or processor
+        self.lm_output_processors = lm_output_processor
+        self.reference_processors = reference_processor
 
     def evaluate(
         self,
@@ -49,8 +48,10 @@ class CharF1(Metric):
         references_list: list[list[str]],
         task_inputs_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
-        if self.processors:
-            lm_outputs = [functools.reduce(lambda x, norm: norm(x), self.processors, output) for output in lm_outputs]
+        if self.lm_output_processors:
+            lm_outputs = [
+                functools.reduce(lambda x, norm: norm(x), self.lm_output_processors, output) for output in lm_outputs
+            ]
 
         if self.reference_processors:
             references_list = [

--- a/flexeval/core/metric/exact_match.py
+++ b/flexeval/core/metric/exact_match.py
@@ -12,8 +12,8 @@ class ExactMatch(Metric):
     If there are multiple references, the output is considered correct if it matches any of the references.
 
     Args:
-        processor: StringProcessor or a list of StringProcessor to be applied to the model outputs before comparison.
-            Unless reference_processor is specified, this processor will be applied to the references as well.
+        lm_output_processor:
+            StringProcessor or a list of StringProcessor to be applied to the model outputs before comparison.
         reference_processor: StringProcessor or list of Normalizers to apply to the references before comparison.
 
     Examples:
@@ -31,16 +31,16 @@ class ExactMatch(Metric):
 
     def __init__(
         self,
-        processor: StringProcessor | list[StringProcessor] | None = None,
+        lm_output_processor: StringProcessor | list[StringProcessor] | None = None,
         reference_processor: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
-        if isinstance(processor, StringProcessor):
-            processor = [processor]
+        if isinstance(lm_output_processor, StringProcessor):
+            lm_output_processor = [lm_output_processor]
         if isinstance(reference_processor, StringProcessor):
             reference_processor = [reference_processor]
 
-        self.processors = processor
-        self.reference_processors = reference_processor or processor
+        self.lm_output_processors = lm_output_processor
+        self.reference_processors = reference_processor
 
     def evaluate(
         self,
@@ -55,8 +55,10 @@ class ExactMatch(Metric):
             )
             raise ValueError(msg)
 
-        if self.processors:
-            lm_outputs = [functools.reduce(lambda x, norm: norm(x), self.processors, output) for output in lm_outputs]
+        if self.lm_output_processors:
+            lm_outputs = [
+                functools.reduce(lambda x, norm: norm(x), self.lm_output_processors, output) for output in lm_outputs
+            ]
 
         if self.reference_processors:
             references_list = [

--- a/flexeval/preset_configs/EvalSetup/code_chat/mbpp_chat.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/code_chat/mbpp_chat.jsonnet
@@ -36,7 +36,7 @@ local dataset_base_args = {
       },
     },
     metrics: [
-      { class_path: 'CodeEval', init_args: { processor: { class_path: 'RegexExtractor', init_args: { pattern: '```python\n(.*?)\n```' } } } },
+      { class_path: 'CodeEval', init_args: { lm_output_processor: { class_path: 'RegexExtractor', init_args: { pattern: '```python\n(.*?)\n```' } } } },
     ],
     gen_kwargs: { max_new_tokens: 512 },
     batch_size: 4,

--- a/flexeval/preset_configs/EvalSetup/en_generation/gsm8k.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/en_generation/gsm8k.jsonnet
@@ -40,7 +40,13 @@ local dataset_base_args = {
       },
     },
     metrics: [
-      { class_path: 'ExactMatch', init_args: { processor: { class_path: 'RegexExtractor', init_args: { pattern: '-?[0-9.,]+' } } } },
+      {
+        class_path: 'ExactMatch',
+        init_args: {
+          lm_output_processor: { class_path: 'RegexExtractor', init_args: { pattern: '-?[0-9.,]+' } },
+          reference_processor: { class_path: 'RegexExtractor', init_args: { pattern: '-?[0-9.,]+' } },
+        },
+      },
     ],
     gen_kwargs: { max_new_tokens: 256, stop_sequences: ['Q:'] },
   },

--- a/flexeval/preset_configs/EvalSetup/ja_chat/aio_chat.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_chat/aio_chat.jsonnet
@@ -30,8 +30,20 @@ local dataset_base_args = {
       },
     },
     metrics: [
-      { class_path: 'CharF1', init_args: { processor: { class_path: 'AIONormalizer' } } },
-      { class_path: 'ExactMatch', init_args: { processor: { class_path: 'AIONormalizer' } } },
+      {
+        class_path: 'CharF1',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
+      {
+        class_path: 'ExactMatch',
+        init_args: {
+          lm_output_processor: { class_path: 'AIONormalizer' },
+          reference_processor: { class_path: 'AIONormalizer' },
+        },
+      },
     ],
     gen_kwargs: { max_new_tokens: 32 },
     batch_size: 4,

--- a/flexeval/preset_configs/EvalSetup/ja_chat/mgsm_ja_chat.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_chat/mgsm_ja_chat.jsonnet
@@ -29,7 +29,7 @@ local dataset_base_args = {
       },
     },
     metrics: [
-      { class_path: 'ExactMatch', init_args: { processor: { class_path: 'RegexExtractor', init_args: { pattern: '-?[0-9.,]+' } } } },
+      { class_path: 'ExactMatch', init_args: { lm_output_processor: { class_path: 'RegexExtractor', init_args: { pattern: '-?[0-9.,]+' } } } },
     ],
     gen_kwargs: { max_new_tokens: 256 },
   },

--- a/flexeval/preset_configs/EvalSetup/ja_generation/aio.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/aio.jsonnet
@@ -31,14 +31,14 @@ local template_ = '{{ question }}答えは「';
       {
         class_path: 'CharF1',
         init_args: {
-          processor: { class_path: 'AIONormalizer' },
+          lm_output_processor: { class_path: 'AIONormalizer' },
           reference_processor: { class_path: 'AIONormalizer' },
         },
       },
       {
         class_path: 'ExactMatch',
         init_args: {
-          processor: { class_path: 'AIONormalizer' },
+          lm_output_processor: { class_path: 'AIONormalizer' },
           reference_processor: { class_path: 'AIONormalizer' },
         },
       },

--- a/flexeval/preset_configs/EvalSetup/ja_generation/mgsm_ja.jsonnet
+++ b/flexeval/preset_configs/EvalSetup/ja_generation/mgsm_ja.jsonnet
@@ -40,7 +40,7 @@ local dataset_base_args = {
       },
     },
     metrics: [
-      { class_path: 'ExactMatch', init_args: { processor: { class_path: 'RegexExtractor', init_args: { pattern: '-?[0-9.,]+' } } } },
+      { class_path: 'ExactMatch', init_args: { lm_output_processor: { class_path: 'RegexExtractor', init_args: { pattern: '-?[0-9.,]+' } } } },
     ],
     gen_kwargs: { max_new_tokens: 256, stop_sequences: ['問題:'] },
   },

--- a/tests/core/metric/test_char_f1.py
+++ b/tests/core/metric/test_char_f1.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 import pytest
 
 from flexeval.core.metric import CharF1
-from flexeval.core.metric.string_processor import AIONormalizer, NoopNormalizer, RegexExtractor, StringProcessor
+from flexeval.core.metric.string_processor import AIONormalizer, RegexExtractor, StringProcessor
 
 
 @pytest.mark.parametrize(
-    ("lm_outputs", "expected_outputs", "processor", "reference_processor", "score"),
+    ("lm_outputs", "expected_outputs", "lm_output_processor", "reference_processor", "score"),
     [
         (["テスト"], [["テスト"]], None, None, 1.0),
         (["テスト"], [["テストです"]], None, None, 0.75),
         (["テスト"], [["テストです", "テスト"]], None, None, 1.0),
-        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), None, 1.0),
-        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), NoopNormalizer(), 0.33),
+        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), RegexExtractor(r"\d+"), 1.0),
+        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), None, 0.33),
         (
             ["答えは以下の通りです。\nA: 「蛹化（ようか）」"],
             [["蛹化"]],
             [RegexExtractor(r"A: (.*)"), AIONormalizer()],
-            NoopNormalizer(),
+            None,
             1.0,
         ),
     ],
@@ -26,11 +26,11 @@ from flexeval.core.metric.string_processor import AIONormalizer, NoopNormalizer,
 def test_char_f1(
     lm_outputs: list[str],
     expected_outputs: list[list[str]],
-    processor: StringProcessor | list[StringProcessor] | None,
+    lm_output_processor: StringProcessor | list[StringProcessor] | None,
     reference_processor: StringProcessor | list[StringProcessor] | None,
     score: float,
 ) -> None:
-    metric = CharF1(processor=processor, reference_processor=reference_processor)
+    metric = CharF1(lm_output_processor=lm_output_processor, reference_processor=reference_processor)
     metric_result = metric.evaluate(lm_outputs, expected_outputs)
     assert metric_result.summary["char_f1"] == score
     assert metric_result.instance_details[0]["char_f1"] == score

--- a/tests/core/metric/test_code_eval.py
+++ b/tests/core/metric/test_code_eval.py
@@ -19,7 +19,7 @@ def test_correct_code(code: str, test_case: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("code", "test_case", "processor"),
+    ("code", "test_case", "lm_output_processor"),
     [
         (
             "```python\ndef add(a, b):\n    return a + b\n```",
@@ -28,8 +28,8 @@ def test_correct_code(code: str, test_case: str) -> None:
         ),
     ],
 )
-def test_correct_code_with_processor(code: str, test_case: str, processor: StringProcessor) -> None:
-    code_eval = CodeEval(processor=processor)
+def test_correct_code_with_processor(code: str, test_case: str, lm_output_processor: StringProcessor) -> None:
+    code_eval = CodeEval(lm_output_processor=lm_output_processor)
     metric_result = code_eval.evaluate([code], references_list=[[test_case]])
     assert metric_result.summary == {"pass@1": 1.0}
 

--- a/tests/core/metric/test_exact_match.py
+++ b/tests/core/metric/test_exact_match.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 import pytest
 
 from flexeval.core.metric import ExactMatch
-from flexeval.core.metric.string_processor import AIONormalizer, NoopNormalizer, RegexExtractor, StringProcessor
+from flexeval.core.metric.string_processor import AIONormalizer, RegexExtractor, StringProcessor
 
 
 @pytest.mark.parametrize(
-    ("lm_outputs", "expected_outputs", "processor", "reference_processor", "score"),
+    ("lm_outputs", "expected_outputs", "lm_output_processor", "reference_processor", "score"),
     [
         (["テスト"], [["テスト"]], None, None, 1.0),
         (["テスト"], [["テストです"]], None, None, 0.0),
         (["テスト"], [["テストです", "テスト"]], None, None, 1.0),
-        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), None, 1.0),
-        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), NoopNormalizer(), 0.0),
+        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), RegexExtractor(r"\d+"), 1.0),
+        (["The answer is 10."], [["Answer: 10"]], RegexExtractor(r"\d+"), None, 0.0),
         (
             ["答えは以下の通りです。\nA: 「蛹化（ようか）」"],
             [["蛹化"]],
             [RegexExtractor(r"A: (.*)"), AIONormalizer()],
-            NoopNormalizer(),
+            None,
             1.0,
         ),
     ],
@@ -26,11 +26,11 @@ from flexeval.core.metric.string_processor import AIONormalizer, NoopNormalizer,
 def test_exact_match(
     lm_outputs: list[str],
     expected_outputs: list[list[str]],
-    processor: StringProcessor | list[StringProcessor] | None,
+    lm_output_processor: StringProcessor | list[StringProcessor] | None,
     reference_processor: StringProcessor | list[StringProcessor] | None,
     score: float,
 ) -> None:
-    metric = ExactMatch(processor=processor, reference_processor=reference_processor)
+    metric = ExactMatch(lm_output_processor=lm_output_processor, reference_processor=reference_processor)
     metric_result = metric.evaluate(lm_outputs, references_list=expected_outputs)
     assert metric_result.summary["exact_match"] == score
     assert isinstance(metric_result.instance_details[0]["exact_match"], int)

--- a/tests/scripts/test_flexeval_file.py
+++ b/tests/scripts/test_flexeval_file.py
@@ -26,7 +26,7 @@ from .test_flexeval_lm import CHAT_RESPONSE_CMD, GENERATION_CMD, check_if_eval_r
 )
 @pytest.mark.parametrize(
     "override_args",
-    [[], ["--metrics.processor", "AIONormalizer"]],
+    [[], ["--metrics.lm_output_processor", "AIONormalizer"]],
 )
 def test_if_outputs_from_flexval_lm_can_be_passed_to_flexeval_file(
     flexeval_lm_command: list[str],


### PR DESCRIPTION
When specifying `processor: StringProcessor` for metrics like `ExactMatch`, the processing was applied not only to the language model output (`lm_output`) but also to the reference string (`reference`).

https://github.com/sbintuitions/flexeval/blob/e8debacc9bf5e56f94c61c0c880d93f7c6cc02e9/flexeval/core/metric/exact_match.py#L34

This is convenient for certain types of normalization (e.g., NFKC normalization), but considering that there are many processes you'd want to apply only to the language model output (such as extracting an answer string for a math task from the LM output), it seems more natural to separate them.
This would also prevent unexpected processing of the reference strings.

**Changes:**
* Rename `processor` to `lm_output_processor` in `ExactMatch`, `CharF1`, `CodeEval`.
  * This is not applied to `reference`.
* Update preset/example configs accordingly.

