### PR TITLE
Fix `get_most_repeated_pattern`

### DIFF
--- a/flexeval/core/metric/repetition_count.py
+++ b/flexeval/core/metric/repetition_count.py
@@ -16,7 +16,10 @@ def get_most_repeated_pattern(text: str, threshold_length: int = 10) -> tuple[st
         if any(subtext.startswith(c) or subtext.endswith(c) for c in special_chars):
             continue
         counter[subtext] += 1
-    subtext, count = counter.most_common(1)[0]
+    if len(counter) > 0:
+        subtext, count = counter.most_common(1)[0]
+    else:
+        subtext, count = "", 0
     return subtext, count
 
 

--- a/tests/core/metric/test_repetition_count.py
+++ b/tests/core/metric/test_repetition_count.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from flexeval.core.metric.repetition_count import RepetitionCount
+from flexeval.core.metric.repetition_count import RepetitionCount, get_most_repeated_pattern
 
 
 @pytest.mark.parametrize(
@@ -19,3 +19,9 @@ def test_get_most_repeated_pattern(
     metric = RepetitionCount(count_threshold=count_threshold, threshold_length=threshold_length)
     result = metric.evaluate(lm_outputs, references_list=[[]] * len(lm_outputs))
     assert result.summary["repetition_ratio"] == expected_ratio
+
+
+def test_get_most_repeated_pattern_with_empty_input():
+    subtext, count = get_most_repeated_pattern(" ")
+    assert subtext == ""
+    assert count == 0

--- a/tests/core/metric/test_repetition_count.py
+++ b/tests/core/metric/test_repetition_count.py
@@ -21,7 +21,7 @@ def test_get_most_repeated_pattern(
     assert result.summary["repetition_ratio"] == expected_ratio
 
 
-def test_get_most_repeated_pattern_with_empty_input():
+def test_get_most_repeated_pattern_with_empty_input() -> None:
     subtext, count = get_most_repeated_pattern(" ")
     assert subtext == ""
     assert count == 0


### PR DESCRIPTION
Currently, `get_most_repeated_pattern` does not support input with spaces and symbols like ` ` and ` _ _ _ _`.

```
In [9]: get_most_repeated_pattern(' ')
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[9], line 1
----> 1 get_most_repeated_pattern(' ')

Cell In[4], line 11, in get_most_repeated_pattern(text, threshold_length)
      7         continue
      8     counter[subtext] += 1
---> 11 subtext, count = counter.most_common(1)[0]
     14 return subtext, count

IndexError: list index out of range
```

With this PR, the function returns empty substring and count of 0.