### PR TITLE
fix OpenAIChatBatchAPI class

### DIFF
--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -84,7 +84,6 @@ class OpenAIChatBatchAPI(LanguageModel):
         max_new_tokens: int | None = None,
         **kwargs,
     ) -> str:
-        
         gen_kwargs = self.default_gen_kwargs.copy()
         gen_kwargs.update(kwargs)
         """Send batch chat requests to the OpenAI."""


### PR DESCRIPTION
Fixed OpenAIChatBatchAPI class to accept default_gen_kwargs as an initial argument.