### PR TITLE
re-fix OpenAIChatBatchAPI class

### DIFF
--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -88,26 +88,26 @@ class OpenAIChatBatchAPI(LanguageModel):
         gen_kwargs.update(kwargs)
         """Send batch chat requests to the OpenAI."""
         if stop_sequences is not None:
-            if "stop" in kwargs:
+            if "stop" in gen_kwargs:
                 msg = (
                     "You specified both `stop_sequences` and `stop` in generation kwargs. "
                     "However, `stop_sequences` will be normalized into `stop`. "
                     "Please specify only one of them."
                 )
                 raise ValueError(msg)
-            kwargs["stop"] = stop_sequences
+            gen_kwargs["stop"] = stop_sequences
 
         if max_new_tokens is not None:
-            if "max_completion_tokens" in kwargs:
+            if "max_completion_tokens" in gen_kwargs:
                 msg = (
                     "You specified both `max_new_tokens` and `max_completion_tokens` in generation kwargs. "
                     "However, `max_new_tokens` will be normalized into `max_completion_tokens`. "
                     "Please specify only one of them."
                 )
                 raise ValueError(msg)
-            kwargs["max_completion_tokens"] = max_new_tokens
+            gen_kwargs["max_completion_tokens"] = max_new_tokens
 
-        self.create_batch_file(custom_id_2_message, **kwargs)
+        self.create_batch_file(custom_id_2_message, **gen_kwargs)
 
         # Update batch file
         with open(self.temp_jsonl_file.name, "rb") as batch_file:  # noqa: ASYNC101

--- a/tests/core/language_model/test_openai_chatgpt_batch_api.py
+++ b/tests/core/language_model/test_openai_chatgpt_batch_api.py
@@ -11,7 +11,9 @@ def is_openai_enabled() -> bool:
 
 @pytest.fixture(scope="module")
 def lm() -> OpenAIChatBatchAPI:
-    return OpenAIChatBatchAPI(model="gpt-4o-mini-2024-07-18", polling_interval_seconds=6)
+    return OpenAIChatBatchAPI(
+        model="gpt-4o-mini-2024-07-18", polling_interval_seconds=6, default_gen_kwargs={"temperature": 0.7}
+    )
 
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
@@ -32,6 +34,6 @@ def test_batch_generate_chat_response(lm: OpenAIChatBatchAPI) -> None:
         [[{"role": "user", "content": "こんにちは。"}]],
         max_new_tokens=40,
     )
-
+    
     assert len(responses) == 1
     assert isinstance(responses[0], str)

--- a/tests/core/language_model/test_openai_chatgpt_batch_api.py
+++ b/tests/core/language_model/test_openai_chatgpt_batch_api.py
@@ -34,6 +34,6 @@ def test_batch_generate_chat_response(lm: OpenAIChatBatchAPI) -> None:
         [[{"role": "user", "content": "こんにちは。"}]],
         max_new_tokens=40,
     )
-    
+
     assert len(responses) == 1
     assert isinstance(responses[0], str)


### PR DESCRIPTION
- Fixed `OpenAIChatBatchAPI` class to use `gen_kwargs` when calling API.
    - `gen_kwargs` is initialized by `default_gen_kwargs` and updated by `kwargs`.
- Updated test for `OpenAIChatBatchAPI`.