### PR TITLE
Save `finish_reason` statistics

### DIFF
--- a/flexeval/core/evaluate_generation.py
+++ b/flexeval/core/evaluate_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any, Sequence
 
 from loguru import logger
@@ -81,6 +82,10 @@ def evaluate_generation(  # noqa: C901
                 metric_result.instance_details,
             ):
                 instance_metrics_list[instance_idx].update(instance_details)
+    # Calculate the finish_reason statistics
+    finish_reason_counter = Counter([lm_output.finish_reason for lm_output in lm_output_list])
+    for finish_reason, count in finish_reason_counter.items():
+        metrics_summary_dict[f"finish_reason_ratio-{finish_reason}"] = count / len(lm_output_list)
 
     logger.info(metrics_summary_dict)
 
@@ -88,6 +93,7 @@ def evaluate_generation(  # noqa: C901
         {
             "lm_prompt": lm_prompt,
             "lm_output": lm_output.text,
+            "finish_reason": lm_output.finish_reason,
             "task_inputs": eval_instance.inputs,
             "references": eval_instance.references,
             **instance_metrics,

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -48,6 +48,7 @@ def test_evaluate_chat_response(require_incremental_response: bool, use_few_shot
         max_instances=max_instances,
     )
     assert isinstance(metrics, dict)
+    assert metrics["finish_reason_ratio-length"] == 1.0
     assert isinstance(outputs, list)
 
     if max_instances is not None:
@@ -74,6 +75,7 @@ def test_evaluate_generation(use_few_shot: bool) -> None:
         batch_size=1,
     )
     assert isinstance(metrics, dict)
+    assert metrics["finish_reason_ratio-length"] == 1.0
     assert isinstance(outputs, list)
 
 


### PR DESCRIPTION
Output `finish_reason` in the result to gain insights into how the LM stops generation.

With this PR,
* Each line in `outputs.jsonl` includes a finish_reason indicating how the generation ended.
* `metrics.json` contains `finish_reason_ratio-{finish_reason}` values, representing the fraction of each finish reason.
  * For example, a high `finish_reason_ratio-length` suggests that generation stops because it reaches `max_new_tokens`, whether intentionally or not.