### PR TITLE
Avoid using MPS for pre MacOS_14_0

### DIFF
--- a/flexeval/utils/hf_utils.py
+++ b/flexeval/utils/hf_utils.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
+import platform
 from typing import Any
 
 import torch
+
+
+def is_pre_macos_14() -> bool:
+    """
+    Returns True if the macOS version is older than 14.0
+
+    This function is useful for avoiding MPS-related issues on older macOS versions,
+        such as the following error:
+    "RuntimeError: isin_Tensor_Tensor_out only works on floating types on MPS for pre MacOS_14_0"
+    """
+    if platform.system() != "Darwin":
+        return False  # Not running on macOS
+
+    version = platform.mac_ver()[0]
+    if not version:
+        return False  # Could not determine macOS version
+
+    major_version = int(version.split(".")[0])
+    return major_version < 14
 
 
 def get_default_model_kwargs(model_kwargs: None | dict[str, Any] = None) -> dict[str, Any]:
@@ -15,6 +35,10 @@ def get_default_model_kwargs(model_kwargs: None | dict[str, Any] = None) -> dict
     model_kwargs = {**model_kwargs}  # copy kwargs to avoid modifying the original dict
     if "device_map" not in model_kwargs:
         model_kwargs["device_map"] = "auto"
+        if is_pre_macos_14():
+            # If the macOS version is older than 14.0, we need to use "cpu" instead of "auto".
+            # This is to avoid MPS-related issues on older macOS versions.
+            model_kwargs["device_map"] = "cpu"
     if "torch_dtype" not in model_kwargs:
         # You need to set torch_dtype to use the optimal dtype for the model.
         # https://huggingface.co/docs/transformers/main/main_classes/model#model-instantiation-dtype


### PR DESCRIPTION
When using HuggingFaceLM on a Mac, the following error may occur:

```
  File "..../flexeval/core/language_model/hf_lm.py", line 287, in batch_complete_text
    generated_tokens = self.model.generate(**model_inputs, **gen_kwargs)
  File "..../lib/python3.9/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "..../lib/python3.9/site-packages/transformers/generation/utils.py", line 2004, in generate
    self._prepare_special_tokens(generation_config, kwargs_has_attention_mask, device=device)
  File "..../lib/python3.9/site-packages/transformers/generation/utils.py", line 1853, in _prepare_special_tokens
    and isin_mps_friendly(elements=eos_token_tensor, test_elements=pad_token_tensor).any()
  File "..../lib/python3.9/site-packages/transformers/pytorch_utils.py", line 344, in isin_mps_friendly
    return torch.isin(elements, test_elements)
RuntimeError: isin_Tensor_Tensor_out only works on floating types on MPS for pre MacOS_14_0. Received dtype: Long
```
  
This can be avoided by setting `HuggingFaceLM(..., model_kwargs = {"device_map": "cpu"})`.
To handle this automatically, modify `get_default_model_kwargs` to set "device_map": "cpu" based on the running platform. 