### PR TITLE
Introduce `decode_for_lm_continuation`

### DIFF
--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -56,7 +56,7 @@ def tokenize_text_for_lm_prefix(
 def tokenize_text_for_lm_continuation(
     text_list: list[str],
     tokenizer: PreTrainedTokenizer,
-    oov_character: str = "彁",
+    single_token_character: str = "\x80",
     as_continuation: bool | list[bool] = True,
 ) -> BatchEncoding:
     """When tokenizing a prefix and continuation separately, the sentencepiece-
@@ -82,17 +82,14 @@ def tokenize_text_for_lm_continuation(
         msg = "The length of as_continuation must be the same as the length of text_list."
         raise ValueError(msg)
 
-    if oov_character in tokenizer.get_vocab():
-        msg = f"oov_character '{oov_character}' is already in the tokenizer's vocab."
-        raise ValueError(msg)
-    oov_char_len = len(tokenizer.tokenize(oov_character))
+    oov_char_len = len(tokenizer.tokenize(single_token_character))
 
     encoding_list: list[BatchEncoding] = []
     for text, as_cont in zip(text_list, as_continuation):
         input_text = text
         # tokenize with OOV character
         if as_cont:
-            input_text = oov_character + text
+            input_text = single_token_character + text
         encoding = tokenizer(
             input_text,
             add_special_tokens=False,

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -56,7 +56,7 @@ def tokenize_text_for_lm_prefix(
 def tokenize_text_for_lm_continuation(
     text_list: list[str],
     tokenizer: PreTrainedTokenizer,
-    single_token_character: str = "\x80",
+    single_token_character: str = "\x80",  # noqa: S107
     as_continuation: bool | list[bool] = True,
 ) -> BatchEncoding:
     """When tokenizing a prefix and continuation separately, the sentencepiece-

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -6,7 +6,7 @@ import torch
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from .base import LanguageModel, LMOutput, normalize_stop_sequences
-from .hf_lm import get_prefix_and_completion_from_chat
+from .hf_lm import decode_for_lm_continuation, get_prefix_and_completion_from_chat
 
 
 def tokenize_text_for_lm_prefix(
@@ -149,17 +149,18 @@ class VLLM(LanguageModel):
             use_tqdm=False,
         )
         outputs = []
-        for vllm_output in vllm_outputs:
-            text = self.tokenizer.decode(vllm_output.outputs[0].token_ids)
+        for input_token_ids, vllm_output in zip(model_inputs.input_ids, vllm_outputs):
+            output_token_ids = list(vllm_output.outputs[0].token_ids)
+            decoded_text = decode_for_lm_continuation(output_token_ids, input_token_ids, self.tokenizer)
             finish_reason = "length"
             # We manually remove the stop sequences from the generated texts.
             for stop in stop_sequences:
-                stop_index = text.find(stop)
+                stop_index = decoded_text.find(stop)
                 if stop_index != -1:
-                    text = text[:stop_index]
+                    decoded_text = decoded_text[:stop_index]
                     finish_reason = "stop"
 
-            outputs.append(LMOutput(text=text, finish_reason=finish_reason))
+            outputs.append(LMOutput(text=decoded_text, finish_reason=finish_reason))
         return outputs
 
     def batch_generate_chat_response(

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -65,7 +65,9 @@ def test_if_tokenizer_add_bos_tokens_in_an_expected_way(
         "line-corporation/japanese-large-lm-1.7b",
         "rinna/japanese-gpt-1b",
         "sbintuitions/sarashina2-7b",
-        "meta-llama/Meta-Llama-3-8B",
+        # We cannot get the tokenizer from CI because we need permission to access the model.
+        # Leave this for manual testing.
+        # "meta-llama/Meta-Llama-3-8B",
     ],
 )
 def test_tokenize_text_for_lm_continuation(tokenizer_name: str) -> None:

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -100,7 +100,14 @@ def test_tokenize_text_for_lm_continuation(tokenizer_name: str) -> None:
 
 @pytest.mark.parametrize(
     "tokenizer_name",
-    ["sbintuitions/sarashina2-7b", "llm-jp/llm-jp-3-3.7b", "meta-llama/Meta-Llama-3-8B", "Qwen/Qwen2.5-0.5B"],
+    [
+        "sbintuitions/sarashina2-7b",
+        "llm-jp/llm-jp-3-3.7b",
+        "Qwen/Qwen2.5-0.5B",
+        # We cannot get the tokenizer from CI because we need permission to access the model.
+        # Leave this for manual testing.
+        # "meta-llama/Meta-Llama-3-8B"
+    ],
 )
 @pytest.mark.parametrize(
     "text", ["def foo():\n", "    return 1", "こんにちは世界", "<|im_start|>Hello<|end_of_text|>Yes"]

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -65,9 +65,7 @@ def test_if_tokenizer_add_bos_tokens_in_an_expected_way(
         "line-corporation/japanese-large-lm-1.7b",
         "rinna/japanese-gpt-1b",
         "sbintuitions/sarashina2-7b",
-        # We cannot get the tokenizer from CI because we need permission to access the model.
-        # Leave this for manual testing.
-        # "meta-llama/Meta-Llama-3-8B",
+        "allenai/Llama-3.1-Tulu-3-8B",
     ],
 )
 def test_tokenize_text_for_lm_continuation(tokenizer_name: str) -> None:
@@ -100,14 +98,7 @@ def test_tokenize_text_for_lm_continuation(tokenizer_name: str) -> None:
 
 @pytest.mark.parametrize(
     "tokenizer_name",
-    [
-        "sbintuitions/sarashina2-7b",
-        "llm-jp/llm-jp-3-3.7b",
-        "Qwen/Qwen2.5-0.5B",
-        # We cannot get the tokenizer from CI because we need permission to access the model.
-        # Leave this for manual testing.
-        # "meta-llama/Meta-Llama-3-8B"
-    ],
+    ["sbintuitions/sarashina2-7b", "llm-jp/llm-jp-3-3.7b", "Qwen/Qwen2.5-0.5B", "allenai/Llama-3.1-Tulu-3-8B"],
 )
 @pytest.mark.parametrize(
     "text", ["def foo():\n", "    return 1", "こんにちは世界", "<|im_start|>Hello<|end_of_text|>Yes"]

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -75,6 +75,7 @@ def test_tokenize_text_for_lm_continuation(tokenizer_name: str) -> None:
         tokenizer.pad_token = tokenizer.eos_token
 
     # normal test cases
+    # The character 'm' forms a weird token when it follows certain multi-byte characters in Llama3 tokenizer.
     text_list = ["は続き", "is continuation.", "m"]
     batch_encoding = tokenize_text_for_lm_continuation(text_list, tokenizer)
     for i, tokens in enumerate(batch_encoding.input_ids):

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -61,13 +61,21 @@ def test_if_tokenizer_add_bos_tokens_in_an_expected_way(
 
 @pytest.mark.parametrize(
     "tokenizer_name",
-    ["line-corporation/japanese-large-lm-1.7b", "rinna/japanese-gpt-1b", "sbintuitions/sarashina2-7b"],
+    [
+        "line-corporation/japanese-large-lm-1.7b",
+        "rinna/japanese-gpt-1b",
+        "sbintuitions/sarashina2-7b",
+        "meta-llama/Meta-Llama-3-8B",
+    ],
 )
 def test_tokenize_text_for_lm_continuation(tokenizer_name: str) -> None:
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, use_fast=False)
+    # Set pad_token for tokenizers such as "meta-llama/Meta-Llama-3-8B"
+    if not tokenizer.pad_token:
+        tokenizer.pad_token = tokenizer.eos_token
 
     # normal test cases
-    text_list = ["は続き", "is continuation."]
+    text_list = ["は続き", "is continuation.", "m"]
     batch_encoding = tokenize_text_for_lm_continuation(text_list, tokenizer)
     for i, tokens in enumerate(batch_encoding.input_ids):
         first_token = tokenizer.convert_ids_to_tokens([tokens[0]])[0]


### PR DESCRIPTION
The generated text in `HuggingFaceLM` and `VLLM` is decoded using the following code:

```
decoded_text = self.tokenizer.decode(output_tokens, skip_special_tokens=False)
```

However, the issue is that the decoded output of some tokenizers depends on the surrounding context of the tokens.

Example:
```
from transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("llm-jp/llm-jp-3-3.7b")

prefix = [813, 19229, 5896, 18]
continuation = [277, 617, 36803]

print(tokenizer.decode(continuation))
# Output: "   return 1"
# Note: There are three spaces before "return"

print(tokenizer.decode(prefix))
# Output: "def foo():\n"

print(tokenizer.decode(prefix + continuation))
# Output: "def foo():    return 1"
# Now, the number of spaces before "return" is four
```
As a result, decoding tokens in isolation may lead to incorrect formatting.
This behavior is influenced by the "add_prefix_space" option or the tokenizer’s post-processing logic.

Solution:
To ensure correct decoding, the implementation now decodes the entire sequence—including both the prefix and the continuation—and then removes the prefix from the final output.


Since this could affect the core functionality of the LM, I conducted an extensive degradation check. I observed no change in scores for QA, coding, or math tasks across multiple models, including Sarashina, Qwen, and Llama.