### PR TITLE
Update `SubstringMatch`

### DIFF
--- a/flexeval/core/metric/substring_match.py
+++ b/flexeval/core/metric/substring_match.py
@@ -27,13 +27,15 @@ class SubstringMatch(Metric):
         )
     """
 
-    def __init__(self, mode: Literal["any", "all"] = "any"):
+    def __init__(self, mode: Literal["any", "all"] = "any") -> None:
+        self.mode = mode
         if mode == "all":
             self.match_func = all
         elif mode == "any":
             self.match_func = any
         else:
-            raise ValueError(f"mode must be 'any' or 'all', but got '{mode}'.")
+            msg = f"mode must be 'any' or 'all', but got '{mode}'."
+            raise ValueError(msg)
 
     def evaluate(
         self,
@@ -53,7 +55,11 @@ class SubstringMatch(Metric):
             for lm_output, expected_output in zip(lm_outputs, references_list)
         ]
 
+        score = 0.0
+        if len(match_list):
+            score = sum(match_list) / len(match_list)
+
         return MetricResult(
-            {"substring_match": sum(match_list) / len(match_list)},
+            {f"substring_match-{self.mode}": score},
             instance_details=[{"substring_match": match} for match in match_list],
         )

--- a/flexeval/core/metric/substring_match.py
+++ b/flexeval/core/metric/substring_match.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from .base import Metric, MetricResult
 
 
 class SubstringMatch(Metric):
     """
     A metric that calculates how many outputs contain any of the expected substrings.
+
+    Args:
+        mode: The mode to calculate the substring match.
+            - "any": If any of the expected substrings are in the output, it is a match.
+            - "all": If all of the expected substrings are in the output, it is a match.
 
     Examples:
         >>> from flexeval import SubstringMatch
@@ -19,6 +26,14 @@ class SubstringMatch(Metric):
             instance_details=[{'substring_match': True}, {'substring_match': False}]
         )
     """
+
+    def __init__(self, mode: Literal["any", "all"] = "any"):
+        if mode == "all":
+            self.match_func = all
+        elif mode == "any":
+            self.match_func = any
+        else:
+            raise ValueError(f"mode must be 'any' or 'all', but got '{mode}'.")
 
     def evaluate(
         self,
@@ -34,7 +49,7 @@ class SubstringMatch(Metric):
             raise ValueError(msg)
 
         match_list = [
-            any(substring in lm_output for substring in expected_output)
+            self.match_func(substring in lm_output for substring in expected_output)
             for lm_output, expected_output in zip(lm_outputs, references_list)
         ]
 

--- a/tests/core/metric/test_substring_match.py
+++ b/tests/core/metric/test_substring_match.py
@@ -2,21 +2,71 @@ from __future__ import annotations
 
 import pytest
 
-from flexeval.core.metric import SubstringMatch
+from flexeval import MetricResult, SubstringMatch
 
 
 @pytest.mark.parametrize(
     ("lm_outputs", "expected_outputs", "score"),
     [
-        (["テスト"], [["テスト"]], 1.0),
-        (["テストです"], [["テスト"]], 1.0),
-        (["テスト"], [["テストです"]], 0.0),
-        (["0", "1"], [["0"], ["0"]], 0.5),
+        (["cat dog", "dog cat"], [["cat"], ["dog"]], 1.0),
+        (["cat", "dog", "mouse"], [["cat"], ["dog"], ["elephant"]], 0.6667),
+        (["", "cat dog"], [["anything"], ["cat"]], 0.5),
+        (["Substring is not present"], [["missing"]], 0.0),
     ],
 )
-def test_exact_match(lm_outputs: list[str], expected_outputs: list[list[str]], score: float) -> None:
-    metric = SubstringMatch()
+def test_substring_match_any_mode(lm_outputs: list[str], expected_outputs: list[list[str]], score: float) -> None:
+    """Test SubstringMatch in 'any' mode with various inputs."""
+    metric = SubstringMatch(mode="any")
     metric_result = metric.evaluate(lm_outputs=lm_outputs, references_list=expected_outputs)
-    assert metric_result.summary["substring_match"] == score
-    assert isinstance(metric_result.instance_details[0]["substring_match"], int)
+    assert round(metric_result.summary["substring_match-any"], 4) == round(score, 4)
+    assert all(isinstance(detail["substring_match"], bool) for detail in metric_result.instance_details)
     assert len(metric_result.instance_details) == len(lm_outputs)
+
+
+@pytest.mark.parametrize(
+    ("lm_outputs", "expected_outputs", "score"),
+    [
+        (["cat dog"], [["cat", "dog"]], 1.0),
+        (["cat dog mouse"], [["cat", "dog"]], 1.0),
+        (["cat"], [["cat", "dog"]], 0.0),
+        (["cat dog", "dog cat", "elephant"], [["cat", "dog"], ["dog", "cat"], ["elephant", "trunk"]], 0.6667),
+        (["The quick brown fox"], [["quick", "fox"]], 1.0),
+        (["The quick brown fox"], [["quick", "zebra"]], 0.0),
+        (["one two three"], [["one", "two", "three"]], 1.0),
+        (["one three"], [["one", "two", "three"]], 0.0),
+    ],
+)
+def test_substring_match_all_mode(lm_outputs: list[str], expected_outputs: list[list[str]], score: float) -> None:
+    metric = SubstringMatch(mode="all")
+    metric_result = metric.evaluate(lm_outputs=lm_outputs, references_list=expected_outputs)
+    assert round(metric_result.summary["substring_match-all"], 4) == round(score, 4)
+    assert all(isinstance(detail["substring_match"], bool) for detail in metric_result.instance_details)
+    assert len(metric_result.instance_details) == len(lm_outputs)
+
+
+def test_default_mode() -> None:
+    """Test that the default mode is 'any'."""
+    metric = SubstringMatch()
+    assert metric.mode == "any"
+    assert metric.match_func == any
+
+
+def test_invalid_mode() -> None:
+    """Test that an invalid mode raises a ValueError."""
+    with pytest.raises(ValueError, match="mode must be 'any' or 'all'"):
+        SubstringMatch(mode="invalid")
+
+
+def test_mismatched_input_lengths() -> None:
+    """Test that mismatched input lengths raise a ValueError."""
+    metric = SubstringMatch()
+    with pytest.raises(ValueError, match="lm_outputs and references_list must have the same length"):
+        metric.evaluate(lm_outputs=["cat"], references_list=[["cat"], ["dog"]])
+
+
+def test_empty_inputs() -> None:
+    """Test with empty inputs."""
+    metric = SubstringMatch()
+    result = metric.evaluate(lm_outputs=[], references_list=[])
+    assert isinstance(result, MetricResult)
+    assert len(result.instance_details) == 0


### PR DESCRIPTION
This pull request enhances the `SubstringMatch` metric by adding a `mode` parameter and expanding the test coverage. 

### Enhancements to `SubstringMatch` metric:

* [`flexeval/core/metric/substring_match.py`](diffhunk://#diff-5090dda21490b09635bc8b682c6825a481a4fee513e259304bb9482b1e036628R3-R16): Added a `mode` parameter to the `SubstringMatch` class to allow matching 'any' or 'all' substrings, and updated the `evaluate` method to use this mode for calculating the match score. [[1]](diffhunk://#diff-5090dda21490b09635bc8b682c6825a481a4fee513e259304bb9482b1e036628R3-R16) [[2]](diffhunk://#diff-5090dda21490b09635bc8b682c6825a481a4fee513e259304bb9482b1e036628R30-R39) [[3]](diffhunk://#diff-5090dda21490b09635bc8b682c6825a481a4fee513e259304bb9482b1e036628L37-R63)

### Expanded test coverage:

* [`tests/core/metric/test_substring_match.py`](diffhunk://#diff-646b8fac0ce864ef834e37e26dabe67f92d619f903c912dab0dcd83cc03c4f37L5-R72): Added new test cases to cover different modes ('any' and 'all'), default mode, invalid mode, mismatched input lengths, and empty inputs.