### PR TITLE
Add tokenizers

### DIFF
--- a/flexeval/core/metric/tokenizer/__init__.py
+++ b/flexeval/core/metric/tokenizer/__init__.py
@@ -2,4 +2,5 @@ from .base import Tokenizer
 from .mecab import MecabTokenizer
 from .sacrebleu_tokenizer import SacreBleuTokenizer
 from .tiktoken_tokenizer import TiktokenTokenizer
+from .transformers_tokenizer import TransformersTokenizer
 from .whitespace import WhitespaceTokenizer

--- a/flexeval/core/metric/tokenizer/__init__.py
+++ b/flexeval/core/metric/tokenizer/__init__.py
@@ -1,4 +1,5 @@
 from .base import Tokenizer
 from .mecab import MecabTokenizer
 from .sacrebleu_tokenizer import SacreBleuTokenizer
+from .tiktoken_tokenizer import TiktokenTokenizer
 from .whitespace import WhitespaceTokenizer

--- a/flexeval/core/metric/tokenizer/tiktoken_tokenizer.py
+++ b/flexeval/core/metric/tokenizer/tiktoken_tokenizer.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import tiktoken
+
+
+class TiktokenTokenizer:
+    def __init__(self, tokenizer_name: str | None = None, model_name: str | None = None) -> None:
+        # raise error, if both tokenizer_name and model_name are provided
+        if tokenizer_name is not None and model_name is not None:
+            msg = "Only one of tokenizer_name or model_name must be provided."
+            raise ValueError(msg)
+
+        if tokenizer_name:
+            self.encoding = tiktoken.get_encoding(tokenizer_name)
+        elif model_name:
+            self.encoding = tiktoken.encoding_for_model(model_name)
+        else:
+            msg = "Either tokenizer_name or model_name must be provided"
+            raise ValueError(msg)
+
+    def tokenize(self, text: str) -> list[str]:
+        token_ids = self.encoding.encode(text)
+        return [self.encoding.decode([token_id]) for token_id in token_ids]

--- a/flexeval/core/metric/tokenizer/tiktoken_tokenizer.py
+++ b/flexeval/core/metric/tokenizer/tiktoken_tokenizer.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import tiktoken
 
+from .base import Tokenizer
 
-class TiktokenTokenizer:
+
+class TiktokenTokenizer(Tokenizer):
     def __init__(self, tokenizer_name: str | None = None, model_name: str | None = None) -> None:
         # raise error, if both tokenizer_name and model_name are provided
         if tokenizer_name is not None and model_name is not None:

--- a/flexeval/core/metric/tokenizer/transformers_tokenizer.py
+++ b/flexeval/core/metric/tokenizer/transformers_tokenizer.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from transformers import AutoTokenizer
+
+
+class TransformersTokenizer:
+    def __init__(
+        self,
+        path: str,
+        init_kwargs: dict[str, Any] | None = None,
+        tokenize_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        init_kwargs = init_kwargs or {}
+        self.tokenizer = AutoTokenizer.from_pretrained(path, **init_kwargs)
+        self.tokenize_kwargs = tokenize_kwargs or {}
+
+    def tokenize(self, text: str) -> list[str]:
+        return self.tokenizer.tokenize(text, **self.tokenize_kwargs)

--- a/flexeval/core/metric/tokenizer/transformers_tokenizer.py
+++ b/flexeval/core/metric/tokenizer/transformers_tokenizer.py
@@ -4,8 +4,10 @@ from typing import Any
 
 from transformers import AutoTokenizer
 
+from .base import Tokenizer
 
-class TransformersTokenizer:
+
+class TransformersTokenizer(Tokenizer):
     def __init__(
         self,
         path: str,

--- a/tests/core/metric/tokenizer/test_tiktoken_tokenizer.py
+++ b/tests/core/metric/tokenizer/test_tiktoken_tokenizer.py
@@ -1,0 +1,11 @@
+from flexeval.core.metric.tokenizer import TiktokenTokenizer
+
+
+def test_tokenizer_from_tokenizer_name() -> None:
+    tokenizer = TiktokenTokenizer(tokenizer_name="o200k_base")
+    assert tokenizer.tokenize("Hello world!") == ["Hello", " world", "!"]
+
+
+def test_tokenizer_from_model_name() -> None:
+    tokenizer = TiktokenTokenizer(model_name="gpt-4o")
+    assert tokenizer.tokenize("Hello world!") == ["Hello", " world", "!"]

--- a/tests/core/metric/tokenizer/test_transformers_tokenizer.py
+++ b/tests/core/metric/tokenizer/test_transformers_tokenizer.py
@@ -1,0 +1,6 @@
+from flexeval.core.metric.tokenizer import TransformersTokenizer
+
+
+def test_transformers_tokenizer() -> None:
+    tokenizer = TransformersTokenizer(path="sbintuitions/tiny-lm")
+    assert tokenizer.tokenize("Hello world!") == ["▁", "Hello", "▁world", "!"]


### PR DESCRIPTION
This pull request introduces two new tokenizers: `TiktokenTokenizer` and `TransformersTokenizer` classes.

New tokenizers added:

* [`flexeval/core/metric/tokenizer/__init__.py`](diffhunk://#diff-310ca6115d3002c841e50cc1e0d677aa35557c819bbfdcad23318c30b9c2d3f1R4-R5): Added imports for `TiktokenTokenizer` and `TransformersTokenizer`.
* [`flexeval/core/metric/tokenizer/tiktoken_tokenizer.py`](diffhunk://#diff-99fb318747a160bfb1b7ef29c653a0a946d9612baaf28ccc4ebf62a6ea7d10d9R1-R23): Introduced the `TiktokenTokenizer` class, which supports tokenization using the `tiktoken` library.
* [`flexeval/core/metric/tokenizer/transformers_tokenizer.py`](diffhunk://#diff-48ef00fca2a514f79f55144c49dd067c47dbe726e9300ba24bf71024b169c458R1-R20): Introduced the `TransformersTokenizer` class, which supports tokenization using the `transformers` library from Hugging Face.

Tests for new tokenizers:

* [`tests/core/metric/tokenizer/test_tiktoken_tokenizer.py`](diffhunk://#diff-6436aa129a705056ade537330fca8c9b601d5ba1436f499b1e4d35ceeb43adf2R1-R11): Added tests for the `TiktokenTokenizer`, ensuring it works with both tokenizer names and model names.
* [`tests/core/metric/tokenizer/test_transformers_tokenizer.py`](diffhunk://#diff-c7489a6832ab46758dd6070690acd5ea7d9300fb7b549111f5fc543d00031952R1-R6): Added a test for the `TransformersTokenizer`, verifying its tokenization functionality.