### PR TITLE
Compute category-wise scores in `ExactMatch` and `SubstringMatch` if specified

### DIFF
--- a/flexeval/core/metric/exact_match.py
+++ b/flexeval/core/metric/exact_match.py
@@ -5,6 +5,7 @@ import functools
 from flexeval.core.string_processor import StringProcessor
 
 from .base import Metric, MetricResult
+from .utils import aggregate_category_wise_scores
 
 
 class ExactMatch(Metric):
@@ -34,6 +35,7 @@ class ExactMatch(Metric):
         self,
         lm_output_processor: StringProcessor | list[StringProcessor] | None = None,
         reference_processor: StringProcessor | list[StringProcessor] | None = None,
+        category_key: str | None = None,
     ) -> None:
         if isinstance(lm_output_processor, StringProcessor):
             lm_output_processor = [lm_output_processor]
@@ -42,6 +44,7 @@ class ExactMatch(Metric):
 
         self.lm_output_processors = lm_output_processor
         self.reference_processors = reference_processor
+        self.category_key = category_key
 
     def evaluate(
         self,
@@ -70,8 +73,15 @@ class ExactMatch(Metric):
         exact_match_list = [
             lm_output in expected_output for lm_output, expected_output in zip(lm_outputs, references_list)
         ]
+        summary = {"exact_match": sum(exact_match_list) / len(exact_match_list)}
+
+        if self.category_key:
+            categories = [task_input[self.category_key] for task_input in task_inputs_list]
+            category_wise_scores = aggregate_category_wise_scores(exact_match_list, categories)
+            for category, category_wise_score in category_wise_scores.items():
+                summary[f"exact_match/{category}"] = category_wise_score
 
         return MetricResult(
-            {"exact_match": sum(exact_match_list) / len(exact_match_list)},
+            summary,
             instance_details=[{"exact_match": s} for s in exact_match_list],
         )

--- a/flexeval/core/metric/exact_match.py
+++ b/flexeval/core/metric/exact_match.py
@@ -16,7 +16,7 @@ class ExactMatch(Metric):
     Args:
         lm_output_processor:
             StringProcessor or a list of StringProcessor to be applied to the model outputs before comparison.
-        reference_processor: StringProcessor or list of Normalizers to apply to the references before comparison.
+        reference_processor: StringProcessor or list of StringProcessor to apply to the references before comparison.
 
     Examples:
         >>> from flexeval import ExactMatch

--- a/flexeval/core/metric/utils.py
+++ b/flexeval/core/metric/utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def aggregate_category_wise_scores(scores: list[float, bool], categories: list[T]) -> dict[T, float]:
+    """
+    Compute average scores for each category.
+    """
+    if len(scores) != len(categories):
+        msg = f"Length of scores ({len(scores)}) and category_keys ({len(categories)}) should be the same."
+        raise ValueError(msg)
+
+    category_set = sorted(set(categories))
+    category_scores = {category: [] for category in category_set}
+    for score, category in zip(scores, categories):
+        category_scores[category].append(score)
+
+    return {category: sum(scores) / len(scores) for category, scores in category_scores.items()}

--- a/flexeval/core/metric/utils.py
+++ b/flexeval/core/metric/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -13,8 +14,7 @@ def aggregate_category_wise_scores(scores: list[float, bool], categories: list[T
         msg = f"Length of scores ({len(scores)}) and category_keys ({len(categories)}) must be the same."
         raise ValueError(msg)
 
-    category_set = sorted(set(categories))
-    category_scores = {category: [] for category in category_set}
+    category_scores = defaultdict(list)
     for score, category in zip(scores, categories):
         category_scores[category].append(score)
 

--- a/flexeval/core/metric/utils.py
+++ b/flexeval/core/metric/utils.py
@@ -10,7 +10,7 @@ def aggregate_category_wise_scores(scores: list[float, bool], categories: list[T
     Compute average scores for each category.
     """
     if len(scores) != len(categories):
-        msg = f"Length of scores ({len(scores)}) and category_keys ({len(categories)}) should be the same."
+        msg = f"Length of scores ({len(scores)}) and category_keys ({len(categories)}) must be the same."
         raise ValueError(msg)
 
     category_set = sorted(set(categories))

--- a/tests/core/metric/test_exact_match.py
+++ b/tests/core/metric/test_exact_match.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from flexeval.core.metric import ExactMatch
+from flexeval.core.metric import ExactMatch, MetricResult
 from flexeval.core.string_processor import AIONormalizer, RegexExtractor, StringProcessor
 
 
@@ -32,6 +32,43 @@ def test_exact_match(
 ) -> None:
     metric = ExactMatch(lm_output_processor=lm_output_processor, reference_processor=reference_processor)
     metric_result = metric.evaluate(lm_outputs, references_list=expected_outputs)
+
+    assert isinstance(metric_result, MetricResult)
     assert metric_result.summary["exact_match"] == score
     assert isinstance(metric_result.instance_details[0]["exact_match"], int)
     assert len(metric_result.instance_details) == len(lm_outputs)
+
+
+def test_exact_match_with_category_key() -> None:
+    """Test ExactMatch metric with category_key parameter."""
+    metric = ExactMatch(category_key="category")
+
+    task_inputs_list = [
+        {"category": "binary", "text": "Is this true?"},
+        {"category": "binary", "text": "Is this false?"},
+        {"category": "binary", "text": "Is this correct?"},
+        {"category": "open", "text": "What do you think?"},
+    ]
+    lm_outputs = ["yes", "no", "yes", "maybe"]
+    references_list = [["yes"], ["no"], ["no"], ["maybe"]]
+
+    result = metric.evaluate(lm_outputs, references_list, task_inputs_list)
+
+    assert isinstance(result, MetricResult)
+    assert "exact_match" in result.summary
+    assert "exact_match/binary" in result.summary
+    assert "exact_match/open" in result.summary
+
+    # Overall accuracy: 3/4 = 0.75 (yes, no, maybe matched correctly)
+    assert result.summary["exact_match"] == 0.75
+    # Binary category accuracy: 2/3 = ~0.67 (2 correct out of 3)
+    assert pytest.approx(result.summary["exact_match/binary"]) == 2 / 3
+    # Open category accuracy: 1/1 = 1.0 (1 correct out of 1)
+    assert result.summary["exact_match/open"] == 1.0
+
+    # Check instance details
+    assert len(result.instance_details) == 4
+    assert result.instance_details[0]["exact_match"] is True  # "yes" matches
+    assert result.instance_details[1]["exact_match"] is True  # "no" matches
+    assert result.instance_details[2]["exact_match"] is False  # "yes" doesn't match "no"
+    assert result.instance_details[3]["exact_match"] is True  # "maybe" matches

--- a/tests/core/metric/test_utils.py
+++ b/tests/core/metric/test_utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+import pytest
+
+from flexeval.core.metric.utils import aggregate_category_wise_scores
+
+T = TypeVar("T")
+
+
+@pytest.mark.parametrize(
+    ("scores", "categories", "expected", "error_msg"),
+    [
+        # Normal case with multiple categories
+        (
+            [1.0, 2.0, 3.0, 4.0],
+            ["A", "A", "B", "B"],
+            {"A": 1.5, "B": 3.5},
+            None,
+        ),
+        # Single category case
+        (
+            [1.0, 2.0, 3.0],
+            ["A", "A", "A"],
+            {"A": 2.0},
+            None,
+        ),
+        # Boolean scores case
+        (
+            [True, False, True],
+            ["X", "X", "Y"],
+            {"X": 0.5, "Y": 1.0},
+            None,
+        ),
+        # Length mismatch error case
+        (
+            [1.0, 2.0],
+            ["A", "B", "C"],
+            None,
+            "Length of scores (2) and category_keys (3) should be the same",
+        ),
+    ],
+)
+def test_aggregate_category_wise_scores(
+    scores: list[float | bool], categories: list[T], expected: dict[T, float], error_msg: str | None
+) -> None:
+    if error_msg is not None:
+        with pytest.raises(ValueError) as exc_info:
+            aggregate_category_wise_scores(scores, categories)
+        assert error_msg in str(exc_info.value)
+    else:
+        result = aggregate_category_wise_scores(scores, categories)
+        assert result == expected

--- a/tests/core/metric/test_utils.py
+++ b/tests/core/metric/test_utils.py
@@ -38,7 +38,7 @@ T = TypeVar("T")
             [1.0, 2.0],
             ["A", "B", "C"],
             None,
-            "Length of scores (2) and category_keys (3) should be the same",
+            "Length of scores (2) and category_keys (3) must be the same",
         ),
     ],
 )


### PR DESCRIPTION
This pull request introduces category-wise score aggregation to the `ExactMatch` and `SubstringMatch` metrics.


* [`flexeval/core/metric/utils.py`](diffhunk://#diff-d23e135e68e3237a07e6f7b3abbaf3abec8b96ced90b306e97af871d3c41de74R1-R21): Introduced the `aggregate_category_wise_scores` function to compute average scores for each category. This function is used by both `ExactMatch` and `SubstringMatch` metrics for category-wise score aggregation.

* [`flexeval/core/metric/exact_match.py`](diffhunk://#diff-c30d4cba3baa6527b62850831c3254e61c932a310723f2e505eeec922a32cd57R38): Added a `category_key` parameter to the `ExactMatch` class to allow for category-wise score aggregation. Updated the `evaluate` method to compute and include category-wise scores in the summary if the `category_key` is provided. [[1]](diffhunk://#diff-c30d4cba3baa6527b62850831c3254e61c932a310723f2e505eeec922a32cd57R38) [[2]](diffhunk://#diff-c30d4cba3baa6527b62850831c3254e61c932a310723f2e505eeec922a32cd57R47) [[3]](diffhunk://#diff-c30d4cba3baa6527b62850831c3254e61c932a310723f2e505eeec922a32cd57R76-R85)
* [`flexeval/core/metric/substring_match.py`](diffhunk://#diff-5090dda21490b09635bc8b682c6825a481a4fee513e259304bb9482b1e036628L30-R34): Added a `category_key` parameter to the `SubstringMatch` class to allow for category-wise score aggregation. Updated the `evaluate` method to compute and include category-wise scores in the summary if the `category_key` is provided. [[1]](diffhunk://#diff-5090dda21490b09635bc8b682c6825a481a4fee513e259304bb9482b1e036628L30-R34) [[2]](diffhunk://#diff-5090dda21490b09635bc8b682c6825a481a4fee513e259304bb9482b1e036628R65-R74)

The corresponding test functions are added as well.