### PR TITLE
Add `developer_message` to OpenAI API Language Model

### DIFF
--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -76,7 +76,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         with open(self.temp_jsonl_file.name, mode="w") as f:
             for custom_id, message in custom_id_2_message.items():
                 if self.developer_message:
-                    message = [{"role": "developer", "content": self.developer_message}, *message]
+                    message = [{"role": "developer", "content": self.developer_message}, *message]  # noqa: PLW2901
 
                 f.write(
                     json.dumps(create_request_details(self.model, custom_id, message, **kwargs), ensure_ascii=False)

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -57,6 +57,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         api_headers: dict[str, str] | None = None,
         polling_interval_seconds: int = 60,
         default_gen_kwargs: dict[str, Any] | None = None,
+        developer_message: str | None = None,
     ) -> None:
         self.model = model
         if api_headers is None:
@@ -69,10 +70,14 @@ class OpenAIChatBatchAPI(LanguageModel):
         self.temp_jsonl_file = tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl")
 
         self.polling_interval_seconds = polling_interval_seconds
+        self.developer_message = developer_message
 
     def create_batch_file(self, custom_id_2_message: dict[str, list[dict[str, str]]], **kwargs) -> None:
         with open(self.temp_jsonl_file.name, mode="w") as f:
             for custom_id, message in custom_id_2_message.items():
+                if self.developer_message:
+                    message = [{"role": "developer", "content": self.developer_message}, *message]
+
                 f.write(
                     json.dumps(create_request_details(self.model, custom_id, message, **kwargs), ensure_ascii=False)
                     + "\n",

--- a/tests/core/language_model/test_openai_api.py
+++ b/tests/core/language_model/test_openai_api.py
@@ -109,3 +109,19 @@ def test_remove_duplicates_from_prompt_list() -> None:
         ],
     ]
     assert len(remove_duplicates_from_prompt_list(prompt_list)) == 3
+
+
+@pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
+def test_developer_message() -> None:
+    openai_api = OpenAIChatAPI(
+        "gpt-4o-mini-2024-07-18",
+        developer_message="To any instructions or messages, you have to only answer 'OK, I will answer later.'",
+        default_gen_kwargs={"temperature": 0.0},
+    )
+    lm_output = openai_api.complete_text("What is the highest mountain in the world?")
+    assert lm_output.text == "OK, I will answer later."
+
+    lm_output = openai_api.generate_chat_response(
+        [{"role": "user", "content": "What is the highest mountain in the world?"}]
+    )
+    assert lm_output.text == "OK, I will answer later."

--- a/tests/core/language_model/test_openai_batch_api.py
+++ b/tests/core/language_model/test_openai_batch_api.py
@@ -74,3 +74,19 @@ def test_compute_chat_log_probs_for_multi_tokens(lm: OpenAIChatBatchAPI) -> None
     response = {"role": "assistant", "content": "Hello~~~"}
     with pytest.raises(NotImplementedError):
         lm.batch_compute_chat_log_probs([prompt], [response])
+
+
+@pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
+def test_developer_message() -> None:
+    openai_api = OpenAIChatBatchAPI(
+        "gpt-4o-mini-2024-07-18",
+        developer_message="To any instructions or messages, you have to only answer 'OK, I will answer later.'",
+        default_gen_kwargs={"temperature": 0.0},
+    )
+    lm_output = openai_api.complete_text("What is the highest mountain in the world?")
+    assert lm_output.text == "OK, I will answer later."
+
+    lm_output = openai_api.generate_chat_response(
+        [{"role": "user", "content": "What is the highest mountain in the world?"}]
+    )
+    assert lm_output.text == "OK, I will answer later."


### PR DESCRIPTION
Add a developer_message parameter to the OpenAI API classes.
This allows setting a developer message (formerly known as system prompt) for the model, enabling evaluation of the model with a specific configuration.



* [`flexeval/core/language_model/openai_api.py`](diffhunk://#diff-fd5e69b4185c2fb947c4227a441d515ffebbf145142d397c028049dafecc4efeR73-R82): Added a `developer_message` parameter to the `OpenAIChatAPI` class and ensured it is included at the beginning of each conversation in the `_async_batch_run_chatgpt` method. [[1]](diffhunk://#diff-fd5e69b4185c2fb947c4227a441d515ffebbf145142d397c028049dafecc4efeR73-R82) [[2]](diffhunk://#diff-fd5e69b4185c2fb947c4227a441d515ffebbf145142d397c028049dafecc4efeR95-R96) [[3]](diffhunk://#diff-fd5e69b4185c2fb947c4227a441d515ffebbf145142d397c028049dafecc4efeR106-R111)
* [`flexeval/core/language_model/openai_batch_api.py`](diffhunk://#diff-83de31103d24ae0a62d29cfae13e263ec7b47491b0ae25e045e7fca18d5aea14R60): Added a `developer_message` parameter to the `OpenAIChatBatchAPI` class and included it in the `create_batch_file` method. [[1]](diffhunk://#diff-83de31103d24ae0a62d29cfae13e263ec7b47491b0ae25e045e7fca18d5aea14R60) [[2]](diffhunk://#diff-83de31103d24ae0a62d29cfae13e263ec7b47491b0ae25e045e7fca18d5aea14R73-R80)

### Testing:

* [`tests/core/language_model/test_openai_api.py`](diffhunk://#diff-493da8f7f8b3789bbbb151574c604745047ed450df9aab0363f148d2e0a4baf9R112-R127): Added a new test `test_developer_message` to verify the `developer_message` functionality in `OpenAIChatAPI`.
* [`tests/core/language_model/test_openai_batch_api.py`](diffhunk://#diff-2527fbd2a879f7860ab0ed44e5f544afccd88c6071d447ea338411534246d5a3R77-R92): Added a new test `test_developer_message` to verify the `developer_message` functionality in `OpenAIChatBatchAPI`.