### PR TITLE
Change `LanguageModel._batch_*` methods to private

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -50,7 +50,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912
                     input_messages_list[input_id] = [*few_shot_messages, *input_messages_list[input_id]]
 
             if not eval_dataset.require_incremental_response():
-                lm_outputs = language_model.batch_generate_chat_response(
+                lm_outputs = language_model.generate_chat_response(
                     input_messages_list,
                     **gen_kwargs,
                 )
@@ -73,7 +73,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912
                         current_chat_history[b_id] + [input_messages_list[b_id][turn]]
                         for b_id in batch_ids_fed_to_model
                     ]
-                    lm_outputs = language_model.batch_generate_chat_response(
+                    lm_outputs = language_model.generate_chat_response(
                         current_model_inputs,
                         **gen_kwargs,
                     )

--- a/flexeval/core/evaluate_generation.py
+++ b/flexeval/core/evaluate_generation.py
@@ -52,7 +52,7 @@ def evaluate_generation(  # noqa: C901
                 prompt = prompt_template.embed_inputs(template_inputs)
                 lm_prompts.append(prompt)
 
-            lm_outputs = language_model.batch_complete_text(
+            lm_outputs = language_model.complete_text(
                 lm_prompts,
                 **gen_kwargs,
             )

--- a/flexeval/core/evaluate_multiple_choice.py
+++ b/flexeval/core/evaluate_multiple_choice.py
@@ -59,7 +59,7 @@ def evaluate_multiple_choice(
                 logger.info(f"prefix: {batch_prefixes[0]}")
                 logger.info(f"choices: {batch_choices[:len(eval_instance.choices)]}")
 
-            batch_log_probs = language_model.batch_compute_log_probs(
+            batch_log_probs = language_model.compute_log_probs(
                 text_list=batch_choices,
                 prefix_list=batch_prefixes,
             )

--- a/flexeval/core/evaluate_perplexity.py
+++ b/flexeval/core/evaluate_perplexity.py
@@ -29,7 +29,7 @@ def evaluate_perplexity(
     token_counts: dict[str, int] = defaultdict(int)
     with tqdm(total=len(eval_instances)) as pbar:
         for batch in batch_iter(eval_instances, batch_size):
-            log_probs = language_model.batch_compute_log_probs(
+            log_probs = language_model.compute_log_probs(
                 text_list=[i.text for i in batch], prefix_list=[i.prefix for i in batch]
             )
             total_log_prob += sum(log_probs)

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -16,7 +16,7 @@ class LanguageModel:
     It can generate text based on the input text, response to chat messages, and compute log probabilities.
     """
 
-    def batch_complete_text(
+    def _batch_complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -42,7 +42,7 @@ class LanguageModel:
         msg = f"{self.__class__.__name__} cannot generate text."
         raise NotImplementedError(msg)
 
-    def batch_generate_chat_response(
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
@@ -56,7 +56,7 @@ class LanguageModel:
         msg = f"{self.__class__.__name__} cannot generate chat responses."
         raise NotImplementedError(msg)
 
-    def batch_compute_log_probs(
+    def _batch_compute_log_probs(
         self,
         text_list: list[str],
         prefix_list: list[str] | None = None,
@@ -74,7 +74,7 @@ class LanguageModel:
         msg = f"{self.__class__.__name__} cannot compute perplexity."
         raise NotImplementedError(msg)
 
-    def batch_compute_chat_log_probs(
+    def _batch_compute_chat_log_probs(
         self, prompt_list: list[list[dict[str, str]]], response_list: list[dict[str, str]]
     ) -> list[float]:
         """
@@ -102,8 +102,8 @@ class LanguageModel:
         """
 
         if isinstance(text_list, str):
-            return self.batch_complete_text([text_list], stop_sequences, max_new_tokens, **kwargs)[0]
-        return self.batch_complete_text(text_list, stop_sequences, max_new_tokens, **kwargs)
+            return self._batch_complete_text([text_list], stop_sequences, max_new_tokens, **kwargs)[0]
+        return self._batch_complete_text(text_list, stop_sequences, max_new_tokens, **kwargs)
 
     @final
     def generate_chat_response(
@@ -118,8 +118,8 @@ class LanguageModel:
         """
 
         if isinstance(chat_messages[0], dict):
-            return self.batch_generate_chat_response([chat_messages], **kwargs)[0]
-        return self.batch_generate_chat_response(chat_messages, **kwargs)
+            return self._batch_generate_chat_response([chat_messages], **kwargs)[0]
+        return self._batch_generate_chat_response(chat_messages, **kwargs)
 
     @final
     def compute_log_probs(
@@ -135,8 +135,8 @@ class LanguageModel:
         """
 
         if isinstance(text_list, str):
-            return self.batch_compute_log_probs([text_list], prefix_list, stride)[0]
-        return self.batch_compute_log_probs(text_list, prefix_list, stride)
+            return self._batch_compute_log_probs([text_list], prefix_list, stride)[0]
+        return self._batch_compute_log_probs(text_list, prefix_list, stride)
 
     @final
     def compute_chat_log_probs(
@@ -149,8 +149,8 @@ class LanguageModel:
         """
 
         if isinstance(prompt[0], dict):
-            return self.batch_compute_chat_log_probs([prompt], [response])[0]
-        return self.batch_compute_chat_log_probs(prompt, response)
+            return self._batch_compute_chat_log_probs([prompt], [response])[0]
+        return self._batch_compute_chat_log_probs(prompt, response)
 
 
 def normalize_stop_sequences(

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -242,7 +242,7 @@ class HuggingFaceLM(LanguageModel):
         return stop_token_ids
 
     @torch.inference_mode()
-    def batch_complete_text(
+    def _batch_complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -303,7 +303,7 @@ class HuggingFaceLM(LanguageModel):
             lm_outputs.append(LMOutput(text=decoded_text, finish_reason=finish_reason))
         return lm_outputs
 
-    def batch_generate_chat_response(
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
@@ -317,10 +317,10 @@ class HuggingFaceLM(LanguageModel):
             )
             for chat_messages in chat_messages_list
         ]
-        return self.batch_complete_text(chat_messages_as_string, **kwargs)
+        return self.complete_text(chat_messages_as_string, **kwargs)
 
     @torch.inference_mode()
-    def batch_compute_log_probs(
+    def _batch_compute_log_probs(
         self,
         text_list: list[str],
         prefix_list: list[str] | None = None,
@@ -426,7 +426,7 @@ class HuggingFaceLM(LanguageModel):
             total_log_probs = (log_prob_of_next * log_prob_mask).sum(dim=-1)
         return total_log_probs.tolist()
 
-    def batch_compute_chat_log_probs(
+    def _batch_compute_chat_log_probs(
         self, prompt_list: list[list[dict[str, str]]], response_list: list[dict[str, str]]
     ) -> list[float]:
         prompt_as_string: list[str] = []
@@ -440,7 +440,7 @@ class HuggingFaceLM(LanguageModel):
             )
             prompt_as_string.append(prompt_as_string_i)
             response_as_string.append(response_as_string_i)
-        return self.batch_compute_log_probs(response_as_string, prefix_list=prompt_as_string)
+        return self.compute_log_probs(response_as_string, prefix_list=prompt_as_string)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self._model_name_or_path!r})"

--- a/flexeval/core/language_model/litellm_api.py
+++ b/flexeval/core/language_model/litellm_api.py
@@ -43,7 +43,7 @@ class LiteLLMChatAPI(OpenAIChatAPI):
             model_response_object=ModelResponse(),
         )
 
-    def batch_compute_chat_log_probs(
+    def _batch_compute_chat_log_probs(
         self,
         prompt_list: list[list[dict[str, str]]],
         response_list: list[dict[str, str]],

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -145,7 +145,7 @@ class OpenAIChatAPI(LanguageModel):
         ]
         return await asyncio.gather(*tasks)
 
-    def complete_text(
+    def _batch_complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -170,7 +170,7 @@ class OpenAIChatAPI(LanguageModel):
             logger.warning("All generated texts are empty strings. Something may be wrong.")
         return outputs
 
-    def generate_chat_response(
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
@@ -186,7 +186,7 @@ class OpenAIChatAPI(LanguageModel):
             logger.warning("All generated texts are empty strings. Something may go wrong.")
         return outputs
 
-    def compute_chat_log_probs(
+    def _batch_compute_chat_log_probs(
         self,
         prompt_list: list[list[dict[str, str]]],
         response_list: list[dict[str, str]],

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -145,7 +145,7 @@ class OpenAIChatAPI(LanguageModel):
         ]
         return await asyncio.gather(*tasks)
 
-    def batch_complete_text(
+    def complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -170,7 +170,7 @@ class OpenAIChatAPI(LanguageModel):
             logger.warning("All generated texts are empty strings. Something may be wrong.")
         return outputs
 
-    def batch_generate_chat_response(
+    def generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
@@ -186,7 +186,7 @@ class OpenAIChatAPI(LanguageModel):
             logger.warning("All generated texts are empty strings. Something may go wrong.")
         return outputs
 
-    def batch_compute_chat_log_probs(
+    def compute_chat_log_probs(
         self,
         prompt_list: list[list[dict[str, str]]],
         response_list: list[dict[str, str]],
@@ -350,7 +350,7 @@ class OpenAICompletionAPI(LanguageModel):
         ]
         return await asyncio.gather(*tasks)
 
-    def batch_complete_text(
+    def _batch_complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -209,7 +209,7 @@ class OpenAIChatBatchAPI(LanguageModel):
 
         return list(custom_id_2_response.values())
 
-    def batch_complete_text(
+    def _batch_complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -228,7 +228,7 @@ class OpenAIChatBatchAPI(LanguageModel):
             for res in api_responses
         ]
 
-    def batch_generate_chat_response(
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
@@ -254,7 +254,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         except OSError as e:
             logger.error(f"Error: {e.filename} - {e.strerror}.")
 
-    def batch_compute_chat_log_probs(
+    def _batch_compute_chat_log_probs(
         self,
         prompt_list: list[list[dict[str, str]]],
         response_list: list[dict[str, str]],

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -113,7 +113,7 @@ class VLLM(LanguageModel):
             model_kwargs["disable_sliding_window"] = True
         self.llm = LLM(model, **model_kwargs)
 
-    def batch_complete_text(
+    def complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -164,7 +164,7 @@ class VLLM(LanguageModel):
             outputs.append(LMOutput(text=decoded_text, finish_reason=finish_reason))
         return outputs
 
-    def batch_generate_chat_response(
+    def generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
@@ -178,9 +178,9 @@ class VLLM(LanguageModel):
             )
             for chat_messages in chat_messages_list
         ]
-        return self.batch_complete_text(chat_messages_as_string, **kwargs)
+        return self.complete_text(chat_messages_as_string, **kwargs)
 
-    def batch_compute_log_probs(
+    def _batch_compute_log_probs(
         self, text_list: list[str], prefix_list: list[str] | None = None, stride: int | None = None
     ) -> list[float]:
         batch_size = len(text_list)
@@ -259,7 +259,7 @@ class VLLM(LanguageModel):
 
         return batch_logprobs
 
-    def batch_compute_chat_log_probs(
+    def _batch_compute_chat_log_probs(
         self, prompt_list: list[list[dict[str, str]]], response_list: list[dict[str, str]]
     ) -> list[float]:
         prompt_as_string: list[str] = []
@@ -273,7 +273,7 @@ class VLLM(LanguageModel):
             )
             prompt_as_string.append(prompt_as_string_i)
             response_as_string.append(response_as_string_i)
-        return self.batch_compute_log_probs(response_as_string, prefix_list=prompt_as_string)
+        return self.compute_log_probs(response_as_string, prefix_list=prompt_as_string)
 
     def __repr__(self) -> str:
         return f"VLLM(model_name={self.model_name})"

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -113,7 +113,7 @@ class VLLM(LanguageModel):
             model_kwargs["disable_sliding_window"] = True
         self.llm = LLM(model, **model_kwargs)
 
-    def complete_text(
+    def _batch_complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -164,7 +164,7 @@ class VLLM(LanguageModel):
             outputs.append(LMOutput(text=decoded_text, finish_reason=finish_reason))
         return outputs
 
-    def generate_chat_response(
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
@@ -178,7 +178,7 @@ class VLLM(LanguageModel):
             )
             for chat_messages in chat_messages_list
         ]
-        return self.complete_text(chat_messages_as_string, **kwargs)
+        return self._batch_complete_text(chat_messages_as_string, **kwargs)
 
     def _batch_compute_log_probs(
         self, text_list: list[str], prefix_list: list[str] | None = None, stride: int | None = None

--- a/flexeval/core/metric/llm_geval_score.py
+++ b/flexeval/core/metric/llm_geval_score.py
@@ -108,13 +108,13 @@ def generate_evaluation_logprobs(
         evaluator_logprobs_list: list[dict[str, float]] = []
         for evaluator_input in evaluator_input_list:
             if isinstance(evaluator_input, str):
-                evaluator_logprobs = language_model.batch_compute_log_probs(
+                evaluator_logprobs = language_model.compute_log_probs(
                     valid_labels,  # for openai models, len(valid_labels) <= 20 due to constraint
                     [evaluator_input]
                     * len(valid_labels),  # we have to provide len(valid_labels) same inputs for generate logprob
                 )
             else:
-                evaluator_logprobs = language_model.batch_compute_chat_log_probs(
+                evaluator_logprobs = language_model.compute_chat_log_probs(
                     [evaluator_input for _ in valid_labels],
                     [{"role": "assistant", "content": label} for label in valid_labels],
                 )

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -153,11 +153,11 @@ def generate_evaluations(
             batch_size=batch_size,
         ):
             if all(isinstance(elem, str) for elem in batch_inputs):
-                evaluator_outputs = language_model.batch_complete_text(
+                evaluator_outputs = language_model.complete_text(
                     batch_inputs,
                 )
             else:
-                evaluator_outputs = language_model.batch_generate_chat_response(
+                evaluator_outputs = language_model.generate_chat_response(
                     batch_inputs,
                 )
             evaluator_output_list += evaluator_outputs

--- a/flexeval/core/pairwise_comparison/judge/llm_judge.py
+++ b/flexeval/core/pairwise_comparison/judge/llm_judge.py
@@ -81,5 +81,5 @@ class ChatLLMPairwiseJudge(PairwiseJudge):
                     {"role": "system", "content": system_message},
                 )
             input_chat_messages_list.append(input_chat_messages)
-        judge_outputs = self.language_model.batch_generate_chat_response(input_chat_messages_list)
+        judge_outputs = self.language_model.generate_chat_response(input_chat_messages_list)
         return [self._parse_judge_output(output) for output in judge_outputs]

--- a/flexeval/core/reward_model/log_prob.py
+++ b/flexeval/core/reward_model/log_prob.py
@@ -27,11 +27,11 @@ class LogProbRewardModel(RewardModel):
             msg = "`rejected` field must have exactly one element."
             raise ValueError(msg)
 
-        chosen_log_probs = self.language_model.batch_compute_chat_log_probs(
+        chosen_log_probs = self.language_model.compute_chat_log_probs(
             prompt_list=[instance.prompt for instance in batch_reward_bench_instances],
             response_list=[instance.chosen[0] for instance in batch_reward_bench_instances],
         )
-        rejected_log_probs = self.language_model.batch_compute_chat_log_probs(
+        rejected_log_probs = self.language_model.compute_chat_log_probs(
             prompt_list=[instance.prompt for instance in batch_reward_bench_instances],
             response_list=[instance.rejected[0] for instance in batch_reward_bench_instances],
         )

--- a/flexeval/core/reward_model/pairwise_judge_reward_model.py
+++ b/flexeval/core/reward_model/pairwise_judge_reward_model.py
@@ -117,7 +117,7 @@ class PairwiseJudgeRewardModel(RewardModel):
                 "llm_inputs": [input_chat_messages_a_is_chosen, input_chat_messages_b_is_chosen],
             }
             outputs.append(output)
-        judge_outputs = self.language_model.batch_generate_chat_response(input_chat_messages_list, **self.gen_kwargs)
+        judge_outputs = self.language_model.generate_chat_response(input_chat_messages_list, **self.gen_kwargs)
         chosen_is_betters: list[bool] = [
             self._is_correct_llm_answer(judge_output.text, shuffle_pairwise_instance.answer_label)
             for judge_output, shuffle_pairwise_instance in zip(judge_outputs, all_pairwise_instances)

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -167,7 +167,7 @@ def test_if_random_seed_fixes_the_lm_outputs(lm_init_func: Callable[..., Hugging
     completions = set()
     for i in range(3):
         lm = lm_init_func(random_seed=i)
-        completion = lm.batch_complete_text(["<s>"], do_sample=True)[0]
+        completion = lm.complete_text(["<s>"], do_sample=True)[0]
         completions.add(completion.text)
     assert len(completions) > 1
 
@@ -175,7 +175,7 @@ def test_if_random_seed_fixes_the_lm_outputs(lm_init_func: Callable[..., Hugging
     completions = set()
     for _ in range(3):
         lm = lm_init_func(random_seed=42)
-        completion = lm.batch_complete_text(["<s>"], do_sample=True)[0]
+        completion = lm.complete_text(["<s>"], do_sample=True)[0]
         completions.add(completion.text)
     assert len(completions) == 1
 
@@ -184,7 +184,7 @@ def test_if_random_seed_fixes_the_lm_outputs(lm_init_func: Callable[..., Hugging
     lm = lm_init_func(random_seed=42)
     completions = set()
     for _ in range(3):
-        completion = lm.batch_complete_text(["<s>"], do_sample=True)[0]
+        completion = lm.complete_text(["<s>"], do_sample=True)[0]
         completions.add(completion.text)
     assert len(completions) > 1
 
@@ -197,7 +197,7 @@ def test_if_custom_chat_template_is_given(lm_init_func: Callable[..., HuggingFac
         random_seed=42,
         custom_chat_template=custom_chat_template,
     )
-    responses = lm.batch_generate_chat_response([[{"role": "user", "content": "こんにちは。"}]], max_length=40)
+    responses = lm.generate_chat_response([[{"role": "user", "content": "こんにちは。"}]], max_length=40)
     assert len(responses) == 1
     assert responses[0].text.strip().startswith("0 0")
 
@@ -206,12 +206,12 @@ def test_if_stop_sequences_work_as_expected(chat_lm: HuggingFaceLM) -> None:
     test_inputs = [[{"role": "user", "content": "こんにちは"}]]
 
     # check if the response does not have eos_token by default
-    response = chat_lm.batch_generate_chat_response(test_inputs, max_new_tokens=50)[0]
+    response = chat_lm.generate_chat_response(test_inputs, max_new_tokens=50)[0]
     assert response.text
     assert response.finish_reason == "stop"
 
     # check if ignore_eos=True works
-    response = chat_lm.batch_generate_chat_response(test_inputs, max_new_tokens=50, ignore_eos=True)[0]
+    response = chat_lm.generate_chat_response(test_inputs, max_new_tokens=50, ignore_eos=True)[0]
     assert response.text
     assert response.finish_reason == "length"
 

--- a/tests/core/language_model/test_litellm_api.py
+++ b/tests/core/language_model/test_litellm_api.py
@@ -41,4 +41,4 @@ def test_compute_chat_log_probs_for_multi_tokens(chat_lm: LiteLLMChatAPI) -> Non
     prompt_list = [[{"role": "user", "content": "Output a number from 1 to 3."}] for _ in range(2)]
     response_list = [{"role": "assistant", "content": "1"}, {"role": "assistant", "content": "4"}]
     with pytest.raises(NotImplementedError):
-        chat_lm.batch_compute_chat_log_probs(prompt_list, response_list)
+        chat_lm.compute_chat_log_probs(prompt_list, response_list)

--- a/tests/core/language_model/test_openai_api.py
+++ b/tests/core/language_model/test_openai_api.py
@@ -48,9 +48,7 @@ def test_warning_if_conflict_max_new_tokens(caplog: pytest.LogCaptureFixture) ->
     chat_lm_with_max_new_tokens = OpenAIChatAPI(
         "gpt-4o-mini-2024-07-18", default_gen_kwargs={"max_completion_tokens": 10}
     )
-    chat_lm_with_max_new_tokens.batch_generate_chat_response(
-        [[{"role": "user", "content": "テスト"}]], max_new_tokens=20
-    )
+    chat_lm_with_max_new_tokens.generate_chat_response([[{"role": "user", "content": "テスト"}]], max_new_tokens=20)
     assert len(caplog.records) >= 1
     assert any(record.msg.startswith("You specified both `max_new_tokens`") for record in caplog.records)
 
@@ -60,7 +58,7 @@ def test_compute_chat_log_probs_for_multi_tokens(chat_lm: OpenAIChatAPI) -> None
     prompt = [{"role": "user", "content": "Hello."}]
     response = {"role": "assistant", "content": "Hello~~~"}
     with pytest.raises(NotImplementedError):
-        chat_lm.batch_compute_chat_log_probs([prompt], [response])
+        chat_lm.compute_chat_log_probs([prompt], [response])
 
 
 def test_message_list_and_prompt() -> None:

--- a/tests/core/language_model/test_openai_batch_api.py
+++ b/tests/core/language_model/test_openai_batch_api.py
@@ -60,9 +60,7 @@ def test_warning_if_conflict_max_new_tokens(caplog: pytest.LogCaptureFixture) ->
         default_gen_kwargs={"max_completion_tokens": 10},
     )
     with pytest.raises(ValueError):
-        chat_lm_with_max_new_tokens.batch_generate_chat_response(
-            [[{"role": "user", "content": "テスト"}]], max_new_tokens=20
-        )
+        chat_lm_with_max_new_tokens.generate_chat_response([[{"role": "user", "content": "テスト"}]], max_new_tokens=20)
     assert len(caplog.records) >= 1
     assert any(record.msg.startswith("You specified both `max_new_tokens`") for record in caplog.records)
 
@@ -73,7 +71,7 @@ def test_compute_chat_log_probs_for_multi_tokens(lm: OpenAIChatBatchAPI) -> None
     prompt = [{"role": "user", "content": "Hello."}]
     response = {"role": "assistant", "content": "Hello~~~"}
     with pytest.raises(NotImplementedError):
-        lm.batch_compute_chat_log_probs([prompt], [response])
+        lm.compute_chat_log_probs([prompt], [response])
 
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")

--- a/tests/core/language_model/vllm/test_vllm_custom_template.py
+++ b/tests/core/language_model/vllm/test_vllm_custom_template.py
@@ -37,7 +37,7 @@ def chat_lm_with_custom_chat_template() -> VLLM:
 
 @pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
 def test_if_custom_chat_template_is_given(chat_lm_with_custom_chat_template: VLLM) -> None:
-    responses = chat_lm_with_custom_chat_template.batch_generate_chat_response(
+    responses = chat_lm_with_custom_chat_template.generate_chat_response(
         [[{"role": "user", "content": "こんにちは。"}]],
         max_new_tokens=10,
     )

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -34,10 +34,10 @@ def test_batch_compute_log_probs_approximates_hf_lm(chat_lm: LanguageModel, hf_l
     prefix_list = ["それは正しい日本語ですか？"]
     text_list = ["これは正しい日本語です。"]
 
-    vllm_log_probs = chat_lm.batch_compute_log_probs(text_list)
-    hf_log_probs = hf_lm.batch_compute_log_probs(text_list)
+    vllm_log_probs = chat_lm.compute_log_probs(text_list)
+    hf_log_probs = hf_lm.compute_log_probs(text_list)
     assert vllm_log_probs == pytest.approx(hf_log_probs, abs=1e-2)
 
-    vllm_log_probs = chat_lm.batch_compute_log_probs(text_list, prefix_list=prefix_list)
-    hf_log_probs = hf_lm.batch_compute_log_probs(text_list, prefix_list=prefix_list)
+    vllm_log_probs = chat_lm.compute_log_probs(text_list, prefix_list=prefix_list)
+    hf_log_probs = hf_lm.compute_log_probs(text_list, prefix_list=prefix_list)
     assert vllm_log_probs == pytest.approx(hf_log_probs, abs=1e-2)

--- a/tests/core/metric/test_llm_geval_score.py
+++ b/tests/core/metric/test_llm_geval_score.py
@@ -7,7 +7,7 @@ from flexeval.core.metric.llm_geval_score import ChatLLMGEvalScore, LLMGEvalScor
 
 
 class EchoBackLanguageModel(LanguageModel):
-    def batch_compute_log_probs(
+    def compute_log_probs(
         self,
         text_list: list[str],
         prefix_list: list[str] | None = None,
@@ -24,11 +24,11 @@ class EchoBackLanguageModel(LanguageModel):
         # This simulates all of the valid scores are not obtained from logprob results.
         return [None, None, None, None, None]
 
-    def batch_compute_chat_log_probs(
+    def compute_chat_log_probs(
         self, prompt_list: list[list[dict[str, str]]], response_list: list[dict[str, str]]
     ) -> list[float]:
         text = prompt_list[0][-1]["content"]
-        return self.batch_compute_log_probs([], [text])
+        return self.compute_log_probs([], [text])
 
 
 @pytest.mark.parametrize(

--- a/tests/core/metric/test_llm_label.py
+++ b/tests/core/metric/test_llm_label.py
@@ -8,7 +8,7 @@ from flexeval.core.metric.llm_label import ChatLLMLabel, LLMLabel, parse_label_f
 
 
 class EchoBackLanguageModel(LanguageModel):
-    def batch_complete_text(
+    def complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -17,7 +17,7 @@ class EchoBackLanguageModel(LanguageModel):
     ) -> list[LMOutput]:
         return [LMOutput(text=text, finish_reason="length") for text in text_list]
 
-    def batch_generate_chat_response(
+    def generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -13,7 +13,7 @@ from flexeval.core.metric.llm_score import (
 
 
 class EchoBackLanguageModel(LanguageModel):
-    def batch_complete_text(
+    def complete_text(
         self,
         text_list: list[str],
         stop_sequences: str | list[str] | None = None,
@@ -22,7 +22,7 @@ class EchoBackLanguageModel(LanguageModel):
     ) -> list[LMOutput]:
         return [LMOutput(text=text, finish_reason="length") for text in text_list]
 
-    def batch_generate_chat_response(
+    def generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,

--- a/tests/dummy_modules/lm.py
+++ b/tests/dummy_modules/lm.py
@@ -9,11 +9,11 @@ from flexeval.core.language_model.base import LMOutput
 class DummyLanguageModel(LanguageModel):
     """入力をそのまま出力するダミーの言語モデルです。 テスト用に用意しています。"""
 
-    def batch_complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
+    def complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
         kwargs_as_text = json.dumps(kwargs)
         return [LMOutput(text=text + kwargs_as_text, finish_reason="length") for text in text_list]
 
-    def batch_compute_log_probs(
+    def compute_log_probs(
         self,
         text_list: list[str],
         prefix_list: list[str] | None = None,
@@ -21,7 +21,7 @@ class DummyLanguageModel(LanguageModel):
     ) -> list[float]:
         return [-1.0] * len(text_list)
 
-    def batch_generate_chat_response(
+    def generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,

--- a/tests/dummy_modules/lm.py
+++ b/tests/dummy_modules/lm.py
@@ -9,11 +9,11 @@ from flexeval.core.language_model.base import LMOutput
 class DummyLanguageModel(LanguageModel):
     """入力をそのまま出力するダミーの言語モデルです。 テスト用に用意しています。"""
 
-    def complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
+    def _batch_complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
         kwargs_as_text = json.dumps(kwargs)
         return [LMOutput(text=text + kwargs_as_text, finish_reason="length") for text in text_list]
 
-    def compute_log_probs(
+    def _batch_compute_log_probs(
         self,
         text_list: list[str],
         prefix_list: list[str] | None = None,
@@ -21,7 +21,7 @@ class DummyLanguageModel(LanguageModel):
     ) -> list[float]:
         return [-1.0] * len(text_list)
 
-    def generate_chat_response(
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,

--- a/tests/dummy_modules/reward_lm.py
+++ b/tests/dummy_modules/reward_lm.py
@@ -11,10 +11,10 @@ class DummyRewardLanguageModel(LanguageModel):
         super().__init__()
         self.response = response
 
-    def batch_complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
+    def complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
         return [LMOutput(text=self.response, finish_reason="length") for _ in text_list]
 
-    def batch_compute_log_probs(
+    def compute_log_probs(
         self,
         text_list: list[str],
         prefix_list: list[str] | None = None,
@@ -22,7 +22,7 @@ class DummyRewardLanguageModel(LanguageModel):
     ) -> list[float]:
         return [-1.0] * len(text_list)
 
-    def batch_generate_chat_response(
+    def generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,

--- a/tests/dummy_modules/reward_lm.py
+++ b/tests/dummy_modules/reward_lm.py
@@ -11,10 +11,10 @@ class DummyRewardLanguageModel(LanguageModel):
         super().__init__()
         self.response = response
 
-    def complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
+    def _batch_complete_text(self, text_list: list[str], **kwargs) -> list[LMOutput]:
         return [LMOutput(text=self.response, finish_reason="length") for _ in text_list]
 
-    def compute_log_probs(
+    def _batch_compute_log_probs(
         self,
         text_list: list[str],
         prefix_list: list[str] | None = None,
@@ -22,7 +22,7 @@ class DummyRewardLanguageModel(LanguageModel):
     ) -> list[float]:
         return [-1.0] * len(text_list)
 
-    def generate_chat_response(
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,


### PR DESCRIPTION
Changes `LanguageModel`'s `batch_*` methods to private methods `_batch_*`.  
Users should now use only public APIs, such as `complete_text` and `generate_chat_response`, which accept both single and batch inputs.

The purpose of this change is to improve code maintainability by unifying the APIs and minimizing the impact of future changes.





