### PR TITLE
Add `StringProcessor` to `LanguageModel`

### DIFF
--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -35,7 +35,7 @@ class LanguageModel:
 
     """
 
-    def __init__(self, string_processors: StringProcessor | list[StringProcessor] | None = None):
+    def __init__(self, string_processors: StringProcessor | list[StringProcessor] | None = None) -> None:
         if string_processors is None:
             string_processors = []
         elif isinstance(string_processors, StringProcessor):

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -142,7 +142,7 @@ class LanguageModel:
             for lm_output in lm_outputs:
                 lm_output.raw_text = lm_output.text
                 for string_processor in self.string_processors:
-                    lm_output.text = string_processor.post_process(lm_output.text)
+                    lm_output.text = string_processor(lm_output.text)
 
         # Return the result
         if isinstance(text, str):
@@ -172,7 +172,7 @@ class LanguageModel:
             for lm_output in lm_outputs:
                 lm_output.raw_text = lm_output.text
                 for string_processor in self.string_processors:
-                    lm_output.text = string_processor.post_process(lm_output.text)
+                    lm_output.text = string_processor(lm_output.text)
 
         # Return the result
         if isinstance(chat_messages[0], dict):

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -322,7 +322,7 @@ class HuggingFaceLM(LanguageModel):
             )
             for chat_messages in chat_messages_list
         ]
-        return self.complete_text(chat_messages_as_string, **kwargs)
+        return self._batch_complete_text(chat_messages_as_string, **kwargs)
 
     @torch.inference_mode()
     def _batch_compute_log_probs(
@@ -445,7 +445,7 @@ class HuggingFaceLM(LanguageModel):
             )
             prompt_as_string.append(prompt_as_string_i)
             response_as_string.append(response_as_string_i)
-        return self.compute_log_probs(response_as_string, prefix_list=prompt_as_string)
+        return self._batch_compute_log_probs(response_as_string, prefix_list=prompt_as_string)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self._model_name_or_path!r})"

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -9,6 +9,7 @@ import transformers
 from loguru import logger
 from transformers import AutoModelForCausalLM, AutoTokenizer, BatchEncoding, PreTrainedModel, PreTrainedTokenizer
 
+from flexeval.core.string_processor import StringProcessor
 from flexeval.utils.hf_utils import get_default_model_kwargs
 
 from .base import LanguageModel, LMOutput, normalize_stop_sequences
@@ -152,6 +153,8 @@ class HuggingFaceLM(LanguageModel):
         load_peft: Should be set to True when loading the model from PEFT weights.
         custom_chat_template: A custom chat template for chatbot models.
             If specified, this overrides the default chat template of the tokenizer.
+        default_gen_kwargs: Default generation kwargs to use when calling the API.
+        string_processors: A single or a list of StringProcessor objects to process the model's output.
     """
 
     def __init__(
@@ -166,7 +169,9 @@ class HuggingFaceLM(LanguageModel):
         load_peft: bool = False,
         custom_chat_template: str | None = None,
         default_gen_kwargs: dict[str, Any] | None = None,
+        string_processors: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
+        super().__init__(string_processors=string_processors)
         self._model_name_or_path = model
         tokenizer = tokenizer if tokenizer else model
         tokenizer_kwargs = tokenizer_kwargs or {}

--- a/flexeval/core/language_model/litellm_api.py
+++ b/flexeval/core/language_model/litellm_api.py
@@ -5,6 +5,8 @@ from typing import Any, TypeVar
 from litellm import ModelResponse, acompletion
 from litellm.utils import convert_to_model_response_object
 
+from flexeval.core.string_processor import StringProcessor
+
 from .openai_api import EMPTY_RESPONSE as EMPTY_RESPONSE_OPENAI
 from .openai_api import OpenAIChatAPI
 
@@ -20,6 +22,9 @@ class LiteLLMChatAPI(OpenAIChatAPI):
     Args:
         model: The name of the model to use. e.g. 'openai/gpt-3.5-turbo',
         default_gen_kwargs: Default generation kwargs to use when calling the API.
+        developer_message: Instructions to the model that are prioritized ahead of user messages.
+            Previously called the system prompt.
+        string_processors: A single or a list of StringProcessor objects to process the model's output.
     """
 
     def __init__(
@@ -27,9 +32,14 @@ class LiteLLMChatAPI(OpenAIChatAPI):
         model: str = "openai/gpt-3.5-turbo",
         default_gen_kwargs: dict[str, Any] | None = None,
         developer_message: str | None = None,
+        string_processors: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
         super().__init__(
-            model=model, api_headers=None, default_gen_kwargs=default_gen_kwargs, developer_message=developer_message
+            model=model,
+            api_headers=None,
+            default_gen_kwargs=default_gen_kwargs,
+            developer_message=developer_message,
+            string_processors=string_processors,
         )
         self.model = model
         self.default_gen_kwargs = default_gen_kwargs or {}

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -11,6 +11,8 @@ from openai import AsyncOpenAI, BaseModel
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 
+from flexeval.core.string_processor import StringProcessor
+
 from .base import LanguageModel, LMOutput, normalize_stop_sequences
 
 T = TypeVar("T")
@@ -72,6 +74,7 @@ class OpenAIChatAPI(LanguageModel):
         default_gen_kwargs: Default generation kwargs to use when calling the API.
         developer_message: Instructions to the model that are prioritized ahead of user messages.
             Previously called the system prompt.
+        string_processors: A single or a list of StringProcessor objects to process the model's output.
     """
 
     def __init__(
@@ -80,7 +83,9 @@ class OpenAIChatAPI(LanguageModel):
         api_headers: dict[str, str] | None = None,
         default_gen_kwargs: dict[str, Any] | None = None,
         developer_message: str | None = None,
+        string_processors: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
+        super().__init__(string_processors=string_processors)
         self.model = model
         if api_headers is None:
             api_headers = {}

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -298,6 +298,7 @@ class OpenAICompletionAPI(LanguageModel):
         model: The name of the model to use.
         api_headers: A dictionary of headers to use when making requests to the OpenAI API.
         default_gen_kwargs: Default generation kwargs to use when calling the API.
+        string_processors: A single or a list of StringProcessor objects to process the model's output.
     """
 
     def __init__(
@@ -305,7 +306,9 @@ class OpenAICompletionAPI(LanguageModel):
         model: str = "gpt-3.5-turbo-instruct",
         api_headers: dict[str, str] | None = None,
         default_gen_kwargs: dict[str, Any] | None = None,
+        string_processors: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
+        super().__init__(string_processors=string_processors)
         self.model = model
         if api_headers is None:
             api_headers = {}

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -13,6 +13,8 @@ from loguru import logger
 from openai import AsyncOpenAI
 from openai.types import Batch
 
+from flexeval.core.string_processor import StringProcessor
+
 from .base import LanguageModel, LMOutput, normalize_stop_sequences
 from .openai_api import number_of_tokens_in_openai_model, remove_duplicates_from_prompt_list
 
@@ -49,6 +51,9 @@ class OpenAIChatBatchAPI(LanguageModel):
         api_headers: A dictionary of headers to use when making requests to the OpenAI API.
         polling_interval_seconds: The interval in seconds to poll the batch status.
         default_gen_kwargs: Default generation kwargs to use when calling the API.
+        developer_message: Instructions to the model that are prioritized ahead of user messages.
+            Previously called the system prompt.
+        string_processors: A single or a list of StringProcessor objects to process the model's output.
     """
 
     def __init__(
@@ -58,7 +63,9 @@ class OpenAIChatBatchAPI(LanguageModel):
         polling_interval_seconds: int = 60,
         default_gen_kwargs: dict[str, Any] | None = None,
         developer_message: str | None = None,
+        string_processors: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
+        super().__init__(string_processors=string_processors)
         self.model = model
         if api_headers is None:
             api_headers = {}

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -5,6 +5,8 @@ from typing import Any
 import torch
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
+from flexeval.core.string_processor import StringProcessor
+
 from .base import LanguageModel, LMOutput, normalize_stop_sequences
 from .hf_lm import decode_for_lm_continuation, get_prefix_and_completion_from_chat
 
@@ -77,6 +79,7 @@ class VLLM(LanguageModel):
         custom_chat_template: A custom chat template for chatbot models.
             If specified, this overrides the default chat template of the tokenizer.
         default_gen_kwargs: Default generation kwargs to use when calling the model.
+        string_processors: A single or a list of StringProcessor objects to process the model's output.
     """
 
     def __init__(
@@ -88,7 +91,9 @@ class VLLM(LanguageModel):
         add_special_tokens: bool = False,
         custom_chat_template: str | None = None,
         default_gen_kwargs: dict[str, Any] | None = None,
+        string_processors: StringProcessor | list[StringProcessor] | None = None,
     ) -> None:
+        super().__init__(string_processors=string_processors)
         self.model_name = model
         tokenizer = tokenizer if tokenizer else model
         tokenizer_kwargs = tokenizer_kwargs or {}

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -278,7 +278,7 @@ class VLLM(LanguageModel):
             )
             prompt_as_string.append(prompt_as_string_i)
             response_as_string.append(response_as_string_i)
-        return self.compute_log_probs(response_as_string, prefix_list=prompt_as_string)
+        return self._batch_compute_log_probs(response_as_string, prefix_list=prompt_as_string)
 
     def __repr__(self) -> str:
         return f"VLLM(model_name={self.model_name})"

--- a/tests/core/language_model/base.py
+++ b/tests/core/language_model/base.py
@@ -255,3 +255,43 @@ class BaseLanguageModelTest:
         # The completion should be very short and finish_reason should be "length"
         assert len(completion.text.strip()) <= 5  # Allow for some tokenization differences
         assert completion.finish_reason == "length"
+
+    def test_string_processors_with_complete_text(self, lm: LanguageModel) -> None:
+        """Test that string processors work as expected."""
+        try:
+            assert hasattr(lm, "string_processors")
+            original_string_processors = lm.string_processors
+
+            from flexeval import TemplateRenderer
+
+            test_text = "This text is processed by StringProcessor."
+            lm.string_processors = [TemplateRenderer(template=test_text)]
+
+            lm_output = lm.complete_text("Test input: ")
+            assert lm_output.text == test_text
+            assert lm_output.raw_text is not None
+            assert lm_output.raw_text != test_text
+
+            lm.string_processors = original_string_processors
+        except NotImplementedError:
+            pytest.skip("This model does not support complete_text")
+
+    def test_string_processors_with_generate_chat_response(self, chat_lm: LanguageModel) -> None:
+        """Test that string processors work as expected."""
+        try:
+            assert hasattr(chat_lm, "string_processors")
+            original_string_processors = chat_lm.string_processors
+
+            from flexeval import TemplateRenderer
+
+            test_text = "This text is processed by StringProcessor."
+            chat_lm.string_processors = [TemplateRenderer(template=test_text)]
+
+            lm_output = chat_lm.generate_chat_response([{"role": "user", "content": "Test input"}])
+            assert lm_output.text == test_text
+            assert lm_output.raw_text is not None
+            assert lm_output.raw_text != test_text
+
+            chat_lm.string_processors = original_string_processors
+        except NotImplementedError:
+            pytest.skip("This model does not support generate_chat_response")


### PR DESCRIPTION
Now we can specify `StringProcessor` in `LanguageModel`.
The processing is implemented in the interface method `complete_text` and `generate_chat_response`, applied to all `LanguageModel` classes.

`LMOutput` has the additional field `raw_text` which is convenient to check the output before processing.