### PR TITLE
Add a parameter to `LanguageModel` to determine the upper limit of `max_new_tokens`

### DIFF
--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -264,7 +264,7 @@ class HuggingFaceLM(LanguageModel):
         if max_new_tokens is not None:
             gen_kwargs["max_new_tokens"] = max_new_tokens
 
-        if self.model_limit_new_tokens and (gen_kwargs["max_new_tokens"] > self.model_limit_new_tokens):
+        if self.model_limit_new_tokens and (gen_kwargs.get("max_new_tokens", 0) > self.model_limit_new_tokens):
             msg = (
                 f"The specified `max_new_tokens` ({gen_kwargs['max_new_tokens']}) exceeds"
                 f"the model’s capability ({self.model_limit_new_tokens} tokens). It will be reduced."

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -155,8 +155,11 @@ class HuggingFaceLM(LanguageModel):
             If specified, this overrides the default chat template of the tokenizer.
         default_gen_kwargs: Default generation kwargs to use when calling the API.
         string_processors: A single or a list of StringProcessor objects to process the model's output.
-        model_limit_tokens: An upper limit on the number of tokens the model can receive.
-            For example, if a too-large `max_new_tokens` is given to generate_chat_response(), this value will cap it.
+        model_limit_tokens: An upper limit on the number of tokens (input + output) the model can handle.
+            If `max_new_tokens` exceeds this limit in `generate_chat_response()`, it will be capped to this value.
+            If this value is set to less than or equal to the model's capacity and the input exceeds it,
+            an empty string is returned instead of raising an error.
+            If set to “default”, the value will be automatically determined when possible.
     """
 
     def __init__(
@@ -172,7 +175,7 @@ class HuggingFaceLM(LanguageModel):
         custom_chat_template: str | None = None,
         default_gen_kwargs: dict[str, Any] | None = None,
         string_processors: StringProcessor | list[StringProcessor] | None = None,
-        model_limit_tokens: int | None = None,
+        model_limit_tokens: int | None | Literal["default"] = "default",
     ) -> None:
         super().__init__(string_processors=string_processors)
         self._model_name_or_path = model
@@ -200,13 +203,19 @@ class HuggingFaceLM(LanguageModel):
         self.model.eval()
 
         self.amp_dtype = amp_dtype
-        hf_config = self.model.config.to_dict()
-        max_position_embeddings: int | None = None
-        if "n_positions" in hf_config:
-            max_position_embeddings = hf_config["n_positions"]
-        elif "max_position_embeddings" in hf_config:
-            max_position_embeddings = hf_config["max_position_embeddings"]
-        self.model_limit_tokens = model_limit_tokens if model_limit_tokens else max_position_embeddings
+        if model_limit_tokens == "default":
+            hf_config = self.model.config.to_dict()
+            if "n_positions" in hf_config:
+                model_limit_tokens = hf_config["n_positions"]
+            elif "max_position_embeddings" in hf_config:
+                model_limit_tokens = hf_config["max_position_embeddings"]
+            else:
+                msg = (
+                    "`model_limit_tokens` was set to “default”, but the default max_position_embedeings "
+                    "could not be found in the config. Set it to `None`."
+                )
+                logger.warn(msg)
+        self.model_limit_tokens = model_limit_tokens
 
         transformers.set_seed(random_seed)
 
@@ -287,12 +296,7 @@ class HuggingFaceLM(LanguageModel):
                 logger.warning(msg)
                 return [LMOutput(text="", finish_reason="input_length_limit") for _ in text_list]
 
-            if model_limit_new_tokens < gen_kwargs["max_new_tokens"]:
-                msg = (
-                    f"The specified `max_new_tokens` ({gen_kwargs['max_new_tokens']}) exceeds "
-                    f"the model’s capability (remaining {model_limit_new_tokens} tokens). It will be capped."
-                )
-                logger.warning(msg)
+            if "max_new_tokens" not in gen_kwargs or model_limit_new_tokens < gen_kwargs["max_new_tokens"]:
                 gen_kwargs["max_new_tokens"] = model_limit_new_tokens
 
         # set the stop sequences

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -130,7 +130,6 @@ class OpenAIChatAPI(LanguageModel):
                 logger.warning(msg)
             gen_kwargs["max_completion_tokens"] = max_new_tokens
 
-
         if self.model_limit_new_tokens and (gen_kwargs["max_completion_tokens"] > self.model_limit_new_tokens):
             msg = (
                 f"The specified `max_new_tokens` ({gen_kwargs['max_completion_tokens']}) exceeds"
@@ -138,7 +137,6 @@ class OpenAIChatAPI(LanguageModel):
             )
             logger.warning(msg)
             gen_kwargs["max_completion_tokens"] = self.model_limit_new_tokens
-
 
         stop_sequences = normalize_stop_sequences(
             stop_sequences_list=[

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -130,7 +130,7 @@ class OpenAIChatAPI(LanguageModel):
                 logger.warning(msg)
             gen_kwargs["max_completion_tokens"] = max_new_tokens
 
-        if self.model_limit_new_tokens and (gen_kwargs["max_completion_tokens"] > self.model_limit_new_tokens):
+        if self.model_limit_new_tokens and (gen_kwargs.get("max_completion_tokens", 0) > self.model_limit_new_tokens):
             msg = (
                 f"The specified `max_new_tokens` ({gen_kwargs['max_completion_tokens']}) exceeds"
                 f"the model’s capability ({self.model_limit_new_tokens} tokens). It will be reduced."

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -116,7 +116,7 @@ class OpenAIChatBatchAPI(LanguageModel):
             gen_kwargs["max_completion_tokens"] = max_new_tokens
 
         if self.model_limit_completion_tokens and (
-            gen_kwargs["max_completion_tokens"] > self.model_limit_completion_tokens
+            gen_kwargs.get("max_completion_tokens", 0) > self.model_limit_completion_tokens
         ):
             msg = (
                 f"The specified `max_new_tokens` ({gen_kwargs['max_completion_tokens']}) exceeds"

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -66,7 +66,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         default_gen_kwargs: dict[str, Any] | None = None,
         developer_message: str | None = None,
         string_processors: StringProcessor | list[StringProcessor] | None = None,
-        model_limit_completion_tokens: int | None = None
+        model_limit_completion_tokens: int | None = None,
     ) -> None:
         super().__init__(string_processors=string_processors)
         self.model = model
@@ -115,7 +115,9 @@ class OpenAIChatBatchAPI(LanguageModel):
                 logger.warning(msg)
             gen_kwargs["max_completion_tokens"] = max_new_tokens
 
-        if self.model_limit_completion_tokens and (gen_kwargs["max_completion_tokens"] > self.model_limit_completion_tokens):  # noqa: E501
+        if self.model_limit_completion_tokens and (
+            gen_kwargs["max_completion_tokens"] > self.model_limit_completion_tokens
+        ):
             msg = (
                 f"The specified `max_new_tokens` ({gen_kwargs['max_completion_tokens']}) exceeds"
                 f"the model’s capability ({self.model_limit_completion_tokens} tokens). It will be reduced."

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from loguru import logger
 import torch
+from loguru import logger
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from flexeval.core.string_processor import StringProcessor

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -135,9 +135,9 @@ class VLLM(LanguageModel):
         if max_new_tokens is not None:
             gen_kwargs["max_tokens"] = max_new_tokens
 
-        if self.model_limit_new_tokens and (gen_kwargs["max_tokens"] > self.model_limit_new_tokens):
+        if self.model_limit_new_tokens and (gen_kwargs.get("max_tokens", 0) > self.model_limit_new_tokens):
             msg = (
-                f"The specified `max_new_tokens` ({gen_kwargs['max_new_tokens']}) exceeds"
+                f"The specified `max_new_tokens` ({gen_kwargs['max_tokens']}) exceeds"
                 f"the model’s capability ({self.model_limit_new_tokens} tokens). It will be reduced."
             )
             logger.warning(msg)

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -246,7 +246,9 @@ def test_get_prefix_and_completion_from_chat() -> None:
     assert completion == ""
 
 
-def test_model_limit_max_tokens_generate_chat_response(chat_lm: HuggingFaceLM, caplog: pytest.LogCaptureFixture) -> None:  # noqa: E501
+def test_model_limit_max_tokens_generate_chat_response(
+    chat_lm: HuggingFaceLM, caplog: pytest.LogCaptureFixture
+) -> None:
     caplog.set_level(logging.WARNING)
     messages = [{"role": "user", "content": "Hello."}]
 
@@ -264,9 +266,7 @@ def test_model_limit_max_tokens_generate_chat_response(chat_lm: HuggingFaceLM, c
     )
     chat_lm_with_limit_tokens.generate_chat_response(messages, max_new_tokens=128)
     assert len(caplog.records) >= 1
-    assert any(
-        record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records
-    )
+    assert any(record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records)
     caplog.clear()
 
 
@@ -285,11 +285,9 @@ def test_model_limit_max_tokens_complete_text(lm: HuggingFaceLM, caplog: pytest.
         model_kwargs={"torch_dtype": "float32"},
         tokenizer_kwargs={"use_fast": False},
         default_gen_kwargs={"do_sample": False},
-        model_limit_new_tokens=1
+        model_limit_new_tokens=1,
     )
     lm_with_limit_tokens.complete_text(text, max_new_tokens=128)
     assert len(caplog.records) >= 1
-    assert any(
-        record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records
-    )
+    assert any(record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records)
     caplog.clear()

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -247,8 +247,7 @@ def test_get_prefix_and_completion_from_chat() -> None:
     assert completion == ""
 
 
-def test_model_limit_new_tokens_complete_text(lm: HuggingFaceLM, caplog: pytest.LogCaptureFixture) -> None:
-    caplog.set_level(logging.WARNING)
+def test_model_limit_new_tokens_complete_text(lm: HuggingFaceLM) -> None:
     text = "Outputs numbers 0~10: 1 2 3 "
     tokenizer = AutoTokenizer.from_pretrained("sbintuitions/tiny-lm")
     input_length = len(
@@ -261,8 +260,6 @@ def test_model_limit_new_tokens_complete_text(lm: HuggingFaceLM, caplog: pytest.
 
     # if max_new_tokens only, no warnings will be sent.
     lm_output = lm.complete_text(text, max_new_tokens=128)
-    assert len(caplog.records) == 0
-    caplog.clear()
 
     # if max_new_tokens > (model_limit_new_tokens = model_new_tokens - len(input_tokens)), a warning about overwriting is sent.  # noqa: E501
     lm_with_limit_tokens = HuggingFaceLM(
@@ -276,9 +273,6 @@ def test_model_limit_new_tokens_complete_text(lm: HuggingFaceLM, caplog: pytest.
     lm_output_limit_tokens: LMOutput = lm_with_limit_tokens.complete_text(text, max_new_tokens=128)
     assert lm_output_limit_tokens.finish_reason == "length"
     assert len(lm_output.text) > len(lm_output_limit_tokens.text)
-    assert len(caplog.records) >= 1
-    assert any(record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records)
-    caplog.clear()
 
 
 def test_if_input_length_exceeds_model_limit_new_tokens(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -246,7 +246,7 @@ def test_get_prefix_and_completion_from_chat() -> None:
     assert completion == ""
 
 
-def test_model_limit_max_tokens_generate_chat_response(
+def test_model_limit_new_tokens_generate_chat_response(
     chat_lm: HuggingFaceLM, caplog: pytest.LogCaptureFixture
 ) -> None:
     caplog.set_level(logging.WARNING)
@@ -270,7 +270,7 @@ def test_model_limit_max_tokens_generate_chat_response(
     caplog.clear()
 
 
-def test_model_limit_max_tokens_complete_text(lm: HuggingFaceLM, caplog: pytest.LogCaptureFixture) -> None:
+def test_model_limit_new_tokens_complete_text(lm: HuggingFaceLM, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING)
     text = "Hello. I am a "
 

--- a/tests/core/language_model/test_openai_api.py
+++ b/tests/core/language_model/test_openai_api.py
@@ -117,7 +117,7 @@ def test_developer_message() -> None:
 
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
-def test_model_limit_max_tokens_generate_chat_response(
+def test_model_limit_new_tokens_generate_chat_response(
     chat_lm: OpenAIChatAPI, caplog: pytest.LogCaptureFixture
 ) -> None:
     caplog.set_level(logging.WARNING)
@@ -135,7 +135,7 @@ def test_model_limit_max_tokens_generate_chat_response(
 
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
-def test_model_limit_max_tokens_complete_text(chat_lm: OpenAIChatAPI, caplog: pytest.LogCaptureFixture) -> None:
+def test_model_limit_new_tokens_complete_text(chat_lm: OpenAIChatAPI, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING)
     text = "Hello."
 

--- a/tests/core/language_model/test_openai_api.py
+++ b/tests/core/language_model/test_openai_api.py
@@ -115,8 +115,11 @@ def test_developer_message() -> None:
     )
     assert lm_output.text == "OK, I will answer later."
 
+
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
-def test_model_limit_max_tokens_generate_chat_response(chat_lm: OpenAIChatAPI, caplog: pytest.LogCaptureFixture) -> None:  # noqa: E501
+def test_model_limit_max_tokens_generate_chat_response(
+    chat_lm: OpenAIChatAPI, caplog: pytest.LogCaptureFixture
+) -> None:
     caplog.set_level(logging.WARNING)
     messages = [{"role": "user", "content": "Hello."}]
 
@@ -125,14 +128,11 @@ def test_model_limit_max_tokens_generate_chat_response(chat_lm: OpenAIChatAPI, c
     assert len(caplog.records) == 0
 
     # if max_new_tokens > model_limit_completion_tokens, a warning about overwriting is sent.
-    chat_lm_with_limit_tokens = OpenAIChatAPI(
-        "gpt-4o-mini-2024-07-18", model_limit_new_tokens=1
-    )
+    chat_lm_with_limit_tokens = OpenAIChatAPI("gpt-4o-mini-2024-07-18", model_limit_new_tokens=1)
     chat_lm_with_limit_tokens.generate_chat_response(messages, max_new_tokens=128)
     assert len(caplog.records) >= 1
-    assert any(
-        record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records
-    )
+    assert any(record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records)
+
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
 def test_model_limit_max_tokens_complete_text(chat_lm: OpenAIChatAPI, caplog: pytest.LogCaptureFixture) -> None:
@@ -145,13 +145,8 @@ def test_model_limit_max_tokens_complete_text(chat_lm: OpenAIChatAPI, caplog: py
     caplog.clear()
 
     # if max_new_tokens > model_limit_new_tokens, a warning about overwriting is sent.
-    chat_lm_with_limit_tokens = OpenAIChatAPI(
-        "gpt-4o-mini-2024-07-18", model_limit_new_tokens=1
-    )
+    chat_lm_with_limit_tokens = OpenAIChatAPI("gpt-4o-mini-2024-07-18", model_limit_new_tokens=1)
     chat_lm_with_limit_tokens.complete_text(text, max_new_tokens=128)
     assert len(caplog.records) >= 1
-    assert any(
-        record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records
-    )
+    assert any(record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records)
     caplog.clear()
-

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -45,7 +45,8 @@ def test_batch_compute_log_probs_approximates_hf_lm(chat_lm: LanguageModel, hf_l
     assert vllm_log_probs == pytest.approx(hf_log_probs, abs=1e-2)
 
 
-def test_model_limit_max_tokens_generate_chat_response(chat_lm: VLLM, caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
+def test_model_limit_new_tokens_generate_chat_response(chat_lm: VLLM, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING)
     messages = [{"role": "user", "content": "Hello."}]
 
@@ -62,7 +63,8 @@ def test_model_limit_max_tokens_generate_chat_response(chat_lm: VLLM, caplog: py
     caplog.clear()
 
 
-def test_model_limit_max_tokens_generate_complete_text(lm: VLLM, caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
+def test_model_limit_new_tokens_generate_complete_text(lm: VLLM, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING)
     text = "Hello."
 

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-from transformers import AutoTokenizer
 
 from flexeval.core.language_model import VLLM, HuggingFaceLM, LanguageModel
 from tests.conftest import is_vllm_enabled
@@ -59,9 +58,7 @@ def test_model_limit_max_tokens_generate_chat_response(chat_lm: VLLM, caplog: py
     chat_lm_with_limit_tokens = VLLM(model="sbintuitions/tiny-lm-chat", model_limit_new_tokens=1)
     chat_lm_with_limit_tokens.generate_chat_response(messages, max_new_tokens=128)
     assert len(caplog.records) >= 1
-    assert any(
-        record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records
-    )
+    assert any(record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records)
     caplog.clear()
 
 
@@ -78,7 +75,5 @@ def test_model_limit_max_tokens_generate_complete_text(lm: VLLM, caplog: pytest.
     lm_with_limit_tokens = VLLM(model="sbintuitions/tiny-lm", model_limit_new_tokens=1)
     lm_with_limit_tokens.complete_text(text, max_new_tokens=128)
     assert len(caplog.records) >= 1
-    assert any(
-        record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records
-    )
+    assert any(record.msg.startswith("The specified `max_new_tokens` (128) exceeds") for record in caplog.records)
     caplog.clear()


### PR DESCRIPTION
Add a `model_limit_new_tokens` argument to various `LanguageModel` implementations.
This allows `max_new_tokens` —as specified in `EvalSetup`, etc.—to be capped at the model-specific upper limit when it exceeds what the model can handle.

For example, if max_new_tokens is set to 8192 in `EvalSetup`, models like OpenAI's gpt-3.5-turbo may return an error:
```bash
bash
$ poetry run flexeval_lm --eval_setup rakuda-v2-ja --eval_setup.gen_kwargs.max_new_tokens 8192 --language_model OpenAIChatAPI --language_model.model gpt-3.5-turbo-0125
...
2025-04-08 17:48:30.999 | WARNING  | flexeval.core.language_model.openai_api:_retry_on_error:56 - We got an error: Error code: 400 - {'error': {'message': 'max_tokens is too large: 8192. This model supports at most 4096 completion tokens, whereas you provided 8192.', 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': None}}
```

With this change, LanguageModel can now enforce an upper limit in advance, helping to avoid such errors (while still issuing warnings):
```bash
$ poetry run flexeval_lm --eval_setup rakuda-v2-ja --eval_setup.gen_kwargs.max_new_tokens 8192 --language_model OpenAIChatAPI --language_model.model gpt-3.5-turbo-0125 --language_model.model_limit_new_tokens 4096
...
2025-04-08 17:51:33.860 | WARNING  | flexeval.core.language_model.openai_api:_async_batch_run_chatgpt:139 - The specified `max_new_tokens` (8192) exceedsthe model’s capability (4096 tokens). It will be reduced.
2025-04-08 17:51:36.268 | INFO     | flexeval.core.evaluate_chat_response:evaluate_chat_response:130 - Example of the conversation
2025-04-08 17:51:36.268 | INFO     | flexeval.core.evaluate_chat_response:evaluate_chat_response:131 - [{'role': 'user', 'content': '四国地方の４つの都道府県名と、それぞれの県庁所在地を列挙してください。'}, {'role': 'assistant', 'content': '- 徳島県： 徳島市\n- 香川県： 高松市\n- 愛媛県： 松山市\n- 高知県： 高知市', 'finish_reason': 'stop'}]
 10%|███████████▉                                                                                                           | 4/40 [00:02<00:21,  1.66it/s]
```