### PR TITLE
Add `category_key` and `*_processor` options to some `Metric` s

### DIFF
--- a/flexeval/core/metric/bleu.py
+++ b/flexeval/core/metric/bleu.py
@@ -17,6 +17,9 @@ class BLEU(Metric):
     Args:
         tokenize_option: Tokenization option for sacrebleu.
             If `None`, sacrebleu will use the default tokenization.
+        lm_output_processor:
+            StringProcessor or a list of StringProcessor to be applied to the model outputs before comparison.
+        reference_processor: StringProcessor or list of StringProcessor to apply to the references before comparison.
         category_key: A key to create category-wise mean score.
             The category key is expected to be in task inputs.
 

--- a/flexeval/core/metric/bleu.py
+++ b/flexeval/core/metric/bleu.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import functools
+
 import sacrebleu
+
+from flexeval.core.metric.utils import aggregate_category_wise_scores
+from flexeval.core.string_processor.base import StringProcessor
 
 from .base import Metric, MetricResult
 
@@ -12,6 +17,8 @@ class BLEU(Metric):
     Args:
         tokenize_option: Tokenization option for sacrebleu.
             If `None`, sacrebleu will use the default tokenization.
+        category_key: A key to create category-wise mean score.
+            The category key is expected to be in task inputs.
 
     Examples:
         >>> from flexeval import BLEU
@@ -32,10 +39,25 @@ class BLEU(Metric):
             )
     """
 
-    def __init__(self, tokenize_option: str | None = None) -> None:
+    def __init__(
+        self,
+        tokenize_option: str | None = None,
+        lm_output_processor: StringProcessor | list[StringProcessor] | None = None,
+        reference_processor: StringProcessor | list[StringProcessor] | None = None,
+        category_key: str | None = None,
+    ) -> None:
         self._corpus_bleu = sacrebleu.metrics.BLEU(tokenize=tokenize_option)
         # For sentence BLEU, we need to set `effective_order=True` as recommended by sacrebleu.
         self._sentence_bleu = sacrebleu.metrics.BLEU(tokenize=tokenize_option, effective_order=True)
+
+        if isinstance(lm_output_processor, StringProcessor):
+            lm_output_processor = [lm_output_processor]
+        if isinstance(reference_processor, StringProcessor):
+            reference_processor = [reference_processor]
+
+        self.lm_output_processors = lm_output_processor
+        self.reference_processors = reference_processor
+        self.category_key = category_key
 
     def evaluate(
         self,
@@ -49,6 +71,17 @@ class BLEU(Metric):
                 f"but got {len(lm_outputs)} and {len(references_list)}."
             )
             raise ValueError(msg)
+
+        if self.lm_output_processors:
+            lm_outputs = [
+                functools.reduce(lambda x, norm: norm(x), self.lm_output_processors, output) for output in lm_outputs
+            ]
+
+        if self.reference_processors:
+            references_list = [
+                [functools.reduce(lambda x, norm: norm(x), self.reference_processors, ref) for ref in references]
+                for references in references_list
+            ]
 
         # we need restructure the references to match the format expected by sacrebleu
         max_num_refs = max(len(refs) for refs in references_list)
@@ -67,11 +100,20 @@ class BLEU(Metric):
             self._sentence_bleu.sentence_score(o.strip(), refs) for o, refs in zip(lm_outputs, references_list)
         ]
 
+        summary = {
+            "bleu_score": bleu.score / 100,
+            "bleu_bp": bleu.bp,
+            "bleu_signature": self._corpus_bleu.get_signature(),
+        }
+
+        if self.category_key:
+            categories = [task_input[self.category_key] for task_input in task_inputs_list]
+            sentence_bleu_score_list = [b.score / 100 for b in sentence_bleu_list]
+            category_wise_scores = aggregate_category_wise_scores(sentence_bleu_score_list, categories)
+            for category, category_wise_score in category_wise_scores.items():
+                summary[f"sentence_bleu_score/{category}"] = category_wise_score
+
         return MetricResult(
-            {
-                "bleu_score": bleu.score / 100,
-                "bleu_bp": bleu.bp,
-                "bleu_signature": self._corpus_bleu.get_signature(),
-            },
+            summary,
             instance_details=[{"bleu_score": b.score / 100, "bleu_bp": b.bp} for b in sentence_bleu_list],
         )

--- a/flexeval/core/metric/exact_match.py
+++ b/flexeval/core/metric/exact_match.py
@@ -17,6 +17,8 @@ class ExactMatch(Metric):
         lm_output_processor:
             StringProcessor or a list of StringProcessor to be applied to the model outputs before comparison.
         reference_processor: StringProcessor or list of StringProcessor to apply to the references before comparison.
+        category_key: A key to create category-wise mean score.
+            The category key is expected to be in task inputs.
 
     Examples:
         >>> from flexeval import ExactMatch

--- a/tests/core/metric/test_bleu.py
+++ b/tests/core/metric/test_bleu.py
@@ -3,24 +3,66 @@ from __future__ import annotations
 import pytest
 
 from flexeval.core.metric import BLEU
+from flexeval.core.metric.base import MetricResult
+from flexeval.core.string_processor.base import StringProcessor
+from flexeval.core.string_processor.regex import RegexExtractor
+from flexeval.core.string_processor.string_strip import StringStrip
 
 
 @pytest.mark.parametrize(
-    ("lm_outputs", "expected_outputs", "score"),
+    ("lm_outputs", "expected_outputs", "lm_output_processor", "reference_processor", "score"),
     [
-        (["これはテストです"], [["これはテストです"]], 1.0),
+        (["これはテストです"], [["これはテストです"]], None, None, 1.0),
         (
             ["これはテストです", "あれもテストです"],
             [["これはテストです", "これもテストでした"], ["あれもテストです", "あれはテスト"]],
+            None,
+            None,
             1.0,
         ),
-        (["こんにちは、世界！"], [["こんばんわ, 地方？"]], 0.0),
-        ([""], [["empty"]], 0.0),
+        (["こんにちは、世界！"], [["こんばんわ, 地方？"]], None, None, 0.0),
+        ([""], [["empty"]], None, None, 0.0),
+        (["訳: これはテストです"], [["これはテストです "]], RegexExtractor(r"訳:\s*(.+)"), StringStrip(), 1.0),
     ],
 )
-def test_bleu(lm_outputs: list[str], expected_outputs: list[list[str]], score: float) -> None:
-    bleu = BLEU(tokenize_option="ja-mecab")
+def test_bleu(
+    lm_outputs: list[str],
+    expected_outputs: list[list[str]],
+    lm_output_processor: StringProcessor | list[StringProcessor] | None,
+    reference_processor: StringProcessor | list[StringProcessor] | None,
+    score: float,
+) -> None:
+    bleu = BLEU(
+        tokenize_option="ja-mecab", lm_output_processor=lm_output_processor, reference_processor=reference_processor
+    )
     metric_result = bleu.evaluate(lm_outputs=lm_outputs, references_list=expected_outputs)
     assert metric_result.summary["bleu_score"] == pytest.approx(score)
     assert metric_result.instance_details[0]["bleu_score"] == pytest.approx(score)
     assert len(metric_result.instance_details) == len(lm_outputs)
+
+
+def test_exact_match_with_category_key() -> None:
+    """Test ExactMatch metric with category_key parameter."""
+    metric_w_cat_key = BLEU(tokenize_option="ja-mecab", category_key="category")
+    metric_wo_cat_key = BLEU(tokenize_option="ja-mecab")
+    task_inputs_list = [
+        {"category": "commonsense", "text": "This is sentence1."},
+        {"category": "commonsense", "text": "This is sentence2."},
+        {"category": "science", "text": "This is very scientific sentence."},
+    ]
+    lm_outputs = ["これは文1です。", "間違った訳", "これはすごく科学的な文です。"]
+    references_list = [["これは文1です。"], ["これは文2です。"], ["これはすごく科学的な文です。"]]
+
+    result_w_cat_key = metric_w_cat_key.evaluate(lm_outputs, references_list, task_inputs_list)
+    result_wo_cat_key = metric_wo_cat_key.evaluate(lm_outputs, references_list, task_inputs_list)
+
+    assert isinstance(result_w_cat_key, MetricResult)
+    assert "bleu_score" in result_w_cat_key.summary
+    assert "sentence_bleu_score/commonsense" in result_w_cat_key.summary
+    assert "sentence_bleu_score/science" in result_w_cat_key.summary
+
+    # Confirm that the overall bleu_score do not change with or without the category key
+    assert pytest.approx(result_w_cat_key.summary["bleu_score"]) == result_wo_cat_key.summary["bleu_score"]
+
+    assert pytest.approx(result_w_cat_key.summary["sentence_bleu_score/commonsense"]) == 0.5
+    assert pytest.approx(result_w_cat_key.summary["sentence_bleu_score/science"]) == 1.0


### PR DESCRIPTION
Add `lm_output_processor` and `reference_processor` options to `BLEU`.
And allows `CharF1`, `BLEU` to compute category-wise scores.

When these options are not used, the behaviors are the same as previously.