### PR TITLE
Fix bug on `flexeval_pairwise`

### DIFF
--- a/flexeval/core/pairwise_comparison/judge/llm_judge.py
+++ b/flexeval/core/pairwise_comparison/judge/llm_judge.py
@@ -82,4 +82,4 @@ class ChatLLMPairwiseJudge(PairwiseJudge):
                 )
             input_chat_messages_list.append(input_chat_messages)
         judge_outputs = self.language_model.generate_chat_response(input_chat_messages_list)
-        return [self._parse_judge_output(output) for output in judge_outputs]
+        return [self._parse_judge_output(output.text) for output in judge_outputs]


### PR DESCRIPTION
Fix `flexeval_pairwise` to follow the introduction of the LMOutput class.
