### PR TITLE
Update typing of messages to `dict[str, Any]`

### DIFF
--- a/flexeval/core/chat_dataset/base.py
+++ b/flexeval/core/chat_dataset/base.py
@@ -12,7 +12,7 @@ class ChatInstance:
     A dataclass representing a single chat that will be fed to a chat language model.
     """
 
-    messages: list[dict[str, str]]
+    messages: list[dict[str, Any]]
     """
     A list of messages in the chat.
     The format of messages typically follows [OpenAI's Chat Completions API](https://platform.openai.com/docs/guides/text-generation/chat-completions-api).

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -16,9 +16,9 @@ from .utils.data_util import batch_iter
 
 
 def _remove_redundant_keys_from_messages(
-    messages: list[dict[str, str]],
+    messages: list[dict[str, Any]],
     remove_keys: Iterable[str],
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """
     Remove specified keys from all turns in `messages`.
 
@@ -47,7 +47,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912
         eval_instances = [eval_dataset[i] for i in range(min(max_instances, len(eval_dataset)))]
 
     # Generate responses for each instance
-    all_messages_list: list[list[dict[str, str]]] = []
+    all_messages_list: list[list[dict[str, Any]]] = []
     references_list: list[list[str]] = []
     extra_info_list: list[dict[str, Any]] = []
     with tqdm(total=len(eval_instances)) as pbar:
@@ -59,7 +59,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912
             if few_shot_generator is not None:
                 for input_id in range(len(input_messages_list)):
                     few_shot_instances = few_shot_generator(eval_inputs=input_messages_list[input_id])
-                    few_shot_messages: list[dict[str, str]] = []
+                    few_shot_messages: list[dict[str, Any]] = []
                     for few_shot_instance in few_shot_instances:
                         if not isinstance(few_shot_instance, ChatInstance):
                             msg = f"Invalid instance type: {type(few_shot_instance)}"
@@ -94,7 +94,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912
                 # The model first responses to the first user message, then add its response to the chat history,
                 # and responses to the next user message, and so on.
                 max_num_turns = max(len(messages) for messages in input_messages_list)
-                current_chat_history: list[list[dict[str, str]]] = [[] for _ in input_messages_list]
+                current_chat_history: list[list[dict[str, Any]]] = [[] for _ in input_messages_list]
                 # perform generation for each turn
                 for turn in range(max_num_turns):
                     batch_ids_fed_to_model = [

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import final
+from typing import Any, final
 
 from flexeval.core.string_processor import StringProcessor
 
@@ -71,7 +71,7 @@ class LanguageModel:
 
     def _batch_generate_chat_response(
         self,
-        chat_messages_list: list[list[dict[str, str]]],
+        chat_messages_list: list[list[dict[str, Any]]],
         **kwargs,
     ) -> list[LMOutput]:
         """Generate chat responses based on the chat messages in the list.
@@ -102,7 +102,7 @@ class LanguageModel:
         raise NotImplementedError(msg)
 
     def _batch_compute_chat_log_probs(
-        self, prompt_list: list[list[dict[str, str]]], response_list: list[dict[str, str]]
+        self, prompt_list: list[list[dict[str, Any]]], response_list: list[dict[str, Any]]
     ) -> list[float]:
         """
         Compute log probabilities of the chat responses given the chat history.
@@ -152,7 +152,7 @@ class LanguageModel:
     @final
     def generate_chat_response(
         self,
-        chat_messages: list[dict[str, str]] | list[list[dict[str, str]]],
+        chat_messages: list[dict[str, Any]] | list[list[dict[str, Any]]],
         **kwargs,
     ) -> LMOutput | list[LMOutput]:
         """
@@ -198,7 +198,7 @@ class LanguageModel:
 
     @final
     def compute_chat_log_probs(
-        self, prompt: list[dict[str, str]] | list[list[dict[str, str]]], response: dict[str, str] | list[dict[str, str]]
+        self, prompt: list[dict[str, Any]] | list[list[dict[str, Any]]], response: dict[str, Any] | list[dict[str, Any]]
     ) -> float | list[float]:
         """
         A wrapper for `batch_compute_chat_log_probs` that accepts a single chat prompt or a list of chat prompts.

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -342,7 +342,7 @@ class HuggingFaceLM(LanguageModel):
 
     def _batch_generate_chat_response(
         self,
-        chat_messages_list: list[list[dict[str, str]]],
+        chat_messages_list: list[list[dict[str, Any]]],
         **kwargs,
     ) -> list[LMOutput]:
         chat_messages_as_string = [
@@ -464,7 +464,7 @@ class HuggingFaceLM(LanguageModel):
         return total_log_probs.tolist()
 
     def _batch_compute_chat_log_probs(
-        self, prompt_list: list[list[dict[str, str]]], response_list: list[dict[str, str]]
+        self, prompt_list: list[list[dict[str, Any]]], response_list: list[dict[str, Any]]
     ) -> list[float]:
         prompt_as_string: list[str] = []
         response_as_string: list[str] = []

--- a/flexeval/core/language_model/litellm_api.py
+++ b/flexeval/core/language_model/litellm_api.py
@@ -28,7 +28,7 @@ class LiteLLMChatAPI(OpenAIChatAPI):
         string_processors: A single or a list of StringProcessor objects to process the model's output.
         ignore_seed: If True, ignore the seed specified in default_gen_kwargs.
             This is an option for models that do not support seed parameters such as anthropic/claude.
-        model_limit_new_tokens: An upper limit on the number of tokens the model can generate.
+        model_limit_completion_tokens: An upper limit on the number of tokens the model can generate.
             For example, if a too-large `max_new_tokens` is given to generate_chat_response(), this value will cap it.
     """
 
@@ -75,7 +75,7 @@ class LiteLLMChatAPI(OpenAIChatAPI):
 
     def _batch_generate_chat_response(
         self,
-        chat_messages_list: list[list[dict[str, str]]],
+        chat_messages_list: list[list[dict[str, Any]]],
         **kwargs,
     ) -> list[LMOutput]:
         if "seed" in kwargs and self.ignore_seed:
@@ -84,8 +84,8 @@ class LiteLLMChatAPI(OpenAIChatAPI):
 
     def _batch_compute_chat_log_probs(
         self,
-        prompt_list: list[list[dict[str, str]]],
-        response_list: list[dict[str, str]],
+        prompt_list: list[list[dict[str, Any]]],
+        response_list: list[dict[str, Any]],
         temperature: float = 0,
         seed: int = 42,
         top_logprobs: int = 20,

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -105,7 +105,7 @@ class OpenAIChatAPI(LanguageModel):
 
     async def _async_batch_run_chatgpt(
         self,
-        messages_list: list[list[dict[str, str]]],
+        messages_list: list[list[dict[str, Any]]],
         stop_sequences: str | list[str] | None = None,
         max_new_tokens: int | None = None,
         **kwargs,
@@ -189,7 +189,7 @@ class OpenAIChatAPI(LanguageModel):
 
     def _batch_generate_chat_response(
         self,
-        chat_messages_list: list[list[dict[str, str]]],
+        chat_messages_list: list[list[dict[str, Any]]],
         **kwargs,
     ) -> list[LMOutput]:
         api_responses = asyncio.run(
@@ -205,8 +205,8 @@ class OpenAIChatAPI(LanguageModel):
 
     def _batch_compute_chat_log_probs(
         self,
-        prompt_list: list[list[dict[str, str]]],
-        response_list: list[dict[str, str]],
+        prompt_list: list[list[dict[str, Any]]],
+        response_list: list[dict[str, Any]],
         temperature: float = 0,
         seed: int = 42,
         top_logprobs: int = 20,
@@ -267,14 +267,14 @@ def number_of_tokens_in_openai_model(model: str, content: str) -> int:
     return len(encoding.encode(content))
 
 
-def message_list_from_prompt(prompt: list[dict[str, str]]) -> list[str]:
+def message_list_from_prompt(prompt: list[dict[str, Any]]) -> list[str]:
     """A preprocess function to remove duplicates from prompt_list.
     This function translates prompt into list[str], allowing sorting
     """
     return [f"[{message['role']}]{message['content']}" for message in prompt]
 
 
-def prompt_from_message_list(message_list: list[str]) -> list[dict[str, str]]:
+def prompt_from_message_list(message_list: list[str]) -> list[dict[str, Any]]:
     """The inverted function of message_list_from_prompt."""
     prompt = []
     for message_str in message_list:
@@ -285,7 +285,7 @@ def prompt_from_message_list(message_list: list[str]) -> list[dict[str, str]]:
     return prompt
 
 
-def remove_duplicates_from_prompt_list(prompt_list: list[list[dict[str, str]]]) -> list[list[dict[str, str]]]:
+def remove_duplicates_from_prompt_list(prompt_list: list[list[dict[str, Any]]]) -> list[list[dict[str, Any]]]:
     """We cannot sort raw prompt_list because order is not defined for dict.
 
     Removing duplicates can be done as below.

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -33,7 +33,7 @@ class Status(str, Enum):
     canceled = "canceled"
 
 
-def create_request_details(model: str, custom_id: str, messages: list[dict[str, str]], **kwargs) -> dict[str, Any]:
+def create_request_details(model: str, custom_id: str, messages: list[dict[str, Any]], **kwargs) -> dict[str, Any]:
     return {
         "custom_id": custom_id,
         "method": "POST",
@@ -83,7 +83,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         self.developer_message = developer_message
         self.model_limit_new_tokens = model_limit_new_tokens
 
-    def create_batch_file(self, custom_id_2_message: dict[str, list[dict[str, str]]], **kwargs) -> None:
+    def create_batch_file(self, custom_id_2_message: dict[str, list[dict[str, Any]]], **kwargs) -> None:
         with open(self.temp_jsonl_file.name, mode="w") as f:
             for custom_id, message in custom_id_2_message.items():
                 if self.developer_message:
@@ -96,7 +96,7 @@ class OpenAIChatBatchAPI(LanguageModel):
 
     async def _post_batch_requests(
         self,
-        custom_id_2_message: dict[str, list[dict[str, str]]],
+        custom_id_2_message: dict[str, list[dict[str, Any]]],
         stop_sequences: str | list[str] | None = None,
         max_new_tokens: int | None = None,
         **kwargs,
@@ -167,14 +167,14 @@ class OpenAIChatBatchAPI(LanguageModel):
 
     def _execute_batch_requests(
         self,
-        messages_list: list[list[dict[str, str]]],
+        messages_list: list[list[dict[str, Any]]],
         **kwargs,
     ) -> list[Any]:
-        custom_id_2_message: dict[str, list[dict[str, str]]] = {
+        custom_id_2_message: dict[str, list[dict[str, Any]]] = {
             str(uuid.uuid4()): messages for messages in messages_list
         }
         # The response will be an empty string if the API produces an error.
-        custom_id_2_response: dict[str, str | list[dict[str, str]]] = {
+        custom_id_2_response: dict[str, str | list[dict[str, Any]]] = {
             custom_id: "" for custom_id in custom_id_2_message
         }
         exec_cnt = 1
@@ -249,7 +249,7 @@ class OpenAIChatBatchAPI(LanguageModel):
 
     def _batch_generate_chat_response(
         self,
-        chat_messages_list: list[list[dict[str, str]]],
+        chat_messages_list: list[list[dict[str, Any]]],
         **kwargs,
     ) -> list[LMOutput]:
         api_responses = self._execute_batch_requests(
@@ -275,8 +275,8 @@ class OpenAIChatBatchAPI(LanguageModel):
 
     def _batch_compute_chat_log_probs(
         self,
-        prompt_list: list[list[dict[str, str]]],
-        response_list: list[dict[str, str]],
+        prompt_list: list[list[dict[str, Any]]],
+        response_list: list[dict[str, Any]],
         temperature: float = 0,
         seed: int = 42,
         top_logprobs: int = 20,

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -208,7 +208,7 @@ class VLLM(LanguageModel):
 
     def _batch_generate_chat_response(
         self,
-        chat_messages_list: list[list[dict[str, str]]],
+        chat_messages_list: list[list[dict[str, Any]]],
         **kwargs,
     ) -> list[LMOutput]:
         chat_messages_as_string = [
@@ -302,7 +302,7 @@ class VLLM(LanguageModel):
         return batch_logprobs
 
     def _batch_compute_chat_log_probs(
-        self, prompt_list: list[list[dict[str, str]]], response_list: list[dict[str, str]]
+        self, prompt_list: list[list[dict[str, Any]]], response_list: list[dict[str, Any]]
     ) -> list[float]:
         prompt_as_string: list[str] = []
         response_as_string: list[str] = []


### PR DESCRIPTION
Chat messages may be in various forms such as:
```
[
    {"role": "user", "content": "..."},
    {
        "role": "assistant",
        "content": [
            {"type": "text", "text": "..."},
            {"type": "image_url", "content": "..."},
        ],
    },
]
```

To accept such forms, loosen the typing from `dict[str, str]` to `dict[str, Any]`.