### PR TITLE
Remove top-level import in VLLM

### DIFF
--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -5,7 +5,6 @@ from typing import Any, Literal
 import torch
 from loguru import logger
 from transformers import AutoTokenizer, PreTrainedTokenizer
-from vllm import SamplingParams
 
 from flexeval.core.string_processor import StringProcessor
 


### PR DESCRIPTION
It is imported within function.

https://github.com/sbintuitions/flexeval/blob/49ac16035f327aa329105d849bab2636b11384f9/flexeval/core/language_model/vllm_model.py#L162

https://github.com/sbintuitions/flexeval/blob/49ac16035f327aa329105d849bab2636b11384f9/flexeval/core/language_model/vllm_model.py#L263