### PR TITLE
Skip some batch consistency tests for API-based LLM

### DIFF
--- a/tests/core/language_model/test_litellm_api.py
+++ b/tests/core/language_model/test_litellm_api.py
@@ -38,6 +38,14 @@ class TestLiteLLMChatAPI(BaseLanguageModelTest):
     def chat_lm(self, chat_lm: LiteLLMChatAPI) -> LanguageModel:
         return chat_lm
 
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_complete_text_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass
+
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_chat_response_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass
+
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
 def test_compute_chat_log_probs_for_multi_tokens(chat_lm: LiteLLMChatAPI) -> None:

--- a/tests/core/language_model/test_openai_api.py
+++ b/tests/core/language_model/test_openai_api.py
@@ -41,6 +41,14 @@ class TestOpenAIChatAPI(BaseLanguageModelTest):
     def chat_lm(self, chat_lm: OpenAIChatAPI) -> LanguageModel:
         return chat_lm
 
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_complete_text_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass
+
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_chat_response_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass
+
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
 def test_warning_if_conflict_max_new_tokens(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/core/language_model/test_openai_batch_api.py
+++ b/tests/core/language_model/test_openai_batch_api.py
@@ -37,6 +37,14 @@ class TestOpenAIChatBatchAPI(BaseLanguageModelTest):
     def chat_lm(self, chat_lm: OpenAIChatBatchAPI) -> LanguageModel:
         return chat_lm
 
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_complete_text_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass
+
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_chat_response_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass
+
 
 @pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
 @pytest.mark.batch_api()

--- a/tests/core/language_model/test_openai_completion_api.py
+++ b/tests/core/language_model/test_openai_completion_api.py
@@ -29,3 +29,11 @@ class TestOpenAICompletionAPI(BaseLanguageModelTest):
     @pytest.fixture()
     def chat_lm(self, lm: OpenAICompletionAPI) -> LanguageModel:
         return lm
+
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_complete_text_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass
+
+    @pytest.mark.skip(reason="Even with temperature 0.0, the output is not deterministic via API.")
+    def test_batch_chat_response_is_not_affected_by_batch(self, chat_lm: LanguageModel) -> None:
+        pass


### PR DESCRIPTION
The outputs from API are not deterministic even with temperature 0.0.
It sometimes produces false negatives for CI ([example](https://github.com/sbintuitions/flexeval/actions/runs/14659067116/job/41139315905)), so skip them.