### PR TITLE
Handle the error when stop is an empty list

### DIFF
--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -8,6 +8,7 @@ import openai
 import tiktoken
 from loguru import logger
 from openai import AsyncOpenAI, BaseModel
+from openai._types import NotGiven
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 
@@ -157,7 +158,7 @@ class OpenAIChatAPI(LanguageModel):
                     model=self.model,
                     messages=messages,
                     tools=tools,
-                    stop=stop_sequences,
+                    stop=stop_sequences or NotGiven(),
                     **gen_kwargs,
                 ),
                 empty_response=self.empty_response,
@@ -372,7 +373,7 @@ class OpenAICompletionAPI(LanguageModel):
                 openai_call=lambda x=ms: self.api_call_func(
                     model=self.model,
                     prompt=x,
-                    stop=stop_sequences,
+                    stop=stop_sequences or NotGiven(),
                     **gen_kwargs,
                 ),
                 empty_response=self.empty_response,


### PR DESCRIPTION
## Related Issue or Pull Request
<!--
If this pull request is related to an existing issue or another pull request, please provide a link.
You can automatically close an issue when this PR is merged by writing "Closes #XXX" (replace XXX with the issue number).
For more information, see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

None

## Purpose
<!--
Briefly describe the goal of this pull request. What problem does it solve or what feature does it introduce?
-->

This PR handles the error for `stop=[]` in the OpenAI client API when images are provided

## Implementation Details
<!--
Provide an overview of the changes made in this pull request. Explain your approach and the reasoning behind your implementation.
-->

When `stop_sequences ` is None, provide the sentinel `NotGiven()` so that the API ignores this argument

## Verification Steps
<!--
List the steps taken to verify that this pull request works as intended. This may include:
- [ ] Confirming that all tests pass
- [ ] Manual testing scenarios
- [ ] Checking for any potential side effects or regressions
-->

Confirmed if the OpenAIChatAPI works as expected when images are given

## Additional Notes
<!--
Add any other relevant information, context, or considerations related to this pull request.
-->