### PR TITLE
Add an option to `OpenAIMessagesDataset` to drop the last message if it is from the assistant

### DIFF
--- a/flexeval/core/chat_dataset/openai_messages.py
+++ b/flexeval/core/chat_dataset/openai_messages.py
@@ -50,7 +50,7 @@ class OpenAIMessagesDataset(ChatDataset):
         file_path: str | None = None,
         message_key: str = "messages",
         tool_definitions_key: str | None = None,
-        drop_if_last_from_assistant: bool = False
+        drop_if_last_from_assistant: bool = False,
     ) -> None:
         self.conversations: list[ChatInstance] = []
         with open(file_path) as f:


### PR DESCRIPTION
Add an option to `OpenAIMessagesDataset` to drop the last message if it is from the assistant.
This option is useful for loading data where the last utterance, like in the training data, ends with an assistant's utterance.