### PR TITLE
Don't divide BLEU score by 100

### DIFF
--- a/flexeval/core/metric/bleu.py
+++ b/flexeval/core/metric/bleu.py
@@ -15,6 +15,8 @@ class BLEU(Metric):
     Args:
         tokenize_option: Tokenization option for sacrebleu.
             If `None`, sacrebleu will use the default tokenization.
+            For details, see sacreBLEU
+            https://github.com/mjpost/sacrebleu/blob/aa3cc4351af6/sacrebleu/sacrebleu.py#L121-L124
         lm_output_processor:
             StringProcessor or a list of StringProcessor to be applied to the model outputs before comparison.
         reference_processor: StringProcessor or list of StringProcessor to apply to the references before comparison.

--- a/flexeval/core/metric/bleu.py
+++ b/flexeval/core/metric/bleu.py
@@ -30,12 +30,12 @@ class BLEU(Metric):
         >>> print(result)
         MetricResult(
             summary={
-                'bleu_score': 1.0,
+                'bleu_score': 100.0,
                 'bleu_bp': 1.0,
                 'bleu_signature': nrefs:1|case:mixed|eff:no|tok:13a|smooth:exp|version:2.4.1},
                 instance_details=[
-                    {'bleu_score': 1.0, 'bleu_bp': 1.0},
-                    {'bleu_score': 1.0, 'bleu_bp': 1.0}
+                    {'bleu_score': 100.0, 'bleu_bp': 1.0},
+                    {'bleu_score': 100.0, 'bleu_bp': 1.0}
                 ]
             )
     """

--- a/flexeval/core/metric/bleu.py
+++ b/flexeval/core/metric/bleu.py
@@ -89,19 +89,19 @@ class BLEU(Metric):
         ]
 
         summary = {
-            "bleu_score": bleu.score / 100,
+            "bleu_score": bleu.score,
             "bleu_bp": bleu.bp,
             "bleu_signature": self._corpus_bleu.get_signature(),
         }
 
         if self.category_key:
             categories = [extra_info[self.category_key] for extra_info in extra_info_list]
-            sentence_bleu_score_list = [b.score / 100 for b in sentence_bleu_list]
+            sentence_bleu_score_list = [b.score for b in sentence_bleu_list]
             category_wise_scores = aggregate_category_wise_scores(sentence_bleu_score_list, categories)
             for category, category_wise_score in category_wise_scores.items():
                 summary[f"sentence_bleu_score/{category}"] = category_wise_score
 
         return MetricResult(
             summary,
-            instance_details=[{"bleu_score": b.score / 100, "bleu_bp": b.bp} for b in sentence_bleu_list],
+            instance_details=[{"bleu_score": b.score, "bleu_bp": b.bp} for b in sentence_bleu_list],
         )

--- a/tests/core/metric/test_bleu.py
+++ b/tests/core/metric/test_bleu.py
@@ -12,17 +12,17 @@ from flexeval.core.string_processor.string_strip import StringStrip
 @pytest.mark.parametrize(
     ("lm_outputs", "expected_outputs", "lm_output_processor", "reference_processor", "score"),
     [
-        (["これはテストです"], [["これはテストです"]], None, None, 1.0),
+        (["これはテストです"], [["これはテストです"]], None, None, 100.0),
         (
             ["これはテストです", "あれもテストです"],
             [["これはテストです", "これもテストでした"], ["あれもテストです", "あれはテスト"]],
             None,
             None,
-            1.0,
+            100.0,
         ),
         (["こんにちは、世界！"], [["こんばんわ, 地方？"]], None, None, 0.0),
         ([""], [["empty"]], None, None, 0.0),
-        (["訳: これはテストです"], [["これはテストです "]], RegexExtractor(r"訳:\s*(.+)"), StringStrip(), 1.0),
+        (["訳: これはテストです"], [["これはテストです "]], RegexExtractor(r"訳:\s*(.+)"), StringStrip(), 100.0),
     ],
 )
 def test_bleu(
@@ -64,5 +64,5 @@ def test_exact_match_with_category_key() -> None:
     # Confirm that the overall bleu_score do not change with or without the category key
     assert pytest.approx(result_w_cat_key.summary["bleu_score"]) == result_wo_cat_key.summary["bleu_score"]
 
-    assert pytest.approx(result_w_cat_key.summary["sentence_bleu_score/commonsense"]) == 0.5
-    assert pytest.approx(result_w_cat_key.summary["sentence_bleu_score/science"]) == 1.0
+    assert pytest.approx(result_w_cat_key.summary["sentence_bleu_score/commonsense"]) == 50.0
+    assert pytest.approx(result_w_cat_key.summary["sentence_bleu_score/science"]) == 100.0


### PR DESCRIPTION
Reporting the value without division seems to be a common practice.