### PR TITLE
Add JsonNormalizer

### DIFF
--- a/flexeval/core/string_processor/__init__.py
+++ b/flexeval/core/string_processor/__init__.py
@@ -1,5 +1,6 @@
 from .aio import AIONormalizer
 from .base import StringProcessor
+from .json import JsonNormalizer
 from .last_line import LastLineExtractor
 from .lower import StringLower
 from .nfkc import NFKCNormalizer

--- a/flexeval/core/string_processor/json.py
+++ b/flexeval/core/string_processor/json.py
@@ -1,0 +1,25 @@
+import json
+from typing import Any
+
+from .base import StringProcessor
+
+
+class JsonNormalizer(StringProcessor):
+    """Parse input text as json, sort by keys, and finally dump into string.
+    If input text cannot be parsed, always return '{}'.
+
+    Examples:
+        >>> from flexeval import JsonNormalizer
+        >>> processor = JsonNormalizer()
+        >>> text = '{"b": 1, "a": 2}'
+        >>> normalized_text = processor(text)
+        >>> print(normalized_text)
+        {"a": 2, "b": 1}
+    """
+
+    def __call__(self, text: str) -> str:
+        try:
+            data: Any = json.loads(text)
+        except json.JSONDecodeError:
+            data = {}
+        return json.dumps(data, sort_keys=True, ensure_ascii=False)

--- a/tests/core/string_processor/test_json.py
+++ b/tests/core/string_processor/test_json.py
@@ -1,0 +1,19 @@
+import pytest
+
+from flexeval.core.string_processor import JsonNormalizer
+
+
+@pytest.mark.parametrize(
+    ("before", "after"),
+    [
+        ("", "{}"),  # 空文字列 → 空JSON
+        ("not a json", "{}"),  # 無効なJSON → 空JSON
+        ('{"b": 1, "a": 2}', '{"a": 2, "b": 1}'),  # ソートされる
+        ("[1, 2, 3]", "[1, 2, 3]"),  # 配列も処理できる
+        ("42", "42"),  # 数値も処理できる
+        ('"hello"', '"hello"'),  # 文字列型のJSONも処理できる
+    ],
+)
+def test_aio_processor(before: str, after: str) -> None:
+    processor = JsonNormalizer()
+    assert processor(before) == after


### PR DESCRIPTION
This PR adds new string processor called `JsonNormalizer`.

This is mainly for evaluating json-like strings generated by LLMs.