### PR TITLE
Fix module path of Sarashina2.2 evaluation

### DIFF
--- a/examples/sarashina_2_2_evaluation/configs/pretrained_evals/gsm8k.jsonnet
+++ b/examples/sarashina_2_2_evaluation/configs/pretrained_evals/gsm8k.jsonnet
@@ -57,11 +57,11 @@ local template = |||
       {
         class_path: 'ExactMatch',
         init_args: {
-          lm_output_processor: [{ class_path: 'plugins.simple_evals_processors.SimpleEvalMGSMProcessor' }],
-          reference_processor: [{ class_path: 'plugins.simple_evals_processors.RemoveCommaProcessor' }],
+          lm_output_processor: [{ class_path: 'flexeval.core.string_processor.SimpleEvalMGSMProcessor' }],
+          reference_processor: [{ class_path: 'flexeval.core.string_processor.RemoveCommaProcessor' }],
         },
       },
-      { class_path: 'plugins.math_verify_metric.MathVerify' },
+      { class_path: 'flexeval.core.metric.MathVerify' },
     ],
     gen_kwargs: { max_new_tokens: 512, stop_sequences: ['Q:'] },
     batch_size: 1,

--- a/examples/sarashina_2_2_evaluation/configs/pretrained_evals/mgsm-ja.jsonnet
+++ b/examples/sarashina_2_2_evaluation/configs/pretrained_evals/mgsm-ja.jsonnet
@@ -47,17 +47,17 @@ local template_ = |||
         init_args: {
           lm_output_processor: [
             {
-              class_path: 'plugins.simple_evals_processors.SimpleEvalMGSMProcessor',
+              class_path: 'flexeval.core.string_processor.SimpleEvalMGSMProcessor',
               init_args: {
                 answer_prefix: '答えは',
               },
             },
           ],
-          reference_processor: [{ class_path: 'plugins.simple_evals_processors.RemoveCommaProcessor' }],
+          reference_processor: [{ class_path: 'flexeval.core.string_processor.RemoveCommaProcessor' }],
         },
 
       },
-      { class_path: 'plugins.math_verify_metric.MathVerify' },
+      { class_path: 'flexeval.core.metric.MathVerify' },
     ],
     gen_kwargs: { max_new_tokens: 512, stop_sequences: ['\n\n'] },
     batch_size: 1,


### PR DESCRIPTION
This PR addresses #202 

Confirmed w/ following two commands

```bash
export VLLM_USE_V1=0
flexeval_lm \
  --language_model "examples/sarashina_2_2_evaluation/configs/pretrained_models/sarashina2.2-0.5b.jsonnet" \
  --eval_setup "examples/sarashina_2_2_evaluation/configs/pretrained_evals/mgsm-ja.jsonnet" \
  --save_dir "./results_pretrained/sarashina2.2-0.5b/mgsm-ja"

flexeval_lm \
  --language_model "examples/sarashina_2_2_evaluation/configs/pretrained_models/sarashina2.2-0.5b.jsonnet" \
  --eval_setup "examples/sarashina_2_2_evaluation/configs/pretrained_evals/gsm8k.jsonnet" \
  --save_dir "./results_pretrained/sarashina2.2-0.5b/gsm8k"
```