### PR TITLE
Allow Multiple LLM-as-a-Judge-style `Metric` s per `EvalSetup`

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -185,6 +185,8 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
             if mes["content"] is None:
                 mes["content"] = ""
 
+    language_model.resource_cleanup()
+
     # Evaluate the generated responses
     metrics_summary_dict: dict[str, float] = {}
     instance_metrics_list: list[dict[str, Any]] = [{} for _ in range(len(all_messages_list))]
@@ -197,6 +199,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
                 for messages, extra_info in zip(all_messages_list, extra_info_list)
             ],
         )
+        metric.resource_cleanup()
 
         metrics_summary_dict.update(metric_result.summary)
 

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -185,7 +185,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
             if mes["content"] is None:
                 mes["content"] = ""
 
-    language_model.resource_cleanup()
+    language_model.cleanup_resources()
 
     # Evaluate the generated responses
     metrics_summary_dict: dict[str, float] = {}
@@ -199,7 +199,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
                 for messages, extra_info in zip(all_messages_list, extra_info_list)
             ],
         )
-        metric.resource_cleanup()
+        metric.cleanup_resources()
 
         metrics_summary_dict.update(metric_result.summary)
 

--- a/flexeval/core/evaluate_from_data.py
+++ b/flexeval/core/evaluate_from_data.py
@@ -45,7 +45,7 @@ def evaluate_from_data(
             references_list=references_list,
             extra_info_list=extra_info_list,
         )
-        metric.resource_cleanup()
+        metric.cleanup_resources()
 
         metrics_summary_dict.update(metric_result.summary)
 

--- a/flexeval/core/evaluate_from_data.py
+++ b/flexeval/core/evaluate_from_data.py
@@ -45,6 +45,7 @@ def evaluate_from_data(
             references_list=references_list,
             extra_info_list=extra_info_list,
         )
+        metric.resource_cleanup()
 
         metrics_summary_dict.update(metric_result.summary)
 

--- a/flexeval/core/evaluate_generation.py
+++ b/flexeval/core/evaluate_generation.py
@@ -69,6 +69,8 @@ def evaluate_generation(  # noqa: C901
 
             pbar.update(len(batch))
 
+    language_model.resource_cleanup()
+
     # Evaluate the generated continuations
     metrics_summary_dict: dict[str, float] = {}
     instance_metrics_list: list[dict[str, Any]] = [{} for _ in range(len(eval_instances))]
@@ -78,6 +80,7 @@ def evaluate_generation(  # noqa: C901
             references_list=[i.references for i in eval_instances],
             extra_info_list=[i.inputs for i in eval_instances],
         )
+        metric.resource_cleanup()
 
         metrics_summary_dict.update(metric_result.summary)
 

--- a/flexeval/core/evaluate_generation.py
+++ b/flexeval/core/evaluate_generation.py
@@ -69,7 +69,7 @@ def evaluate_generation(  # noqa: C901
 
             pbar.update(len(batch))
 
-    language_model.resource_cleanup()
+    language_model.cleanup_resources()
 
     # Evaluate the generated continuations
     metrics_summary_dict: dict[str, float] = {}
@@ -80,7 +80,7 @@ def evaluate_generation(  # noqa: C901
             references_list=[i.references for i in eval_instances],
             extra_info_list=[i.inputs for i in eval_instances],
         )
-        metric.resource_cleanup()
+        metric.cleanup_resources()
 
         metrics_summary_dict.update(metric_result.summary)
 

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -249,6 +249,7 @@ class LanguageModel:
     def __del__(self) -> None:
         self.resource_cleanup()
 
+
 def normalize_stop_sequences(
     stop_sequences_list: list[str | list[str] | None],
     bos_token: str | None = None,

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -240,6 +240,14 @@ class LanguageModel:
             return self._batch_compute_chat_log_probs([prompt], [response])[0]
         return self._batch_compute_chat_log_probs(prompt, response)
 
+    def resource_cleanup(self) -> None:
+        """
+        Clean up resources if necessary.
+        This method is called when the language model is no longer needed.
+        """
+
+    def __del__(self) -> None:
+        self.resource_cleanup()
 
 def normalize_stop_sequences(
     stop_sequences_list: list[str | list[str] | None],

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -240,14 +240,14 @@ class LanguageModel:
             return self._batch_compute_chat_log_probs([prompt], [response])[0]
         return self._batch_compute_chat_log_probs(prompt, response)
 
-    def resource_cleanup(self) -> None:
+    def cleanup_resources(self) -> None:
         """
         Clean up resources if necessary.
         This method is called when the language model is no longer needed.
         """
 
     def __del__(self) -> None:
-        self.resource_cleanup()
+        self.cleanup_resources()
 
 
 def normalize_stop_sequences(

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import gc
 import json
 from typing import Any, Literal, TypeVar
 
@@ -215,45 +216,52 @@ class HuggingFaceLM(LanguageModel):
         self.chat_template_kwargs = chat_template_kwargs or {}
         self.add_special_tokens = add_special_tokens
         self.default_gen_kwargs = default_gen_kwargs or {}
-
-        model_kwargs = get_default_model_kwargs(model_kwargs)
-        if not load_peft:
-            self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
-                model,
-                **model_kwargs,
-            )
-        else:
-            from peft import AutoPeftModelForCausalLM
-
-            self.model = AutoPeftModelForCausalLM.from_pretrained(
-                model,
-                **model_kwargs,
-            )
-
-        self.model.eval()
-
+        self._model: PreTrainedModel | None = None
+        self.model_kwargs = get_default_model_kwargs(model_kwargs)
+        self.load_peft = load_peft
         self.amp_dtype = amp_dtype
-        if model_limit_tokens == "default":
-            hf_config = self.model.config.to_dict()
-            if "n_positions" in hf_config:
-                model_limit_tokens = hf_config["n_positions"]
-            elif "max_position_embeddings" in hf_config:
-                model_limit_tokens = hf_config["max_position_embeddings"]
-            else:
-                msg = (
-                    "`model_limit_tokens` was set to “default”, but the default max_position_embedeings "
-                    "could not be found in the config. Set it to `None`."
-                )
-                logger.warning(msg)
         self.model_limit_tokens = model_limit_tokens
         self.tool_parser = tool_parser
-
-        transformers.set_seed(random_seed)
-
-        logger.info(f"model device: {self.model.device}")
-        logger.info(f"model dtype: {self.model.dtype}")
         logger.info(f"amp_dtype: {amp_dtype}")
         logger.info(f"random seed: {random_seed}")
+        transformers.set_seed(random_seed)
+
+    @property
+    def model(self) -> PreTrainedModel:
+        """The model property is used to access the model instance."""
+        if self._model is None:
+            if not self.load_peft:
+                self._model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
+                    self._model_name_or_path,
+                    **self.model_kwargs,
+                )
+            else:
+                from peft import AutoPeftModelForCausalLM
+
+                self._model = AutoPeftModelForCausalLM.from_pretrained(
+                    self._model_name_or_path,
+                    **self.model_kwargs,
+                )
+
+            self._model.eval()
+
+            if self.model_limit_tokens == "default":
+                hf_config = self._model.config.to_dict()
+                if "n_positions" in hf_config:
+                    self.model_limit_tokens = hf_config["n_positions"]
+                elif "max_position_embeddings" in hf_config:
+                    self.model_limit_tokens = hf_config["max_position_embeddings"]
+                else:
+                    msg = (
+                        "`model_limit_tokens` was set to “default”, but the default max_position_embedeings "
+                        "could not be found in the config. Set it to `None`."
+                    )
+                    logger.warning(msg)
+
+            logger.info(f"model device: {self.model.device}")
+            logger.info(f"model dtype: {self.model.dtype}")
+
+        return self._model
 
     def _get_amp_context(self) -> contextlib.AbstractContextManager:
         if self.amp_dtype is None:
@@ -532,6 +540,13 @@ class HuggingFaceLM(LanguageModel):
             prompt_as_string.append(prompt_as_string_i)
             response_as_string.append(response_as_string_i)
         return self._batch_compute_log_probs(response_as_string, prefix_list=prompt_as_string)
+
+    def resource_cleanup(self) -> None:
+        del self._model
+        self._model = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self._model_name_or_path!r})"

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -549,7 +549,7 @@ class HuggingFaceLM(LanguageModel):
             response_as_string.append(response_as_string_i)
         return self._batch_compute_log_probs(response_as_string, prefix_list=prompt_as_string)
 
-    def resource_cleanup(self) -> None:
+    def cleanup_resources(self) -> None:
         del self._model
         self._model = None
         gc.collect()

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -279,7 +279,7 @@ class OpenAIChatBatchAPI(LanguageModel):
             for res in api_responses
         ]
 
-    def close(self) -> None:
+    def resource_cleanup(self) -> None:
         # in case that the program fails before the file is initialized in __init__
         if not hasattr(self, "temp_jsonl_file"):
             return
@@ -333,7 +333,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         return log_probs
 
     def __del__(self) -> None:
-        self.close()
+        self.resource_cleanup()
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self.model})"

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -279,7 +279,7 @@ class OpenAIChatBatchAPI(LanguageModel):
             for res in api_responses
         ]
 
-    def resource_cleanup(self) -> None:
+    def cleanup_resources(self) -> None:
         # in case that the program fails before the file is initialized in __init__
         if not hasattr(self, "temp_jsonl_file"):
             return
@@ -333,7 +333,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         return log_probs
 
     def __del__(self) -> None:
-        self.resource_cleanup()
+        self.cleanup_resources()
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self.model})"

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import torch
@@ -369,6 +370,7 @@ class VLLM(LanguageModel):
         del self.llm
         logger.info("cleaning up vLLM resources...")
         cleanup_dist_env_and_memory()
+        time.sleep(10)  # wait for the vLLM server to release resources
         self.llm = None
 
     def __repr__(self) -> str:

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -363,7 +363,7 @@ class VLLM(LanguageModel):
             response_as_string.append(response_as_string_i)
         return self._batch_compute_log_probs(response_as_string, prefix_list=prompt_as_string)
 
-    def resource_cleanup(self) -> None:
+    def cleanup_resources(self) -> None:
         from vllm.distributed import cleanup_dist_env_and_memory
 
         del self.llm

--- a/flexeval/core/language_model/vllm_serve_lm.py
+++ b/flexeval/core/language_model/vllm_serve_lm.py
@@ -203,6 +203,6 @@ class VLLMServeLM(OpenAIChatAPI):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self.model})"
 
-    def __del__(self) -> None:
+    def resource_cleanup(self) -> None:
         if hasattr(self, "manager"):
             self.manager.stop()

--- a/flexeval/core/language_model/vllm_serve_lm.py
+++ b/flexeval/core/language_model/vllm_serve_lm.py
@@ -236,6 +236,6 @@ class VLLMServeLM(OpenAIChatAPI):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self.model})"
 
-    def resource_cleanup(self) -> None:
+    def cleanup_resources(self) -> None:
         if hasattr(self, "manager"):
             self.manager.stop()

--- a/flexeval/core/language_model/vllm_serve_lm.py
+++ b/flexeval/core/language_model/vllm_serve_lm.py
@@ -12,6 +12,7 @@ import requests
 import torch
 from loguru import logger
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.string_processor import StringProcessor
 
 from .openai_api import OpenAIChatAPI
@@ -42,6 +43,7 @@ class VLLMServerManager:
         self.model_kwargs = model_kwargs or {}
         self.host = "localhost"
         self.port = find_free_port()
+        self.base_url = f"http://{self.host}:{self.port}/v1"
         self.timeout = timeout
         self.process: subprocess.Popen | None = None
         self._log_threads: list[threading.Thread] = []
@@ -50,6 +52,9 @@ class VLLMServerManager:
         """
         Start the `vllm serve` process and wait until it is ready.
         """
+        if self.is_ready():
+            logger.warning("vLLM server is already running. Skipping start.")
+            return self.host, self.port
 
         cmd = [
             "vllm",
@@ -94,21 +99,13 @@ class VLLMServerManager:
             t.start()
             self._log_threads.append(t)
 
-        url = f"http://{self.host}:{self.port}/v1/models"
-        logger.info("Waiting for server to become available at {}", url)
+        logger.info("Waiting for server to become available")
 
         interval_second = 1
         for _ in range(self.timeout // interval_second):
-            if self.process.poll() is not None:
-                msg = "vLLM server process terminated unexpectedly."
-                raise RuntimeError(msg)
-            try:
-                response = requests.get(url, timeout=1)
-                if response.status_code == 200:
-                    logger.success("vLLM server is up and responding at {}", url)
-                    return self.host, self.port
-            except requests.RequestException:
-                pass
+            if self.is_ready():
+                logger.info(f"vLLM server is ready at {self.base_url}")
+                return self.host, self.port
             time.sleep(interval_second)
 
         self.stop()
@@ -130,6 +127,18 @@ class VLLMServerManager:
                 self.process.kill()
         self.process = None
         self._log_threads.clear()
+
+    def is_ready(self) -> bool:
+        """
+        Check if the vLLM server is ready to accept requests.
+        """
+        if self.process is None or self.process.poll() is not None:
+            return False
+        try:
+            response = requests.get(f"{self.base_url}/models", timeout=1)
+            return response.status_code == 200  # noqa: TRY300
+        except requests.RequestException:
+            return False
 
 
 class VLLMServeLM(OpenAIChatAPI):
@@ -177,10 +186,9 @@ class VLLMServeLM(OpenAIChatAPI):
         if "tensor_parallel_size" not in model_kwargs:
             model_kwargs["tensor_parallel_size"] = torch.cuda.device_count()
         self.manager = VLLMServerManager(model=model, model_kwargs=model_kwargs, timeout=booting_timeout)
-        host, port = self.manager.start()
         if api_headers is None:
             api_headers = {}
-        api_headers["base_url"] = f"http://{host}:{port}/v1"
+        api_headers["base_url"] = self.manager.base_url
         super().__init__(
             model=model,
             api_headers=api_headers,
@@ -188,6 +196,31 @@ class VLLMServeLM(OpenAIChatAPI):
             developer_message=developer_message,
             string_processors=string_processors,
             model_limit_new_tokens=model_limit_new_tokens,
+        )
+
+    def _batch_complete_text(
+        self,
+        text_list: list[str],
+        stop_sequences: str | list[str] | None = None,
+        max_new_tokens: int | None = None,
+        **kwargs,
+    ) -> list[LMOutput]:
+        if not self.manager.is_ready():
+            self.manager.start()
+        return super()._batch_complete_text(text_list, stop_sequences, max_new_tokens, **kwargs)
+
+    def _batch_generate_chat_response(
+        self,
+        chat_messages_list: list[list[dict[str, Any]]],
+        tools_list: list[list[dict[str, Any]]] | None = None,
+        **kwargs,
+    ) -> list[LMOutput]:
+        if not self.manager.is_ready():
+            self.manager.start()
+        return super()._batch_generate_chat_response(
+            chat_messages_list,
+            tools_list=tools_list,
+            **kwargs,
         )
 
     def _batch_compute_chat_log_probs(

--- a/flexeval/core/metric/base.py
+++ b/flexeval/core/metric/base.py
@@ -46,3 +46,10 @@ class Metric(ABC):
             references_list: List of reference outputs.
             extra_info_list: List of task inputs and some extra information.
         """
+
+    def resource_cleanup(self) -> None:  # noqa: B027
+        """
+        Clean up resources if necessary.
+        This method is called when the metric is no longer needed.
+        """
+        pass  # noqa: PIE790

--- a/flexeval/core/metric/base.py
+++ b/flexeval/core/metric/base.py
@@ -47,7 +47,7 @@ class Metric(ABC):
             extra_info_list: List of task inputs and some extra information.
         """
 
-    def resource_cleanup(self) -> None:  # noqa: B027
+    def cleanup_resources(self) -> None:  # noqa: B027
         """
         Clean up resources if necessary.
         This method is called when the metric is no longer needed.

--- a/flexeval/core/metric/llm_geval_score.py
+++ b/flexeval/core/metric/llm_geval_score.py
@@ -287,8 +287,8 @@ class LLMGEvalScore(Metric):
             ],
         )
 
-    def resource_cleanup(self) -> None:
-        self.language_model.resource_cleanup()
+    def cleanup_resources(self) -> None:
+        self.language_model.cleanup_resources()
 
     def __repr__(self) -> str:
         return (
@@ -458,8 +458,8 @@ class ChatLLMGEvalScore(Metric):
             ],
         )
 
-    def resource_cleanup(self) -> None:
-        self.language_model.resource_cleanup()
+    def cleanup_resources(self) -> None:
+        self.language_model.cleanup_resources()
 
     def __repr__(self) -> str:
         return (

--- a/flexeval/core/metric/llm_geval_score.py
+++ b/flexeval/core/metric/llm_geval_score.py
@@ -285,6 +285,9 @@ class LLMGEvalScore(Metric):
             ],
         )
 
+    def resource_cleanup(self) -> None:
+        self.language_model.resource_cleanup()
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(language_model={self.language_model}, prompt_template={self.prompt_template})"
@@ -450,6 +453,9 @@ class ChatLLMGEvalScore(Metric):
                 )
             ],
         )
+
+    def resource_cleanup(self) -> None:
+        self.language_model.resource_cleanup()
 
     def __repr__(self) -> str:
         return (

--- a/flexeval/core/metric/llm_geval_score.py
+++ b/flexeval/core/metric/llm_geval_score.py
@@ -150,6 +150,7 @@ class LLMGEvalScore(Metric):
             The category key is expected to be in extra_info.
         prob_threshold: For considering low probability among all of valid scores,
             return None (invalid) if sum of the all probability among vaild scores is less than this value.
+        metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
 
     Examples:
         >>> from flexeval import LLMGEvalScore, HuggingFaceLM, Jinja2PromptTemplate
@@ -211,6 +212,7 @@ class LLMGEvalScore(Metric):
         disable_tqdm: bool = False,
         category_key: str | None = None,
         prob_threshold: float = 0,
+        metric_prefix: str | None = None,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -219,7 +221,7 @@ class LLMGEvalScore(Metric):
         self.valid_score_range = valid_score_range
         self.category_key = category_key
         self.prob_threshold = prob_threshold
-
+        self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
         self.valid_labels = [str(score) for score in range(valid_score_range[0], valid_score_range[1] + 1)]
 
     def evaluate(
@@ -268,13 +270,13 @@ class LLMGEvalScore(Metric):
         )
 
         return MetricResult(
-            summary,
+            {self.metric_prefix + key: value for key, value in summary.items()},
             instance_details=[
                 {
-                    "llm_geval_score": eval_score,
-                    "llm_geval_score_input": eval_in,
-                    "llm_geval_score_logprobs": eval_logprobs,
-                    "llm_geval_score_generation_probs": eval_probs,
+                    f"{self.metric_prefix}llm_geval_score": eval_score,
+                    f"{self.metric_prefix}llm_geval_score_input": eval_in,
+                    f"{self.metric_prefix}llm_geval_score_logprobs": eval_logprobs,
+                    f"{self.metric_prefix}llm_geval_score_generation_probs": eval_probs,
                 }
                 for eval_score, eval_in, eval_logprobs, eval_probs in zip(
                     evaluator_score_list,
@@ -312,6 +314,7 @@ class ChatLLMGEvalScore(Metric):
             The category key is expected to be in extra_info.
         prob_threshold: For considering low probability among all of valid scores,
             return None (invalid) if sum of the all probability among vaild scores is less than this value.
+        metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
 
 
     Examples:
@@ -381,6 +384,7 @@ class ChatLLMGEvalScore(Metric):
         disable_tqdm: bool = False,
         category_key: str | None = None,
         prob_threshold: float = 0,
+        metric_prefix: str | None = None,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -390,7 +394,7 @@ class ChatLLMGEvalScore(Metric):
         self.valid_score_range = valid_score_range
         self.category_key = category_key
         self.prob_threshold = prob_threshold
-
+        self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
         self.valid_labels = [str(score) for score in range(valid_score_range[0], valid_score_range[1] + 1)]
 
     def evaluate(
@@ -437,13 +441,13 @@ class ChatLLMGEvalScore(Metric):
         )
 
         return MetricResult(
-            summary,
+            {self.metric_prefix + key: value for key, value in summary.items()},
             instance_details=[
                 {
-                    "llm_geval_score": eval_score,
-                    "llm_geval_score_input": eval_in,
-                    "llm_geval_score_logprobs": eval_logprobs,
-                    "llm_geval_score_generation_probs": eval_probs,
+                    f"{self.metric_prefix}llm_geval_score": eval_score,
+                    f"{self.metric_prefix}llm_geval_score_input": eval_in,
+                    f"{self.metric_prefix}llm_geval_score_logprobs": eval_logprobs,
+                    f"{self.metric_prefix}llm_geval_score_generation_probs": eval_probs,
                 }
                 for eval_score, eval_in, eval_logprobs, eval_probs in zip(
                     evaluator_score_list,

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -103,6 +103,7 @@ class LLMLabel(Metric):
         disable_tqdm: Whether to disable the progress bar.
         category_key: A key to create category-wise mean score.
             The category key is expected to be in extra_info.
+        metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
 
     Examples:
         >>> from flexeval import OpenAIChatAPI, Jinja2PromptTemplate, LLMLabel
@@ -144,6 +145,7 @@ class LLMLabel(Metric):
         disable_tqdm: bool = False,
         valid_score_range: tuple[int, int] | None = None,
         category_key: str | None = None,
+        metric_prefix: str | None = None,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -163,6 +165,7 @@ class LLMLabel(Metric):
         self.disable_tqdm = disable_tqdm
         self.valid_score_range = valid_score_range
         self.category_key = category_key
+        self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
 
     def evaluate(
         self,
@@ -207,13 +210,13 @@ class LLMLabel(Metric):
         )
 
         return MetricResult(
-            summary,
+            {self.metric_prefix + key: value for key, value in summary.items()},
             instance_details=[
                 {
-                    "llm_label": eval_label,
-                    "llm_score": eval_score,
-                    "llm_label_input": eval_in,
-                    "llm_label_output": eval_out.text,
+                    f"{self.metric_prefix}llm_label": eval_label,
+                    f"{self.metric_prefix}llm_score": eval_score,
+                    f"{self.metric_prefix}llm_label_input": eval_in,
+                    f"{self.metric_prefix}llm_label_output": eval_out.text,
                 }
                 for eval_label, eval_score, eval_in, eval_out in zip(
                     evaluator_label_list,
@@ -247,6 +250,7 @@ class ChatLLMLabel(Metric):
         disable_tqdm: Whether to disable the progress bar.
         category_key: A key to create category-wise mean score.
             The category key is expected to be in extra_info.
+        metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
 
     Examples:
         >>> from flexeval import ChatLLMScore, OpenAIChatAPI, Jinja2PromptTemplate
@@ -289,6 +293,7 @@ class ChatLLMLabel(Metric):
         batch_size: int = 4,
         disable_tqdm: bool = False,
         category_key: str | None = None,
+        metric_prefix: str | None = None,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -308,6 +313,7 @@ class ChatLLMLabel(Metric):
         self.batch_size = batch_size
         self.disable_tqdm = disable_tqdm
         self.category_key = category_key
+        self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
 
     def evaluate(
         self,
@@ -353,13 +359,13 @@ class ChatLLMLabel(Metric):
         )
 
         return MetricResult(
-            summary,
+            {self.metric_prefix + key: value for key, value in summary.items()},
             instance_details=[
                 {
-                    "llm_label": eval_label,
-                    "llm_score": eval_score,
-                    "llm_label_input": eval_in,
-                    "llm_label_output": eval_out.text,
+                    f"{self.metric_prefix}llm_label": eval_label,
+                    f"{self.metric_prefix}llm_score": eval_score,
+                    f"{self.metric_prefix}llm_label_input": eval_in,
+                    f"{self.metric_prefix}llm_label_output": eval_out.text,
                 }
                 for eval_label, eval_score, eval_in, eval_out in zip(
                     evaluator_label_list,

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -227,8 +227,8 @@ class LLMLabel(Metric):
             ],
         )
 
-    def resource_cleanup(self) -> None:
-        self.language_model.resource_cleanup()
+    def cleanup_resources(self) -> None:
+        self.language_model.cleanup_resources()
 
     def __repr__(self) -> str:
         return (
@@ -376,8 +376,8 @@ class ChatLLMLabel(Metric):
             ],
         )
 
-    def resource_cleanup(self) -> None:
-        self.language_model.resource_cleanup()
+    def cleanup_resources(self) -> None:
+        self.language_model.cleanup_resources()
 
     def __repr__(self) -> str:
         return (

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -224,6 +224,9 @@ class LLMLabel(Metric):
             ],
         )
 
+    def resource_cleanup(self) -> None:
+        self.language_model.resource_cleanup()
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(language_model={self.language_model}, prompt_template={self.prompt_template})"
@@ -366,6 +369,9 @@ class ChatLLMLabel(Metric):
                 )
             ],
         )
+
+    def resource_cleanup(self) -> None:
+        self.language_model.resource_cleanup()
 
     def __repr__(self) -> str:
         return (

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -181,6 +181,7 @@ class LLMScore(Metric):
             If the parsed score is out of the range, it will be ignored.
         category_key: A key to create category-wise mean score.
             The category key is expected to be in extra_info.
+        metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
 
     Examples:
         >>> from flexeval import LLMScore, OpenAIChatAPI, Jinja2PromptTemplate
@@ -214,6 +215,7 @@ class LLMScore(Metric):
         disable_tqdm: bool = False,
         valid_score_range: tuple[int, int] | None = None,
         category_key: str | None = None,
+        metric_prefix: str | None = None,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -221,6 +223,7 @@ class LLMScore(Metric):
         self.disable_tqdm = disable_tqdm
         self.valid_score_range = valid_score_range
         self.category_key = category_key
+        self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
 
     def evaluate(
         self,
@@ -260,9 +263,13 @@ class LLMScore(Metric):
         )
 
         return MetricResult(
-            summary,
+            {self.metric_prefix + key: value for key, value in summary.items()},
             instance_details=[
-                {"llm_score": eval_score, "llm_score_input": eval_in, "llm_score_output": eval_out.text}
+                {
+                    f"{self.metric_prefix}llm_score": eval_score,
+                    f"{self.metric_prefix}llm_score_input": eval_in,
+                    f"{self.metric_prefix}llm_score_output": eval_out.text,
+                }
                 for eval_score, eval_in, eval_out in zip(
                     evaluator_score_list,
                     evaluator_input_list,
@@ -294,6 +301,7 @@ class ChatLLMScore(Metric):
             If the parsed score is out of the range, it will be ignored.
         category_key: A key to create category-wise mean score.
             The category key is expected to be in extra_info.
+        metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
 
     Examples:
         >>> from flexeval import ChatLLMScore, OpenAIChatAPI, Jinja2PromptTemplate
@@ -329,6 +337,7 @@ class ChatLLMScore(Metric):
         disable_tqdm: bool = False,
         valid_score_range: tuple[int, int] | None = None,
         category_key: str | None = None,
+        metric_prefix: str | None = None,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -337,6 +346,7 @@ class ChatLLMScore(Metric):
         self.disable_tqdm = disable_tqdm
         self.valid_score_range = valid_score_range
         self.category_key = category_key
+        self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
 
     def evaluate(
         self,
@@ -374,9 +384,13 @@ class ChatLLMScore(Metric):
         )
 
         return MetricResult(
-            summary,
+            {self.metric_prefix + key: value for key, value in summary.items()},
             instance_details=[
-                {"llm_score": eval_score, "llm_score_input": eval_in, "llm_score_output": eval_out.text}
+                {
+                    f"{self.metric_prefix}llm_score": eval_score,
+                    f"{self.metric_prefix}llm_score_input": eval_in,
+                    f"{self.metric_prefix}llm_score_output": eval_out.text,
+                }
                 for eval_score, eval_in, eval_out in zip(
                     evaluator_score_list,
                     evaluator_input_list,

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -271,6 +271,9 @@ class LLMScore(Metric):
             ],
         )
 
+    def resource_cleanup(self) -> None:
+        self.language_model.resource_cleanup()
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(language_model={self.language_model}, prompt_template={self.prompt_template})"
@@ -381,6 +384,9 @@ class ChatLLMScore(Metric):
                 )
             ],
         )
+
+    def resource_cleanup(self) -> None:
+        self.language_model.resource_cleanup()
 
     def __repr__(self) -> str:
         return (

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -278,8 +278,8 @@ class LLMScore(Metric):
             ],
         )
 
-    def resource_cleanup(self) -> None:
-        self.language_model.resource_cleanup()
+    def cleanup_resources(self) -> None:
+        self.language_model.cleanup_resources()
 
     def __repr__(self) -> str:
         return (
@@ -399,8 +399,8 @@ class ChatLLMScore(Metric):
             ],
         )
 
-    def resource_cleanup(self) -> None:
-        self.language_model.resource_cleanup()
+    def cleanup_resources(self) -> None:
+        self.language_model.cleanup_resources()
 
     def __repr__(self) -> str:
         return (

--- a/tests/core/language_model/vllm/test_vllm_common.py
+++ b/tests/core/language_model/vllm/test_vllm_common.py
@@ -3,12 +3,12 @@ from typing import Callable
 
 import pytest
 
+from flexeval.core.language_model.base import LanguageModel
 from flexeval.core.language_model.vllm_model import (
     VLLM,
 )
 from tests.conftest import is_vllm_enabled
 from tests.core.language_model.base import BaseLanguageModelTest
-from tests.dummy_modules.tool_parser import DummyToolParser
 
 
 @pytest.fixture(scope="module")
@@ -33,26 +33,6 @@ def chat_lm() -> VLLM:
             "disable_custom_all_reduce": True,
         },
         tokenizer_kwargs={"use_fast": False},
-    )
-    yield llm
-    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
-
-    cleanup_dist_env_and_memory()
-
-
-@pytest.fixture(scope="module")
-def chat_lm_for_tool_calling() -> VLLM:
-    tool_parser = DummyToolParser()
-    llm = VLLM(
-        model="sbintuitions/tiny-lm-chat",
-        model_kwargs={
-            "seed": 42,
-            "gpu_memory_utilization": 0.1,
-            "enforce_eager": True,
-            "disable_custom_all_reduce": True,
-        },
-        tokenizer_kwargs={"use_fast": False},
-        tool_parser=tool_parser,
     )
     yield llm
     from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
@@ -89,6 +69,16 @@ class TestVLLM(BaseLanguageModelTest):
     def chat_lm(self, chat_lm: VLLM) -> VLLM:
         return chat_lm
 
-    @pytest.fixture()
-    def chat_lm_for_tool_calling(self, chat_lm_for_tool_calling: VLLM) -> VLLM:
-        return chat_lm_for_tool_calling
+    @pytest.mark.skip(reason="A larger, more high-performance model is required to test the behavior of Tool Calling.")
+    def test_generate_chat_response_single_input_with_tools(self, chat_lm_for_tool_calling: LanguageModel) -> None:
+        pass
+
+    @pytest.mark.skip(reason="A larger, more high-performance model is required to test the behavior of Tool Calling.")
+    def test_generate_chat_response_batch_input_with_tools(self, chat_lm_for_tool_calling: LanguageModel) -> None:
+        pass
+
+    @pytest.mark.skip(reason="A larger, more high-performance model is required to test the behavior of Tool Calling.")
+    def test_generate_chat_response_if_number_of_tools_and_messages_not_equal(
+        self, chat_lm_for_tool_calling: LanguageModel
+    ) -> None:
+        pass

--- a/tests/core/metric/test_llm_geval_score.py
+++ b/tests/core/metric/test_llm_geval_score.py
@@ -61,11 +61,13 @@ def test_calculate_weighted_average(
     assert score == expected_score
 
 
-def test_llm_geval_score() -> None:
+@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
+def test_llm_geval_score(metric_prefix: str | None) -> None:
     metric = LLMGEvalScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         valid_score_range=(1, 5),
+        metric_prefix=metric_prefix,
     )
     lm_outputs = [
         "[A] Output a number from 1 to 5.",
@@ -77,12 +79,13 @@ def test_llm_geval_score() -> None:
         lm_outputs=lm_outputs,
     )
 
+    metric_prefix = metric_prefix + "-" if metric_prefix else ""
     assert len(metric_output.summary) == 2
-    assert metric_output.summary["llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
-    assert metric_output.summary["num_failed_score_parses"] == 1
+    assert metric_output.summary[f"{metric_prefix}llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
+    assert metric_output.summary[f"{metric_prefix}num_failed_score_parses"] == 1
 
     for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_geval_score_input"] == lm_output
+        assert instance_detail[f"{metric_prefix}llm_geval_score_input"] == lm_output
 
 
 def test_llm_geval_score_with_category() -> None:
@@ -117,11 +120,13 @@ def test_llm_geval_score_with_category() -> None:
         assert instance_detail["llm_geval_score_input"] == lm_output
 
 
-def test_chat_llm_geval_score() -> None:
+@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
+def test_chat_llm_geval_score(metric_prefix: str | None) -> None:
     metric = ChatLLMGEvalScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         valid_score_range=(1, 5),
+        metric_prefix=metric_prefix,
     )
     lm_outputs = [
         "[A] Output a number from 1 to 5.",
@@ -133,12 +138,13 @@ def test_chat_llm_geval_score() -> None:
         lm_outputs=lm_outputs,
     )
 
+    metric_prefix = metric_prefix + "-" if metric_prefix else ""
     assert len(metric_output.summary) == 2
-    assert metric_output.summary["llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
-    assert metric_output.summary["num_failed_score_parses"] == 1
+    assert metric_output.summary[f"{metric_prefix}llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
+    assert metric_output.summary[f"{metric_prefix}num_failed_score_parses"] == 1
 
     for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_geval_score_input"] == [{"role": "user", "content": lm_output}]
+        assert instance_detail[f"{metric_prefix}llm_geval_score_input"] == [{"role": "user", "content": lm_output}]
 
 
 def test_chat_llm_geval_score_with_category() -> None:

--- a/tests/core/metric/test_llm_label.py
+++ b/tests/core/metric/test_llm_label.py
@@ -41,27 +41,30 @@ def test_parse_label_from_evaluator_output(
     assert label == expected_label
 
 
-def test_llm_label() -> None:
+@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
+def test_llm_label(metric_prefix: str | None) -> None:
     metric = LLMLabel(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],
+        metric_prefix=metric_prefix,
     )
     lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
     )
 
+    metric_prefix = metric_prefix + "-" if metric_prefix else ""
     assert metric_output.summary == {
-        "llm_score": 0.5,
-        "num_failed_score_parses": 1,
-        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+        f"{metric_prefix}llm_score": 0.5,
+        f"{metric_prefix}num_failed_score_parses": 1,
+        f"{metric_prefix}llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
     }
 
     for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_label_input"] == lm_output
-        assert instance_detail["llm_label_output"] == lm_output
+        assert instance_detail[f"{metric_prefix}llm_label_input"] == lm_output
+        assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output
 
 
 def test_llm_label_with_category() -> None:
@@ -99,27 +102,30 @@ def test_llm_label_with_category() -> None:
         assert instance_detail["llm_label_output"] == lm_output
 
 
-def test_chat_llm_label() -> None:
+@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
+def test_chat_llm_label(metric_prefix: str | None) -> None:
     metric = ChatLLMLabel(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],
+        metric_prefix=metric_prefix,
     )
     lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
     )
 
+    metric_prefix = metric_prefix + "-" if metric_prefix else ""
     assert metric_output.summary == {
-        "llm_score": 0.5,
-        "num_failed_score_parses": 1,
-        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+        f"{metric_prefix}llm_score": 0.5,
+        f"{metric_prefix}num_failed_score_parses": 1,
+        f"{metric_prefix}llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
     }
 
     for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_label_input"] == [{"role": "user", "content": lm_output}]
-        assert instance_detail["llm_label_output"] == lm_output
+        assert instance_detail[f"{metric_prefix}llm_label_input"] == [{"role": "user", "content": lm_output}]
+        assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output
 
 
 def test_chat_llm_label_with_category() -> None:

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -50,21 +50,24 @@ def test_parse_score_from_evaluator_output(
     assert score == expected_score
 
 
-def test_llm_score() -> None:
+@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
+def test_llm_score(metric_prefix: str | None) -> None:
     metric = LLMScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        metric_prefix=metric_prefix,
     )
     lm_outputs = ["This score is 1.", "This score is 2.", "This is a good one."]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
     )
 
-    assert metric_output.summary == {"llm_score": 1.5, "num_failed_score_parses": 1}
+    metric_prefix = metric_prefix + "-" if metric_prefix else ""
+    assert metric_output.summary == {f"{metric_prefix}llm_score": 1.5, f"{metric_prefix}num_failed_score_parses": 1}
 
     for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_score_input"] == lm_output
-        assert instance_detail["llm_score_output"] == lm_output
+        assert instance_detail[f"{metric_prefix}llm_score_input"] == lm_output
+        assert instance_detail[f"{metric_prefix}llm_score_output"] == lm_output
 
 
 @pytest.mark.parametrize(
@@ -120,21 +123,24 @@ def test_llm_score_with_category(
         assert instance_detail["llm_score_output"] == lm_output
 
 
-def test_chat_llm_score() -> None:
+@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
+def test_chat_llm_score(metric_prefix: str | None) -> None:
     metric = ChatLLMScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        metric_prefix=metric_prefix,
     )
     lm_outputs = ["This score is 1.", "This score is 2.", "This is a good one."]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
     )
 
-    assert metric_output.summary == {"llm_score": 1.5, "num_failed_score_parses": 1}
+    metric_prefix = metric_prefix + "-" if metric_prefix else ""
+    assert metric_output.summary == {f"{metric_prefix}llm_score": 1.5, f"{metric_prefix}num_failed_score_parses": 1}
 
     for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_score_input"] == [{"role": "user", "content": lm_output}]
-        assert instance_detail["llm_score_output"] == lm_output
+        assert instance_detail[f"{metric_prefix}llm_score_input"] == [{"role": "user", "content": lm_output}]
+        assert instance_detail[f"{metric_prefix}llm_score_output"] == lm_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR enhances support for using multiple LLM-as-a-Judge-style `Metric` classes (such as `ChatLLMScore`) within a single `EvalSetup`.
The main changes are as follows:

### 1. Unique Metric Key Prefixes

* Added a new `metric_prefix: str | None` argument into some `Metric`s to avoid key name collisions in `metrics.json` (e.g., `llm_score`).
* If you set `metric_prefix = "Qwen"`, the corresponding metric key will be `Qwen-llm_score` in `metrics.json`.

### 2. Efficient Resource Management for GPU-based Models

* For GPU-based LM classes like `VLLM`, loading multiple models simultaneously could previously cause OOM errors.
* To address this, model weights are now loaded lazily—only when a `_batch_generate*()` function is called for the first time.
* A new `cleanup_resources()` method has been added to both `Metric` and `LanguageModel` classes.
  This method can be used to release GPU memory and other resources, preventing unused models from occupying GPU memory unnecessarily.
