### PR TITLE
Refactor `evaluate_chat_response`

### DIFF
--- a/flexeval/core/chat_dataset/base.py
+++ b/flexeval/core/chat_dataset/base.py
@@ -109,13 +109,5 @@ class ChatDataset(Sequence[ChatInstance], ABC):
         """
         raise NotImplementedError
 
-    def require_incremental_response(self) -> bool:
-        """If true, the inputs consist of multiple user utterances and the
-        model should generate responses for each utterance incrementally.
-
-        Otherwise, the model just has to continue the conversation from the last user utterance.
-        """
-        return False
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(num_instances={len(self)})"

--- a/flexeval/core/chat_dataset/chatbot_bench.py
+++ b/flexeval/core/chat_dataset/chatbot_bench.py
@@ -98,9 +98,6 @@ class ChatbotBench(ChatDataset):
             "reasoning",
         ]
 
-    def require_incremental_response(self) -> bool:
-        return True
-
     def __len__(self) -> int:
         return len(self._id_to_question_id)
 

--- a/flexeval/core/chat_dataset/sacrebleu_dataset.py
+++ b/flexeval/core/chat_dataset/sacrebleu_dataset.py
@@ -18,9 +18,6 @@ class SacreBleuChatDataset(ChatDataset):
             msg = "The number of source and reference pairs should be the same."
             raise ValueError(msg)
 
-    def require_incremental_response(self) -> bool:
-        return False
-
     def __len__(self) -> int:
         return len(self._source_list)
 

--- a/flexeval/core/chat_dataset/template_based.py
+++ b/flexeval/core/chat_dataset/template_based.py
@@ -27,7 +27,6 @@ class TemplateChatDataset(ChatDataset):
             if the dataset has a single reference.
         reference_list_template: Specify the Jinja2 template to render a list of reference strings
             if the dataset has multiple references.
-        require_incremental_response: Whether the dataset requires incremental response.
         extra_info_templates: A dictionary of Jinja2 templates for extra information.
         system_message_template: A Jinja2 template for the system message.
         data_range: The range of data to use.
@@ -43,7 +42,6 @@ class TemplateChatDataset(ChatDataset):
         input_template: str,
         reference_template: str | None = None,
         reference_list_template: str | None = None,
-        require_incremental_response: bool = False,
         extra_info_templates: dict[str, str] | None = None,
         system_message_template: str | None = None,
         data_range: tuple[int, int] | None = None,
@@ -83,11 +81,6 @@ class TemplateChatDataset(ChatDataset):
         self._system_message_template: Template | None = (
             JINJA2_ENV.from_string(system_message_template) if system_message_template else None
         )
-
-        self._require_incremental_response = require_incremental_response
-
-    def require_incremental_response(self) -> bool:
-        return self._require_incremental_response
 
     def __len__(self) -> int:
         return len(self.items)
@@ -146,7 +139,6 @@ class HFChatDataset(TemplateChatDataset):
         dataset_kwargs: dict[str, Any] | None = None,
         reference_template: str | None = None,
         reference_list_template: str | None = None,
-        require_incremental_response: bool = False,
         extra_info_templates: dict[str, str] | None = None,
         system_message_template: str | None = None,
         data_range: tuple[int, int] | None = None,
@@ -162,7 +154,6 @@ class HFChatDataset(TemplateChatDataset):
             input_template=input_template,
             reference_template=reference_template,
             reference_list_template=reference_list_template,
-            require_incremental_response=require_incremental_response,
             extra_info_templates=extra_info_templates,
             system_message_template=system_message_template,
             data_range=data_range,
@@ -185,7 +176,6 @@ class JsonlChatDataset(TemplateChatDataset):
         input_template: str,
         reference_template: str | None = None,
         reference_list_template: str | None = None,
-        require_incremental_response: bool = False,
         extra_info_templates: dict[str, str] | None = None,
         system_message_template: str | None = None,
         data_range: tuple[int, int] | None = None,
@@ -200,7 +190,6 @@ class JsonlChatDataset(TemplateChatDataset):
             input_template=input_template,
             reference_template=reference_template,
             reference_list_template=reference_list_template,
-            require_incremental_response=require_incremental_response,
             extra_info_templates=extra_info_templates,
             system_message_template=system_message_template,
             data_range=data_range,

--- a/flexeval/core/eval_setups.py
+++ b/flexeval/core/eval_setups.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Sequence
 
 from .chat_dataset import ChatDataset
-from .evaluate_chat_response import evaluate_chat_response
+from .evaluate_chat_response import ChatInstance, evaluate_chat_response
 from .evaluate_generation import evaluate_generation
 from .evaluate_multiple_choice import evaluate_multiple_choice
 from .evaluate_perplexity import evaluate_perplexity
@@ -59,10 +59,14 @@ class ChatResponse(EvalSetup):
         if isinstance(metrics, Metric):
             metrics = [metrics]
 
+        eval_instances: Sequence[ChatInstance] = self.eval_dataset
+        if self.max_instances is not None:
+            eval_instances = [self.eval_dataset[i] for i in range(min(self.max_instances, len(self.eval_dataset)))]
+
         return evaluate_chat_response(
             language_model=language_model,
             gen_kwargs=self.gen_kwargs,
-            eval_dataset=self.eval_dataset,
+            eval_instances=eval_instances,
             metrics=metrics,
             batch_size=self.batch_size,
             max_instances=self.max_instances,

--- a/flexeval/core/eval_setups.py
+++ b/flexeval/core/eval_setups.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any
 
 from .chat_dataset import ChatDataset
-from .evaluate_chat_response import ChatInstance, evaluate_chat_response
+from .evaluate_chat_response import evaluate_chat_response
 from .evaluate_generation import evaluate_generation
 from .evaluate_multiple_choice import evaluate_multiple_choice
 from .evaluate_perplexity import evaluate_perplexity
@@ -59,15 +59,10 @@ class ChatResponse(EvalSetup):
         if isinstance(metrics, Metric):
             metrics = [metrics]
 
-        eval_instances: Sequence[ChatInstance] = self.eval_dataset
-        if self.max_instances is not None:
-            eval_instances = [self.eval_dataset[i] for i in range(min(self.max_instances, len(self.eval_dataset)))]
-
         return evaluate_chat_response(
             language_model=language_model,
             gen_kwargs=self.gen_kwargs,
-            eval_instances=eval_instances,
-            require_incremental_response=self.eval_dataset.require_incremental_response(),
+            eval_dataset=self.eval_dataset,
             metrics=metrics,
             batch_size=self.batch_size,
             max_instances=self.max_instances,

--- a/flexeval/core/eval_setups.py
+++ b/flexeval/core/eval_setups.py
@@ -67,6 +67,7 @@ class ChatResponse(EvalSetup):
             language_model=language_model,
             gen_kwargs=self.gen_kwargs,
             eval_instances=eval_instances,
+            require_incremental_response=self.eval_dataset.require_incremental_response(),
             metrics=metrics,
             batch_size=self.batch_size,
             max_instances=self.max_instances,

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -80,7 +80,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
                     input_messages_list[input_id] = [*meta_messages, *few_shot_messages, *real_messages]
                     offsets_to_first_turn[input_id] += len(few_shot_messages)
 
-            if not eval_dataset.require_incremental_response():
+            if not require_incremental_response:
                 # Continue generation from the given conversation history
                 lm_outputs: list[LMOutput] = language_model.generate_chat_response(
                     input_messages_list,

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 from flexeval.core.language_model.base import LMOutput
 from flexeval.core.utils.chat_util import find_first_turn_for_response
 
-from .chat_dataset import ChatDataset, ChatInstance
+from .chat_dataset import ChatInstance
 from .few_shot_generator import FewShotGenerator
 from .language_model import LanguageModel
 from .metric import Metric
@@ -34,18 +34,12 @@ def _remove_redundant_keys_from_messages(
 def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
     language_model: LanguageModel,
     gen_kwargs: dict[str, Any],
-    eval_dataset: ChatDataset,
+    eval_instances: Sequence[ChatInstance],
     metrics: list[Metric],
     batch_size: int,
-    max_instances: int | None = None,
     few_shot_generator: FewShotGenerator | None = None,
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     logger.info(f"Evaluate the model with gen_kwargs: {gen_kwargs}")
-
-    # Load the evaluation dataset
-    eval_instances: Sequence[ChatInstance] = eval_dataset
-    if max_instances is not None:
-        eval_instances = [eval_dataset[i] for i in range(min(max_instances, len(eval_dataset)))]
 
     # Generate responses for each instance
     all_messages_list: list[list[dict[str, Any]]] = []

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -6,7 +6,6 @@ from typing import Any, Iterable, Sequence
 from loguru import logger
 from tqdm import tqdm
 
-from flexeval.core.language_model.base import LMOutput
 from flexeval.core.utils.chat_util import find_first_turn_for_response
 
 from .chat_dataset import ChatInstance
@@ -56,16 +55,46 @@ def add_few_shot_messages_to_chat_instance(chat_instance: ChatInstance, few_shot
     ]
 
 
+def find_response_context_index(incomplete_messages: list[dict[str, Any]]) -> int | None:
+    """
+    Finds the index after the earliest message that requires an assistant response.
+
+    Specifically, it looks for the first message from a role that expects an assistant reply
+    ('user' or 'tool') that is not followed by an 'assistant' message.
+
+    Returns:
+        The index to slice messages up to (exclusive of that index), or None if no reply is needed.
+        Use as: incomplete_messages[:index]
+    """
+    expected_roles = {"user", "tool"}
+
+    for i in range(len(incomplete_messages) - 1):
+        current = incomplete_messages[i]
+        next_msg = incomplete_messages[i + 1]
+        if current["role"] in expected_roles and next_msg["role"] != "assistant":
+            return i + 1
+
+    # Check if the last message expects a response
+    if incomplete_messages and incomplete_messages[-1]["role"] in expected_roles:
+        return len(incomplete_messages)
+
+    return None
+
+
 def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
     language_model: LanguageModel,
     gen_kwargs: dict[str, Any],
-    eval_instances: Sequence[ChatInstance],
-    require_incremental_response: bool,
+    eval_dataset: Sequence[ChatInstance],
     metrics: list[Metric],
     batch_size: int,
     few_shot_generator: FewShotGenerator | None = None,
+    max_instances: int | None = None,
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     logger.info(f"Evaluate the model with gen_kwargs: {gen_kwargs}")
+
+    eval_instances: Sequence[ChatInstance] = eval_dataset
+    if max_instances is not None:
+        eval_instances = [eval_dataset[i] for i in range(min(max_instances, len(eval_instances)))]
 
     if few_shot_generator:
         for eval_instance in eval_instances:
@@ -78,92 +107,49 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
     all_input_tools_list: list[list[dict[str, Any]] | None] = []
     with tqdm(total=len(eval_instances)) as pbar:
         for batch_id, batch in enumerate(batch_iter(eval_instances, batch_size)):
-            input_messages_list = [chat_instance.messages for chat_instance in batch]
-            input_tools_list = [chat_instance.tools for chat_instance in batch]
-            all_input_tools_list += input_tools_list
-            if all(tools is None for tools in input_tools_list):
-                input_tools_list = None
-
-            # For the `require_incremental_response==True` case,
-            # it is necessary to identify the first turn that should be responded, excluding system messages, etc.
-            offsets_to_first_turn = [find_first_turn_for_response(messages) for messages in input_messages_list]
-
-            if not require_incremental_response:
-                # Continue generation from the given conversation history
-                lm_outputs: list[LMOutput] = language_model.generate_chat_response(
-                    input_messages_list,
-                    tools=input_tools_list,
+            # Copy the input messages as current_chat_history
+            # We will populate this history with llm
+            current_chat_history: list[list[dict[str, Any]]] = [[*chat_instance.messages] for chat_instance in batch]
+            response_context_indices = [
+                find_response_context_index(chat_history) for chat_history in current_chat_history
+            ]
+            while any(idx is not None for idx in response_context_indices):
+                batch_inputs = [
+                    _remove_redundant_keys_from_messages(
+                        current_chat_history[batch_i][:message_i],
+                        remove_keys={"finish_reason", "raw_content", "tool_call_validation_result"},
+                    )
+                    for batch_i, message_i in enumerate(response_context_indices)
+                    if message_i is not None
+                ]
+                ids_fed_to_lm = [i for i, idx in enumerate(response_context_indices) if idx is not None]
+                lm_outputs = language_model.generate_chat_response(
+                    batch_inputs,
+                    tools=[batch[i].tools for i in ids_fed_to_lm],
                     **gen_kwargs,
                 )
-                for input_messages, lm_output in zip(input_messages_list, lm_outputs):
-                    all_messages_list.append(
-                        [
-                            *input_messages,
-                            {
-                                "role": "assistant",
-                                "content": lm_output.text,
-                                "finish_reason": lm_output.finish_reason,
-                            }
-                            | ({"raw_content": lm_output.raw_text} if lm_output.raw_text else {})
-                            | ({"tool_calls": lm_output.tool_calls} if lm_output.tool_calls else {})
-                            | (
-                                {"tool_call_validation_result": lm_output.tool_call_validation_result}
-                                if lm_output.tool_call_validation_result
-                                else {}
-                            ),
-                        ],
+                for lm_output, batch_i in zip(lm_outputs, ids_fed_to_lm):
+                    lm_output_message = (
+                        {
+                            "role": "assistant",
+                            "content": lm_output.text,
+                            "finish_reason": lm_output.finish_reason,
+                        }
+                        | ({"raw_content": lm_output.raw_text} if lm_output.raw_text else {})
+                        | ({"tool_calls": lm_output.tool_calls} if lm_output.tool_calls else {})
+                        | (
+                            {"tool_call_validation_result": lm_output.tool_call_validation_result}
+                            if lm_output.tool_call_validation_result
+                            else {}
+                        )
                     )
-            else:
-                # In incremental response generation,
-                # the input messages are supposed to be the user messages across turns.
-                # The model first responses to the first user message, then add its response to the chat history,
-                # and responses to the next user message, and so on.
-                max_num_turns = max(
-                    len(messages) - offset for messages, offset in zip(input_messages_list, offsets_to_first_turn)
-                )
-                current_chat_history: list[list[dict[str, Any]]] = [
-                    input_messages[:offset]
-                    for input_messages, offset in zip(input_messages_list, offsets_to_first_turn)
+                    current_chat_history[batch_i].insert(response_context_indices[batch_i], lm_output_message)
+                response_context_indices = [
+                    find_response_context_index(chat_history) for chat_history in current_chat_history
                 ]
-                # perform generation for each turn
-                for turn in range(max_num_turns):
-                    batch_ids_fed_to_model = [
-                        b_id
-                        for b_id, messages in enumerate(input_messages_list)
-                        if turn < (len(messages) - offsets_to_first_turn[b_id])
-                    ]
-                    current_model_inputs = [
-                        _remove_redundant_keys_from_messages(
-                            current_chat_history[b_id]
-                            + [input_messages_list[b_id][turn + offsets_to_first_turn[b_id]]],
-                            remove_keys={"finish_reason", "raw_content", "tool_call_validation_result"},
-                        )
-                        for b_id in batch_ids_fed_to_model
-                    ]
-                    lm_outputs = language_model.generate_chat_response(
-                        current_model_inputs,
-                        tools=[input_tools_list[b_id] for b_id in batch_ids_fed_to_model] if input_tools_list else None,
-                        **gen_kwargs,
-                    )
-                    for o_id, b_id in enumerate(batch_ids_fed_to_model):
-                        offset = offsets_to_first_turn[b_id]
-                        current_chat_history[b_id].append(input_messages_list[b_id][turn + offset])
-                        current_chat_history[b_id].append(
-                            {
-                                "role": "assistant",
-                                "content": lm_outputs[o_id].text,
-                                "finish_reason": lm_outputs[o_id].finish_reason,
-                            }
-                            | ({"raw_content": lm_outputs[o_id].raw_text} if lm_outputs[o_id].raw_text else {})
-                            | ({"tool_calls": lm_outputs[o_id].tool_calls} if lm_outputs[o_id].tool_calls else {})
-                            | (
-                                {"tool_call_validation_result": lm_outputs[o_id].tool_call_validation_result}
-                                if lm_outputs[o_id].tool_call_validation_result
-                                else {}
-                            ),
-                        )
-                all_messages_list += current_chat_history
 
+            all_messages_list += current_chat_history
+            all_input_tools_list += [chat_instance.tools for chat_instance in batch]
             references_list += [chat_instance.references for chat_instance in batch]
             extra_info_list += [chat_instance.extra_info for chat_instance in batch]
 

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -35,6 +35,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
     language_model: LanguageModel,
     gen_kwargs: dict[str, Any],
     eval_instances: Sequence[ChatInstance],
+    require_incremental_response: bool,
     metrics: list[Metric],
     batch_size: int,
     few_shot_generator: FewShotGenerator | None = None,

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -30,7 +30,7 @@ def _remove_redundant_keys_from_messages(
     return [{key: value for key, value in message.items() if key not in remove_keys} for message in messages]
 
 
-def add_few_shot_messages_to_chat_instance(chat_instance: ChatInstance, few_shot_generator: FewShotGenerator) -> None:
+def _add_few_shot_messages_to_chat_instance(chat_instance: ChatInstance, few_shot_generator: FewShotGenerator) -> None:
     """Add few-shot examples to a chat instance by inserting them before the first user message.
     Note that it updates ChatInstance in-place.
     """
@@ -55,7 +55,7 @@ def add_few_shot_messages_to_chat_instance(chat_instance: ChatInstance, few_shot
     ]
 
 
-def find_response_context_index(incomplete_messages: list[dict[str, Any]]) -> int | None:
+def _find_response_context_index(incomplete_messages: list[dict[str, Any]]) -> int | None:
     """
     Finds the index after the earliest message that requires an assistant response.
 
@@ -98,7 +98,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
 
     if few_shot_generator:
         for eval_instance in eval_instances:
-            add_few_shot_messages_to_chat_instance(eval_instance, few_shot_generator)
+            _add_few_shot_messages_to_chat_instance(eval_instance, few_shot_generator)
 
     # Generate responses for each instance
     all_messages_list: list[list[dict[str, Any]]] = []
@@ -111,7 +111,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
             # We will populate this history with llm
             current_chat_history: list[list[dict[str, Any]]] = [[*chat_instance.messages] for chat_instance in batch]
             response_context_indices = [
-                find_response_context_index(chat_history) for chat_history in current_chat_history
+                _find_response_context_index(chat_history) for chat_history in current_chat_history
             ]
             while any(idx is not None for idx in response_context_indices):
                 batch_inputs = [
@@ -145,7 +145,7 @@ def evaluate_chat_response(  # noqa: C901,PLR0912, PLR0915
                     )
                     current_chat_history[batch_i].insert(response_context_indices[batch_i], lm_output_message)
                 response_context_indices = [
-                    find_response_context_index(chat_history) for chat_history in current_chat_history
+                    _find_response_context_index(chat_history) for chat_history in current_chat_history
                 ]
 
             all_messages_list += current_chat_history

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from flexeval.core.evaluate_chat_response import evaluate_chat_response
+from flexeval.core.few_shot_generator import RandomFewShotGenerator
+from tests.dummy_modules import (
+    DummyChatDataset,
+    DummyLanguageModel,
+)
+
+
+@pytest.mark.parametrize(
+    ("use_few_shot", "max_instances", "use_tools", "batch_size"),
+    list(itertools.product([True, False], [None, 1], [True, False], [1, 3])),
+)
+def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int) -> None:
+    few_shot_generator = None
+    if use_few_shot:
+        few_shot_generator = RandomFewShotGenerator(dataset=DummyChatDataset(), num_shots=1, num_trials_to_avoid_leak=0)
+
+    metrics, outputs = evaluate_chat_response(
+        language_model=DummyLanguageModel(),
+        gen_kwargs={},
+        eval_dataset=DummyChatDataset(
+            use_tools=use_tools,
+        ),
+        few_shot_generator=few_shot_generator,
+        metrics=[],
+        batch_size=batch_size,
+        max_instances=max_instances,
+    )
+    assert isinstance(metrics, dict)
+    assert metrics["finish_reason_ratio-length"] == 1.0
+    assert isinstance(outputs, list)
+
+    if max_instances is not None:
+        assert len(outputs) <= max_instances
+
+    # If the system message in "messages", few-shot examples should be inserted after the system message.
+    # Therefore, in any case the system message should be in the first turn.
+    assert outputs[0]["extra_info"]["messages"][0]["role"] == "system"
+
+    if use_tools:
+        assert isinstance(outputs[0]["extra_info"]["tool_calls"], list)
+        assert isinstance(outputs[0]["extra_info"]["tools"], list)
+        assert metrics["tool_call_validation_result_ratio-CompleteToolCall"] == 1.0
+    else:
+        assert "tool_calls" not in outputs[0]["extra_info"]
+        assert "tools" not in outputs[0]["extra_info"]
+        assert metrics["tool_call_validation_result_ratio-TextOnly"] == 1.0

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -4,7 +4,12 @@ import itertools
 
 import pytest
 
-from flexeval.core.evaluate_chat_response import evaluate_chat_response
+from flexeval.core.chat_dataset import ChatInstance
+from flexeval.core.evaluate_chat_response import (
+    _add_few_shot_messages_to_chat_instance,
+    _find_response_context_index,
+    evaluate_chat_response,
+)
 from flexeval.core.few_shot_generator import RandomFewShotGenerator
 from tests.dummy_modules import (
     DummyChatDataset,
@@ -51,3 +56,101 @@ def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tool
         assert "tool_calls" not in outputs[0]["extra_info"]
         assert "tools" not in outputs[0]["extra_info"]
         assert metrics["tool_call_validation_result_ratio-TextOnly"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected"),
+    [
+        # User message at end requires response
+        (
+            [
+                {"role": "system", "content": "You are a helpful assistant"},
+                {"role": "user", "content": "Hello"},
+            ],
+            2,
+        ),
+        # User message followed by assistant message - no response needed
+        (
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+            None,
+        ),
+        # User message not followed by assistant message
+        (
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "user", "content": "Are you there?"},
+            ],
+            1,
+        ),
+        # Tool message requires response
+        (
+            [
+                {"role": "user", "content": "What's the weather?"},
+                {"role": "assistant", "content": "Let me check that for you."},
+                {"role": "tool", "content": "Weather data"},
+            ],
+            3,
+        ),
+        # Tool message followed by assistant message (unnatural, though)
+        (
+            [
+                {"role": "user", "content": "What's the weather?"},
+                {"role": "tool", "content": "Weather data"},
+                {"role": "assistant", "content": "It's sunny!"},
+            ],
+            1,
+        ),
+        # Empty messages list
+        ([], None),
+        # Only system messages (invalid structure)
+        (
+            [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "system", "content": "Be concise"},
+            ],
+            None,
+        ),
+        # First user message not followed by assistant (unnatural, but possible)
+        (
+            [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hello"},
+                {"role": "user", "content": "Second message"},
+                {"role": "assistant", "content": "Response to second"},
+            ],
+            2,
+        ),
+    ],
+)
+def test_find_response_context_index(messages: list[dict[str, str]], expected: int | None) -> None:
+    assert _find_response_context_index(messages) == expected
+
+
+def test_add_few_shot_messages_to_chat_instance() -> None:
+    chat_instance = ChatInstance(
+        messages=[{"role": "system", "content": "You are a helpful assistant"}, {"role": "user", "content": "Hello"}],
+        references=["Expected response"],
+        extra_info={},
+    )
+
+    few_shot_generator = RandomFewShotGenerator(
+        dataset=DummyChatDataset(),
+        num_shots=1,
+    )
+
+    original_length = len(chat_instance.messages)
+    _add_few_shot_messages_to_chat_instance(chat_instance, few_shot_generator)
+
+    # Should have more messages after adding few-shot examples
+    assert len(chat_instance.messages) > original_length
+
+    # System message should still be first
+    assert chat_instance.messages[0]["role"] == "system"
+    assert chat_instance.messages[0]["content"] == "You are a helpful assistant"
+
+    # Original user message should still be present at the end
+    assert chat_instance.messages[-1]["role"] == "user"
+    assert chat_instance.messages[-1]["content"] == "Hello"

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -28,12 +28,10 @@ from tests.dummy_modules.reward_lm import DummyRewardLanguageModel
 
 
 @pytest.mark.parametrize(
-    ("require_incremental_response", "use_few_shot", "max_instances", "use_tools", "batch_size"),
-    list(itertools.product([True, False], [True, False], [None, 1], [True, False], [1, 3])),
+    ("use_few_shot", "max_instances", "use_tools", "batch_size"),
+    list(itertools.product([True, False], [None, 1], [True, False], [1, 3])),
 )
-def test_evaluate_chat_response(
-    require_incremental_response: bool, use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int
-) -> None:
+def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int) -> None:
     few_shot_generator = None
     if use_few_shot:
         few_shot_generator = RandomFewShotGenerator(dataset=DummyChatDataset(), num_shots=1, num_trials_to_avoid_leak=0)
@@ -42,7 +40,6 @@ def test_evaluate_chat_response(
         language_model=DummyLanguageModel(),
         gen_kwargs={},
         eval_dataset=DummyChatDataset(
-            require_incremental_response=require_incremental_response,
             use_tools=use_tools,
         ),
         few_shot_generator=few_shot_generator,

--- a/tests/dummy_modules/lm.py
+++ b/tests/dummy_modules/lm.py
@@ -29,7 +29,6 @@ class DummyLanguageModel(LanguageModel):
         tools_list: list[list[dict[str, Any]]] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
-        kwargs_as_text = json.dumps(kwargs)
 
         tool_calls_list = [None for _ in chat_messages_list]
         if tools_list:

--- a/tests/dummy_modules/lm.py
+++ b/tests/dummy_modules/lm.py
@@ -29,7 +29,6 @@ class DummyLanguageModel(LanguageModel):
         tools_list: list[list[dict[str, Any]]] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
-
         tool_calls_list = [None for _ in chat_messages_list]
         if tools_list:
             for i, tools in enumerate(tools_list):

--- a/tests/dummy_modules/lm.py
+++ b/tests/dummy_modules/lm.py
@@ -29,7 +29,6 @@ class DummyLanguageModel(LanguageModel):
         tools_list: list[list[dict[str, Any]]] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
-        messages_as_text = [json.dumps(messages) for messages in chat_messages_list]
         kwargs_as_text = json.dumps(kwargs)
 
         tool_calls_list = [None for _ in chat_messages_list]
@@ -44,10 +43,10 @@ class DummyLanguageModel(LanguageModel):
 
         return [
             LMOutput(
-                text=m + kwargs_as_text,
+                text=f"This is response to `{messages[-1]['content']}` with kwargs {kwargs}",
                 finish_reason="length",
                 tool_calls=tc,
                 tool_call_validation_result="CompleteToolCall" if tc else "TextOnly",
             )
-            for m, tc in zip(messages_as_text, tool_calls_list)
+            for messages, tc in zip(chat_messages_list, tool_calls_list)
         ]


### PR DESCRIPTION
### Key Changes

Simplified the `evaluate_chat_response` function by...
  * Removed the `require_incremental_response` flag and associated methods from all chat dataset classes.
    * The function now automatically find where to insert the model response by looking at the structure of messages.
  * Extracted few-shot example insertion into `add_few_shot_messages_to_chat_instance`, streamlining the evaluation flow.
 
The operation of inserting the model response works like this:
```
[
   {"role": "system", "content": "..."},
   {"role": "user", "content": "..."},
   # Insert the response here
   {"role": "user", "content": "..."},
   # Insert the response here
]

[
   {"role": "system", "content": "..."},
   {"role": "user", "content": "..."},
   {"role": "assistant", "content": "..."},
   {"role": "user", "content": "..."},
   # Insert the response here
]
```

I've confirmed no degradation in running some benchmarks.
