### PR TITLE
Fix errors when using gpt-5 via `OpenAIChatAPI`

### DIFF
--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -365,6 +365,8 @@ class OpenAICompletionAPI(LanguageModel):
                 gen_kwargs.pop("stop_sequences", None),  # This is a common variable name used in flexeval
             ],
         )
+        if stop_sequences:
+            gen_kwargs["stop"] = stop_sequences
 
         tasks = [
             _retry_on_error(
@@ -373,7 +375,6 @@ class OpenAICompletionAPI(LanguageModel):
                 openai_call=lambda x=ms: self.api_call_func(
                     model=self.model,
                     prompt=x,
-                    stop=stop_sequences or NotGiven(),
                     **gen_kwargs,
                 ),
                 empty_response=self.empty_response,


### PR DESCRIPTION
gpt-5 は `stop` パラメータをサポートしない（`NotGiven()` を渡しても怒られる）ので、`stop_sequences` が空の場合はそもそも `stop` パラメータを渡さないようなロジックに修正します。
```bash
0: 2025-08-08 10:26:16.361 | WARNING | flexeval.core.language_model.openai_api:_retry_on_error:56 - We got an error: Error code: 400 - {'error': {'message': "Unsupported parameter: 'stop' is not supported with this model.", 'type': 'invalid_request_error', 'param': 'stop', 'code': 'unsupported_parameter'}}
```
`OpenAIChatBatchAPI` の方は元々そういうロジックなので修正の必要はなさそうです（が、別の原因でエラーが出ることを確認済みです😢）


