### PR TITLE
Allow case both text and tools are empty

### DIFF
--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, final
 
+from loguru import logger
+
 from flexeval.core.string_processor import StringProcessor
 
 
@@ -34,9 +36,11 @@ class LMOutput:
     """
 
     def __post_init__(self) -> None:
-        if self.tool_calls is None and self.text is None:
-            msg = "It is not allowed for both `text` and `tool_calls` to be None."
-            raise ValueError(msg)
+        if self.text is None:
+            self.text = ""
+            if self.tool_calls is None:
+                msg = "Both `text` and `tool_calls` are empty."
+                logger.warning(msg)
 
 
 class LanguageModel:

--- a/tests/core/language_model/test_base.py
+++ b/tests/core/language_model/test_base.py
@@ -1,0 +1,36 @@
+import logging
+
+from flexeval.core.language_model.base import LMOutput
+
+
+def test_lmoutput_text_only() -> None:
+    output = LMOutput(text="hello world")
+    assert output.text == "hello world"
+    assert output.raw_text is None
+    assert output.finish_reason is None
+    assert output.tool_calls is None
+    assert output.tool_call_validation_result is None
+
+
+def test_lmoutput_tool_calls_with_text() -> None:
+    text = "This is a text."
+    tool_calls = [{"name": "tool1", "args": {}}]
+    output = LMOutput(text=text, tool_calls=tool_calls)
+    assert output.text == text
+    assert output.tool_calls == tool_calls
+
+
+def test_lmoutput_tool_calls_without_text() -> None:
+    tool_calls = [{"name": "tool1", "args": {}}]
+    output = LMOutput(text=None, tool_calls=tool_calls)
+    assert output.text == ""
+    assert output.tool_calls == tool_calls
+
+
+def test_lmoutput_empty_text_and_tool_calls(caplog) -> None:  # noqa: ANN001
+    caplog.set_level(logging.WARNING)
+    output = LMOutput(text=None, tool_calls=None)
+    assert output.text == ""
+    assert output.tool_calls is None
+    assert len(caplog.records) >= 1
+    assert any(record.msg.startswith("Both `text` and `tool_calls` are empty.") for record in caplog.records)


### PR DESCRIPTION
Some models, such as Gemini, occasionally return responses where both `content` and `tool_calls` are `None`.
In some cases, this can be avoided by adjusting parameter settings, but it is not completely preventable.
Since such cases are rare, we will modify `LMOutput` to allow both to be `None` (in which case text will be converted to an empty string).