### PR TITLE
Fix pairwise evaluation of reward model

### DIFF
--- a/flexeval/core/reward_model/pairwise_judge_reward_model.py
+++ b/flexeval/core/reward_model/pairwise_judge_reward_model.py
@@ -40,6 +40,44 @@ def evaluate_model_output(model_output: str, gold_label: PairwiseChoice) -> bool
     return False
 
 
+def aggregate_judge_results(
+    outputs: list[dict],
+    judge_outputs: list,
+    chosen_is_better_list: list[bool],
+) -> tuple[list[bool], list[dict]]:
+    """
+    Aggregates the doubled-length `judge_outputs` and `chosen_is_better_list` into final results for each individual instance.
+
+    Returns:
+        final_results: list[bool]
+            A list indicating whether each instance is ultimately judged as correct.
+    """
+    aggregated_results: list[bool] = []
+    aggregated_outputs: list[dict] = []
+
+    for i, output in enumerate(outputs):
+        ab_output_text = judge_outputs[i * 2].text
+        ba_output_text = judge_outputs[i * 2 + 1].text
+        ab_eval = chosen_is_better_list[i * 2]
+        ba_eval = chosen_is_better_list[i * 2 + 1]
+
+        consistent = ab_eval == ba_eval
+        final_is_correct = consistent and ab_eval
+
+        aggregated_outputs.append(
+            {
+                "llm_outputs": [ab_output_text, ba_output_text],
+                "evaluation_results": [ab_eval, ba_eval],
+                "consistent": consistent,
+                "final_is_correct": final_is_correct,
+                **output,
+            }
+        )
+        aggregated_results.append(final_is_correct)
+
+    return aggregated_results, aggregated_outputs
+
+
 class PairwiseJudgeRewardModel(RewardModel):
     """Pairwise judge using a chat language model to compare two model or human
     outputs.
@@ -93,6 +131,7 @@ class PairwiseJudgeRewardModel(RewardModel):
         all_pairwise_instances: list[PairwiseInstance] = []
         outputs: list[dict[str, Any]] = []
         for reward_bench_instance in batch_reward_bench_instances:
+            # to address position biases, create two inputs by swapping chosen/rejected orderings
             pairwise_instance_answer_a_is_chosen = PairwiseInstance(
                 prompt=reward_bench_instance.prompt,
                 answer_a=reward_bench_instance.chosen,
@@ -130,8 +169,6 @@ class PairwiseJudgeRewardModel(RewardModel):
             msg = "The number of outputs should be twice the number of inputs."
             raise ValueError(msg)
 
-        for i in range(len(outputs)):
-            outputs[i]["llm_outputs"] = [judge_outputs[i * 2].text, judge_outputs[i * 2 + 1].text]
-            outputs[i]["evaluation_results"] = [chosen_is_better_list[i * 2], chosen_is_better_list[i * 2 + 1]]
+        aggregated_results, aggregated_outputs = aggregate_judge_results(outputs, judge_outputs, chosen_is_better_list)
 
-        return chosen_is_better_list, outputs
+        return aggregated_results, aggregated_outputs

--- a/tests/core/reward_model/test_pairwise_judge_reward_model.py
+++ b/tests/core/reward_model/test_pairwise_judge_reward_model.py
@@ -1,6 +1,14 @@
 import pytest
 
-from flexeval.core.reward_model.pairwise_judge_reward_model import PairwiseChoice, evaluate_model_output
+from flexeval import Jinja2PromptTemplate
+from flexeval.core.reward_bench_dataset import RewardBenchInstance
+from flexeval.core.reward_model.pairwise_judge_reward_model import (
+    PairwiseChoice,
+    PairwiseJudgeRewardModel,
+    aggregate_judge_results,
+    evaluate_model_output,
+)
+from tests.dummy_modules import DummyRewardLanguageModel
 
 
 @pytest.mark.parametrize(
@@ -23,3 +31,67 @@ from flexeval.core.reward_model.pairwise_judge_reward_model import PairwiseChoic
 def test_evaluate_model_output(model_output: str, gold_label: PairwiseChoice, expected: bool) -> None:
     result = evaluate_model_output(model_output, gold_label)
     assert result is expected
+
+
+@pytest.mark.parametrize(("num_samples"), [1, 10, 100])
+def test_pairwise_judge_reward_model(num_samples: int):
+    reward_model = PairwiseJudgeRewardModel(
+        language_model=DummyRewardLanguageModel(),
+        prompt_template=Jinja2PromptTemplate(template="{{ prompt }}\t{{ answer_a }}\t{{ answer_b }}"),
+    )
+
+    instances = [
+        RewardBenchInstance(
+            prompt=[{"role": "user", "content": "How is the weather today"}],
+            chosen=[{"role": "assistant", "content": "Sunny"}],
+            rejected=[{"role": "assistant", "content": "I don't know"}],
+        )
+    ] * num_samples
+
+    final_results, outputs = reward_model.batch_judge(instances)
+    assert len(final_results) == num_samples
+    assert len(outputs) == num_samples
+    assert not any(final_results), "All evaluation results should be False"
+
+
+class _MockOut:
+    """dummy judge_output element with text field"""
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+@pytest.mark.parametrize(
+    ("pairs", "expected_finals", "expected_consistencies"),
+    [
+        (
+            [(True, True), (True, False)],
+            [True, False],
+            [True, False],
+        ),
+        (
+            [(False, False), (False, True)],
+            [False, False],
+            [True, False],
+        ),
+    ],
+)
+def test_aggregate_multiple_instances(pairs: list, expected_finals: list, expected_consistencies: list):
+    n = len(pairs)
+    outputs = [{"llm_inputs": [f"ab_{i}", f"ba_{i}"]} for i in range(n)]
+
+    judge_outputs = []
+    chosen_is_better_list = []
+    for i, (ab_eval, ba_eval) in enumerate(pairs):
+        judge_outputs.append(_MockOut(f"ab_text_{i}"))
+        judge_outputs.append(_MockOut(f"ba_text_{i}"))
+        chosen_is_better_list.extend([ab_eval, ba_eval])
+
+    final_results, final_outputs = aggregate_judge_results(outputs, judge_outputs, chosen_is_better_list)
+
+    assert final_results == expected_finals
+    for i in range(n):
+        assert final_outputs[i]["consistent"] == expected_consistencies[i]
+        assert final_outputs[i]["final_is_correct"] == expected_finals[i]
+        assert final_outputs[i]["llm_outputs"] == [f"ab_text_{i}", f"ba_text_{i}"]
+        assert final_outputs[i]["evaluation_results"] == list(pairs[i])


### PR DESCRIPTION
- as-is: `PairwiseJudgeRewardModel.batch_judge` method returns twice as many samples as the number of input
  - This causes a bug in accuracy computation, because [`evaluate_reward_model`](https://github.com/sbintuitions/flexeval/blob/29b7ce90f5b4dca4621e8573bd6d7eab8ced8de6/flexeval/core/evaluate_reward_model.py#L1-L66) expects the number of samples to be the same
- to-be: the method returns the same number of samples
  - To do this, I have introduced a new function for aggregating the outputs