### PR TITLE
Let `Metric` accepts `LMOutput` as inputs

### DIFF
--- a/flexeval/core/metric/base.py
+++ b/flexeval/core/metric/base.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from flexeval.core.language_model.base import LMOutput
+
 
 @dataclass
 class MetricResult:
@@ -34,7 +36,7 @@ class Metric(ABC):
     @abstractmethod
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -42,7 +44,7 @@ class Metric(ABC):
         Evaluate the outputs of `LanguageModel` against the references.
 
         Args:
-            lm_outputs: List of model outputs.
+            lm_outputs: List of model outputs (strings or LMOutput objects).
             references_list: List of reference outputs.
             extra_info_list: List of task inputs and some extra information.
         """

--- a/flexeval/core/metric/bleu.py
+++ b/flexeval/core/metric/bleu.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import sacrebleu
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric.utils import aggregate_category_wise_scores, apply_string_processors, validate_inputs
 from flexeval.core.string_processor.base import StringProcessor
 
 from .base import Metric, MetricResult
+from .utils import extract_text_from_outputs
 
 
 class BLEU(Metric):
@@ -59,13 +61,14 @@ class BLEU(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        # Normalize text data
+        lm_outputs = extract_text_from_outputs(lm_outputs)
+
         lm_outputs = [apply_string_processors(output, self.lm_output_processors) for output in lm_outputs]
         references_list = [
             [apply_string_processors(ref, self.reference_processors) for ref in references]

--- a/flexeval/core/metric/char_f1.py
+++ b/flexeval/core/metric/char_f1.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from fuzzywuzzy import fuzz
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric.utils import aggregate_category_wise_scores, apply_string_processors, validate_inputs
 from flexeval.core.string_processor import StringProcessor
 
 from .base import Metric, MetricResult
+from .utils import extract_text_from_outputs
 
 
 class CharF1(Metric):
@@ -42,13 +44,14 @@ class CharF1(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        # Normalize text data
+        lm_outputs = extract_text_from_outputs(lm_outputs)
+
         lm_outputs = [apply_string_processors(output, self.lm_output_processors) for output in lm_outputs]
         references_list = [
             [apply_string_processors(ref, self.reference_processors) for ref in references]

--- a/flexeval/core/metric/code_eval.py
+++ b/flexeval/core/metric/code_eval.py
@@ -5,11 +5,12 @@ from typing import Any
 
 import evaluate
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric.base import Metric, MetricResult
 from flexeval.core.string_processor import StringProcessor
 from flexeval.core.utils.jinja2_utils import JINJA2_ENV
 
-from .utils import apply_string_processors, validate_inputs
+from .utils import apply_string_processors, extract_text_from_outputs, validate_inputs
 
 # by default, the program is not allowed to execute code and we need to set this environment variable
 os.environ["HF_ALLOW_CODE_EVAL"] = "1"
@@ -58,7 +59,7 @@ class CodeEval(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -67,7 +68,8 @@ class CodeEval(Metric):
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        # Normalize text data
+        lm_outputs = extract_text_from_outputs(lm_outputs)
+
         lm_outputs = [apply_string_processors(output, self.lm_output_processors) for output in lm_outputs]
 
         # Compute metrics

--- a/flexeval/core/metric/common_prefix_length.py
+++ b/flexeval/core/metric/common_prefix_length.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from flexeval.core.language_model.base import LMOutput
+
 from .base import Metric, MetricResult
-from .utils import validate_inputs
+from .utils import extract_text_from_outputs, validate_inputs
 
 
 def get_longest_common_prefix(s1: str, s2: str) -> str:
@@ -33,11 +35,13 @@ class CommonPrefixLength(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         common_prefix_length_list: list[int] = []

--- a/flexeval/core/metric/common_string_length.py
+++ b/flexeval/core/metric/common_string_length.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from flexeval.core.language_model.base import LMOutput
+
 from .base import Metric, MetricResult
-from .utils import validate_inputs
+from .utils import extract_text_from_outputs, validate_inputs
 
 
 def get_longest_common_substring(s1: str, s2: str) -> str:
@@ -57,11 +59,14 @@ class CommonStringLength(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         common_string_length_list: list[int] = []

--- a/flexeval/core/metric/correlation.py
+++ b/flexeval/core/metric/correlation.py
@@ -5,10 +5,11 @@ from typing import Literal
 
 from scipy.stats import kendalltau, pearsonr, spearmanr
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.string_processor import StringProcessor
 
 from .base import Metric, MetricResult
-from .utils import apply_string_processors, validate_inputs
+from .utils import apply_string_processors, extract_text_from_outputs, validate_inputs
 
 
 class Correlation(Metric):
@@ -52,15 +53,16 @@ class Correlation(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        # Normalize text data - we only use the first reference here
-        references = [refs[0] for refs in references_list]
+        lm_outputs = extract_text_from_outputs(lm_outputs)
         lm_outputs = [apply_string_processors(output, self.lm_output_processors) for output in lm_outputs]
+
+        references = [refs[0] for refs in references_list]
         references = [apply_string_processors(ref, self.reference_processors) for ref in references]
 
         # Convert to numeric values

--- a/flexeval/core/metric/exact_match.py
+++ b/flexeval/core/metric/exact_match.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.string_processor import StringProcessor
 
 from .base import Metric, MetricResult
-from .utils import aggregate_category_wise_scores, apply_string_processors, validate_inputs
+from .utils import aggregate_category_wise_scores, apply_string_processors, extract_text_from_outputs, validate_inputs
 
 
 class ExactMatch(Metric):
@@ -47,13 +48,15 @@ class ExactMatch(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        # Normalize text data
+        # Extract text from LMOutput objects and normalize text data
+        lm_outputs = extract_text_from_outputs(lm_outputs)
+
         lm_outputs = [apply_string_processors(output, self.lm_output_processors) for output in lm_outputs]
         references_list = [
             [apply_string_processors(ref, self.reference_processors) for ref in references]

--- a/flexeval/core/metric/llm_geval_score.py
+++ b/flexeval/core/metric/llm_geval_score.py
@@ -9,12 +9,13 @@ from loguru import logger
 from numpy import average
 
 from flexeval.core.language_model import LanguageModel
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.prompt_template import PromptTemplate
 from flexeval.core.utils.data_util import batch_iter
 
 from .base import Metric, MetricResult
 from .llm_score import prepare_chat_input_for_evaluator, prepare_text_input_for_evaluator
-from .utils import validate_inputs
+from .utils import extract_text_from_outputs, validate_inputs
 
 
 def calculate_weighted_average(
@@ -226,7 +227,7 @@ class LLMGEvalScore(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -236,6 +237,8 @@ class LLMGEvalScore(Metric):
             references_list = [[] for _ in lm_outputs]
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list: list[str] = prepare_text_input_for_evaluator(
@@ -399,7 +402,7 @@ class ChatLLMGEvalScore(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -407,6 +410,8 @@ class ChatLLMGEvalScore(Metric):
             extra_info_list = [{} for _ in lm_outputs]
         if references_list is None:
             references_list = [[] for _ in lm_outputs]
+
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list = prepare_chat_input_for_evaluator(

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -14,7 +14,7 @@ from flexeval.core.metric.llm_score import (
 from flexeval.core.prompt_template import PromptTemplate
 
 from .base import Metric, MetricResult
-from .utils import validate_inputs
+from .utils import extract_text_from_outputs, validate_inputs
 
 
 def parse_label_from_evaluator_output(evaluator_output: str, label_names: list[str]) -> str | None:
@@ -169,7 +169,7 @@ class LLMLabel(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -179,6 +179,9 @@ class LLMLabel(Metric):
             references_list = [[] for _ in lm_outputs]
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list: list[str] = prepare_text_input_for_evaluator(
@@ -317,7 +320,7 @@ class ChatLLMLabel(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -327,6 +330,9 @@ class ChatLLMLabel(Metric):
             references_list = [[] for _ in lm_outputs]
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list = prepare_chat_input_for_evaluator(

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -11,7 +11,7 @@ from flexeval.core.prompt_template import PromptTemplate
 from flexeval.core.utils.data_util import batch_iter
 
 from .base import Metric, MetricResult
-from .utils import validate_inputs
+from .utils import extract_text_from_outputs, validate_inputs
 
 
 def parse_score_from_evaluator_output(evaluator_output: str, valid_score_range: tuple[int, int] | None) -> int | None:
@@ -227,7 +227,7 @@ class LLMScore(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -237,6 +237,9 @@ class LLMScore(Metric):
             references_list = [[] for _ in lm_outputs]
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list: list[str] = prepare_text_input_for_evaluator(
@@ -350,7 +353,7 @@ class ChatLLMScore(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -358,6 +361,9 @@ class ChatLLMScore(Metric):
             extra_info_list = [{} for _ in lm_outputs]
         if references_list is None:
             references_list = [[] for _ in lm_outputs]
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list = prepare_chat_input_for_evaluator(

--- a/flexeval/core/metric/math.py
+++ b/flexeval/core/metric/math.py
@@ -5,9 +5,11 @@ import warnings
 
 import math_verify
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.string_processor.base import StringProcessor
 
 from .base import Metric, MetricResult
+from .utils import extract_text_from_outputs
 
 
 class MathVerify(Metric):
@@ -46,7 +48,7 @@ class MathVerify(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
@@ -56,6 +58,9 @@ class MathVerify(Metric):
                 "should be the same."
             )
             raise ValueError(msg)
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         if self.lm_output_processors:
             lm_outputs = [

--- a/flexeval/core/metric/output_length_stats.py
+++ b/flexeval/core/metric/output_length_stats.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from flexeval.core.language_model.base import LMOutput
+
 from .base import Metric, MetricResult
+from .utils import extract_text_from_outputs
 
 
 class OutputLengthStats(Metric):
@@ -21,10 +24,13 @@ class OutputLengthStats(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
+
         # Compute metrics
         output_length_list = [len(output) for output in lm_outputs]
         return MetricResult(

--- a/flexeval/core/metric/perspective_api.py
+++ b/flexeval/core/metric/perspective_api.py
@@ -9,7 +9,10 @@ from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 from loguru import logger
 
+from flexeval.core.language_model.base import LMOutput
+
 from .base import Metric, MetricResult
+from .utils import extract_text_from_outputs
 
 PERSPECTIVE_API_KEY = os.getenv("PERSPECTIVE_API_KEY")
 
@@ -69,10 +72,13 @@ class PerspectiveAPI(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]] | None = None,
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
+
         # Compute metrics
         instance_details = []
         for lm_output in lm_outputs:

--- a/flexeval/core/metric/repetition_count.py
+++ b/flexeval/core/metric/repetition_count.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from collections import Counter
 from typing import Any
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.string_processor import StringProcessor
 
 from .base import Metric, MetricResult
-from .utils import apply_string_processors, validate_inputs
+from .utils import apply_string_processors, extract_text_from_outputs, validate_inputs
 
 
 def get_most_repeated_pattern(text: str, threshold_length: int = 10) -> tuple[str, int]:
@@ -56,11 +57,15 @@ class RepetitionCount(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],  # Not used in this metric
         extra_info_list: list[dict[str, str]] | None = None,  # Not used in this metric
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
+
         # Normalize text data
         lm_outputs = [apply_string_processors(output, self.lm_output_processors) for output in lm_outputs]
 

--- a/flexeval/core/metric/rouge.py
+++ b/flexeval/core/metric/rouge.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from rouge import Rouge as RougeCalculator
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.tokenizer import Tokenizer
 
 from .base import Metric, MetricResult
-from .utils import validate_inputs
+from .utils import extract_text_from_outputs, validate_inputs
 
 
 class ROUGE(Metric):
@@ -39,11 +40,14 @@ class ROUGE(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Extract text from LMOutput objects
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Normalize text data - we only need the first reference
         target_summaries = [references[0] for references in references_list]

--- a/flexeval/core/metric/sari.py
+++ b/flexeval/core/metric/sari.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from collections import Counter
 from typing import Literal
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric.base import Metric, MetricResult
 from flexeval.core.metric.utils import aggregate_category_wise_scores, apply_string_processors, validate_inputs
 from flexeval.core.string_processor.base import StringProcessor
 from flexeval.core.string_processor.lower import StringLower
 from flexeval.core.tokenizer.base import Tokenizer
 from flexeval.core.tokenizer.sacrebleu_tokenizer import SacreBleuTokenizer
+
+from .utils import extract_text_from_outputs
 
 
 def to_ngram(words: list[str], n: int) -> list[str]:
@@ -81,8 +84,15 @@ class SARI(Metric):
         self.lm_output_processors = lm_output_processor
         self.reference_processors = reference_processor
 
-    def evaluate(self, lm_outputs, references_list, extra_info_list=None) -> MetricResult:  # noqa: ANN001
+    def evaluate(
+        self,
+        lm_outputs: list[str | LMOutput],
+        references_list: list[list[str]],
+        extra_info_list: list[dict[str, str]] | None = None,
+    ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         if extra_info_list is None:
             msg = "SARI requires extra_info_list"

--- a/flexeval/core/metric/substring_match.py
+++ b/flexeval/core/metric/substring_match.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Literal
 
+from flexeval.core.language_model.base import LMOutput
+
 from .base import Metric, MetricResult
-from .utils import aggregate_category_wise_scores, validate_inputs
+from .utils import aggregate_category_wise_scores, extract_text_from_outputs, validate_inputs
 
 
 class SubstringMatch(Metric):
@@ -42,11 +44,13 @@ class SubstringMatch(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         match_list = [

--- a/flexeval/core/metric/utils.py
+++ b/flexeval/core/metric/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TypeVar
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.string_processor.base import StringProcessor
 
 T = TypeVar("T")
@@ -54,7 +55,7 @@ def apply_string_processors(text: str, processors: StringProcessor | list[String
 
 
 def validate_inputs(
-    lm_outputs: list[str],
+    lm_outputs: list[str | LMOutput],
     references_list: list[list[str]],
     extra_info_list: list[dict[str, str]] | None = None,
 ) -> None:
@@ -82,3 +83,23 @@ def validate_inputs(
             f"number of outputs ({len(lm_outputs)})."
         )
         raise ValueError(msg)
+
+
+def extract_text_from_outputs(lm_outputs: list[str | LMOutput]) -> list[str]:
+    """
+    Extract text content from a list of mixed string and LMOutput objects.
+
+    Args:
+        lm_outputs: List containing either string outputs or LMOutput objects.
+
+    Returns:
+        List of text strings extracted from the input. For LMOutput objects,
+        returns the text attribute or empty string if text is None.
+    """
+    text_outputs: list[str] = []
+    for output in lm_outputs:
+        if isinstance(output, str):
+            text_outputs.append(output)
+        else:
+            text_outputs.append(output.text or "")
+    return text_outputs

--- a/flexeval/core/metric/xer.py
+++ b/flexeval/core/metric/xer.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from jiwer import cer, wer
 
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.tokenizer import Tokenizer
 
 from .base import Metric, MetricResult
-from .utils import validate_inputs
+from .utils import extract_text_from_outputs, validate_inputs
 
 
 class XER(Metric):
@@ -35,11 +36,13 @@ class XER(Metric):
 
     def evaluate(
         self,
-        lm_outputs: list[str],
+        lm_outputs: list[str | LMOutput],
         references_list: list[list[str]],
         extra_info_list: list[dict[str, str]] | None = None,
     ) -> MetricResult:
         validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Normalize text data - we only need the first reference
         references = [references[0] for references in references_list]

--- a/tests/core/metric/conftest.py
+++ b/tests/core/metric/conftest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from flexeval.core.language_model.base import LMOutput
+
+
+@pytest.fixture(params=["as-str", "as-LMOutput"], ids=["as-str", "as-LMOutput"])
+def as_lm_output(request: pytest.FixtureRequest) -> str:
+    """
+    Fixture that parameterizes tests to run with both string and LMOutput formats.
+
+    This fixture returns either "as-str" or "as-LMOutput" to control how the
+    lm_outputs fixture formats test data. Tests using this fixture will run
+    twice - once with plain strings and once with LMOutput objects.
+
+    Returns:
+        str: Either "as-str" or "as-LMOutput" indicating the desired format.
+    """
+    return request.param
+
+
+@pytest.fixture()
+def lm_outputs(request: pytest.FixtureRequest, as_lm_output: str) -> list[str] | list[LMOutput]:
+    """
+    Fixture that converts parameterized string lists to either strings or LMOutput objects.
+
+    This fixture works with @pytest.mark.parametrize to accept a list of strings
+    and convert them to the appropriate format based on the as_lm_output fixture.
+    It enables testing metric classes with both input formats to ensure they
+    handle both str and LMOutput inputs correctly.
+
+    Args:
+        request: pytest fixture request containing the parameterized data.
+        as_lm_output: Format indicator from as_lm_output fixture.
+
+    Returns:
+        list[str] | list[LMOutput]: The test data formatted as strings or LMOutput objects.
+
+    Example:
+        @pytest.mark.parametrize("lm_outputs", [["hello", "world"]], indirect=True)
+        def test_metric(lm_outputs):
+            # lm_outputs will be either ["hello", "world"] or [LMOutput(text="hello"), LMOutput(text="world")]
+            pass
+    """
+    raw: list[str] = request.param
+    if as_lm_output == "as-LMOutput":
+        return [LMOutput(text=x) for x in raw]
+    return raw

--- a/tests/core/metric/test_bleu.py
+++ b/tests/core/metric/test_bleu.py
@@ -24,6 +24,7 @@ from flexeval.core.string_processor.string_strip import StringStrip
         ([""], [["empty"]], None, None, 0.0),
         (["訳: これはテストです"], [["これはテストです "]], RegexExtractor(r"訳:\s*(.+)"), StringStrip(), 100.0),
     ],
+    indirect=["lm_outputs"],
 )
 def test_bleu(
     lm_outputs: list[str],

--- a/tests/core/metric/test_char_f1.py
+++ b/tests/core/metric/test_char_f1.py
@@ -23,6 +23,7 @@ from flexeval.core.string_processor import AIONormalizer, RegexExtractor, String
             1.0,
         ),
     ],
+    indirect=["lm_outputs"],
 )
 def test_char_f1(
     lm_outputs: list[str],

--- a/tests/core/metric/test_code_eval.py
+++ b/tests/core/metric/test_code_eval.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from flexeval.core.metric import CodeEval
@@ -5,47 +7,30 @@ from flexeval.core.string_processor import RegexExtractor, StringProcessor
 
 
 @pytest.mark.parametrize(
-    ("code", "test_case"),
+    ("lm_outputs", "references", "lm_output_processor", "expected_score"),
     [
-        ("def add(a, b):\n    return a + b", "assert add(1, 2) == 3"),
-        ("def subtract(a, b):\n    return a - b", "assert subtract(1, 2) == -1"),
-        ("import math", "assert math.sqrt(4) == 2.0"),
-    ],
-)
-def test_correct_code(code: str, test_case: str) -> None:
-    code_eval = CodeEval()
-    metric_result = code_eval.evaluate([code], references_list=[[test_case]])
-    assert metric_result.summary == {"pass@1": 1.0}
-
-
-@pytest.mark.parametrize(
-    ("code", "test_case", "lm_output_processor"),
-    [
+        (["def add(a, b):\n    return a + b"], ["assert add(1, 2) == 3"], None, 1.0),
+        (["def subtract(a, b):\n    return a - b"], ["assert subtract(1, 2) == -1"], None, 1.0),
+        (["import math"], ["assert math.sqrt(4) == 2.0"], None, 1.0),
         (
-            "```python\ndef add(a, b):\n    return a + b\n```",
-            "assert add(1, 2) == 3",
+            ["```python\ndef add(a, b):\n    return a + b\n```"],
+            ["assert add(1, 2) == 3"],
             RegexExtractor("```python(.*?)```"),
+            1.0,
         ),
+        # Incorrect test code
+        ([""], ["assert add(1, 2) == 3"], None, 0.0),
+        (["'asdfsad' + 100"], ["assert add(1, 2) == 3"], None, 0.0),
+        (["def add(a, b):\n    return a - b"], ["assert add(1, 2) == 3"], None, 0.0),
     ],
+    indirect=["lm_outputs"],
 )
-def test_correct_code_with_processor(code: str, test_case: str, lm_output_processor: StringProcessor) -> None:
+def test_code(
+    lm_outputs: list[str], references: str, lm_output_processor: StringProcessor | None, expected_score: float
+) -> None:
     code_eval = CodeEval(lm_output_processor=lm_output_processor)
-    metric_result = code_eval.evaluate([code], references_list=[[test_case]])
-    assert metric_result.summary == {"pass@1": 1.0}
-
-
-@pytest.mark.parametrize(
-    ("code", "test_case"),
-    [
-        ("", "assert add(1, 2) == 3"),
-        ("'asdfsad' + 100", "assert add(1, 2) == 3"),
-        ("def add(a, b):\n    return a - b", "assert add(1, 2) == 3"),
-    ],
-)
-def test_incorrect_code(code: str, test_case: str) -> None:
-    code_eval = CodeEval()
-    metric_result = code_eval.evaluate([code], references_list=[[test_case]])
-    assert metric_result.summary == {"pass@1": 0.0}
+    metric_result = code_eval.evaluate(lm_outputs, references_list=[[ref] for ref in references])
+    assert metric_result.summary == {"pass@1": expected_score}
 
 
 @pytest.mark.parametrize(

--- a/tests/core/metric/test_common_prefix_length.py
+++ b/tests/core/metric/test_common_prefix_length.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from flexeval.core.metric.common_prefix_length import (
@@ -21,16 +23,26 @@ def test_get_longest_common_prefix(s1: str, s2: str, common_prefix: str) -> None
     assert get_longest_common_prefix(s1, s2) == common_prefix
 
 
-def test_common_prefix_length() -> None:
+@pytest.mark.parametrize(
+    ("lm_outputs", "references_list", "common_prefix_lengths"),
+    [
+        (
+            ["これはペンです", "これはペンギンです"],
+            [["これはペンです"], ["これはペンです", "これはペンギンです"]],
+            [7, 9],
+        ),
+    ],
+    indirect=["lm_outputs"],
+)
+def test_common_prefix_length(
+    lm_outputs: list[str], references_list: list[list[str]], common_prefix_lengths: list[int]
+) -> None:
     metric = CommonPrefixLength()
 
-    lm_outputs = ["これはペンです", "これはペンギンです"]
-    references_list = [["これはペンです"], ["これはペンです", "これはペンギンです"]]
-
-    metric_result = metric.evaluate(lm_outputs, references_list=references_list)
+    metric_result = metric.evaluate(lm_outputs=lm_outputs, references_list=references_list)
 
     assert metric_result.summary == {
-        "average_common_prefix_length": 8.0,  # average of len("これはペンです")=7 and len("これはペンギンです")=9
-        "longest_common_prefix_length": 9,  # the length of "これはペンギンです"
+        "average_common_prefix_length": sum(common_prefix_lengths) / len(common_prefix_lengths),
+        "longest_common_prefix_length": max(common_prefix_lengths),
     }
-    assert metric_result.instance_details == [{"common_prefix_length": 7}, {"common_prefix_length": 9}]
+    assert metric_result.instance_details == [{"common_prefix_length": length} for length in common_prefix_lengths]

--- a/tests/core/metric/test_correlation.py
+++ b/tests/core/metric/test_correlation.py
@@ -15,6 +15,7 @@ from flexeval import Correlation, MetricResult
         ("kendall", ["1", "2", "3", "4", "5"], ["1", "2", "3", "4", "5"], 1.0),
         ("kendall", ["1", "2", "3", "4", "5"], ["5", "4", "3", "2", "1"], -1.0),
     ],
+    indirect=["lm_outputs"],
 )
 def test_correlation(method: str, lm_outputs: list[str], references: list[float], expected_correlation: float) -> None:
     correlation = Correlation(method=method)

--- a/tests/core/metric/test_correlation.py
+++ b/tests/core/metric/test_correlation.py
@@ -8,17 +8,15 @@ from flexeval import Correlation, MetricResult
 @pytest.mark.parametrize(
     ("method", "lm_outputs", "references", "expected_correlation"),
     [
-        ("pearson", [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], 1.0),
-        ("pearson", [1, 2, 3, 4, 5], [5, 4, 3, 2, 1], -1.0),
-        ("spearman", [1, 2, 3, 4, 5], [1, 20, 30, 400, 500], 1.0),
-        ("spearman", [1, 2, 3, 4, 5], [500, 400, 30, 20, 1], -1.0),
-        ("kendall", [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], 1.0),
-        ("kendall", [1, 2, 3, 4, 5], [5, 4, 3, 2, 1], -1.0),
+        ("pearson", ["1", "2", "3", "4", "5"], ["1", "2", "3", "4", "5"], 1.0),
+        ("pearson", ["1", "2", "3", "4", "5"], ["5", "4", "3", "2", "1"], -1.0),
+        ("spearman", ["1", "2", "3", "4", "5"], ["1", "20", "30", "400", "500"], 1.0),
+        ("spearman", ["1", "2", "3", "4", "5"], ["500", "400", "30", "20", "1"], -1.0),
+        ("kendall", ["1", "2", "3", "4", "5"], ["1", "2", "3", "4", "5"], 1.0),
+        ("kendall", ["1", "2", "3", "4", "5"], ["5", "4", "3", "2", "1"], -1.0),
     ],
 )
-def test_correlation(
-    method: str, lm_outputs: list[float], references: list[float], expected_correlation: float
-) -> None:
+def test_correlation(method: str, lm_outputs: list[str], references: list[float], expected_correlation: float) -> None:
     correlation = Correlation(method=method)
     references_list = [[ref] for ref in references]  # Wrap references in a list for each instance
 

--- a/tests/core/metric/test_exact_match.py
+++ b/tests/core/metric/test_exact_match.py
@@ -22,6 +22,7 @@ from flexeval.core.string_processor import AIONormalizer, RegexExtractor, String
             1.0,
         ),
     ],
+    indirect=["lm_outputs"],
 )
 def test_exact_match(
     lm_outputs: list[str],

--- a/tests/core/metric/test_llm_geval_score.py
+++ b/tests/core/metric/test_llm_geval_score.py
@@ -5,7 +5,9 @@ import re
 import pytest
 
 from flexeval import Jinja2PromptTemplate, LanguageModel
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric.llm_geval_score import ChatLLMGEvalScore, LLMGEvalScore, calculate_weighted_average
+from flexeval.core.metric.utils import extract_text_from_outputs
 
 
 class EchoBackLanguageModel(LanguageModel):
@@ -61,119 +63,139 @@ def test_calculate_weighted_average(
     assert score == expected_score
 
 
-@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
-def test_llm_geval_score(metric_prefix: str | None) -> None:
+@pytest.mark.parametrize(
+    ("lm_outputs", "extra_info_list", "expected_summary"),
+    [
+        (
+            [
+                "[A] Output a number from 1 to 5.",
+                "[B] Output a number from 1 to 5.",
+                "[C] Output a number from 1 to 5.",
+                "[D] Output a number from 1 to 5.",
+            ],
+            None,
+            {
+                "llm_geval_score": pytest.approx(3.0, rel=1e-5),
+                "num_failed_score_parses": 1,
+            },
+        ),
+        (
+            [
+                "[A] Output a number from 1 to 5.",
+                "[B] Output a number from 1 to 5.",
+                "[C] Output a number from 1 to 5.",
+            ],
+            [
+                {"category": "category-0"},
+                {"category": "category-1"},
+                {"category": "category-0"},
+            ],
+            {
+                "llm_geval_score": pytest.approx(3.0, rel=1e-5),
+                "num_failed_score_parses": 0,
+                "llm_geval_score/category-0": pytest.approx(3.1278810469948057, rel=1e-5),
+                "llm_geval_score/category-1": pytest.approx(2.744237906010388, rel=1e-5),
+            },
+        ),
+    ],
+    indirect=["lm_outputs"],
+)
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_llm_geval_score(
+    lm_outputs: list[str | LMOutput],
+    extra_info_list: list[dict[str, str]] | None,
+    expected_summary: dict[str, float | int],
+    metric_prefix: str,
+) -> None:
     metric = LLMGEvalScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         valid_score_range=(1, 5),
+        category_key="category" if extra_info_list else None,
         metric_prefix=metric_prefix,
     )
-    lm_outputs = [
-        "[A] Output a number from 1 to 5.",
-        "[B] Output a number from 1 to 5.",
-        "[C] Output a number from 1 to 5.",
-        "[D] Output a number from 1 to 5.",
-    ]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
+        extra_info_list=extra_info_list,
     )
 
-    metric_prefix = metric_prefix + "-" if metric_prefix else ""
-    assert len(metric_output.summary) == 2
-    assert metric_output.summary[f"{metric_prefix}llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
-    assert metric_output.summary[f"{metric_prefix}num_failed_score_parses"] == 1
+    if metric_prefix:
+        metric_prefix += "-"
 
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
+    expected_len = len(expected_summary)
+    assert len(metric_output.summary) == expected_len
+
+    for key, value in expected_summary.items():
+        assert metric_output.summary[f"{metric_prefix}{key}"] == value
+
+    for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_geval_score_input"] == lm_output
 
 
-def test_llm_geval_score_with_category() -> None:
-    metric = LLMGEvalScore(
-        language_model=EchoBackLanguageModel(),
-        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
-        valid_score_range=(1, 5),
-        category_key="category",
-    )
-    lm_outputs = [
-        "[A] Output a number from 1 to 5.",
-        "[B] Output a number from 1 to 5.",
-        "[C] Output a number from 1 to 5.",
-    ]
-    extra_info_list = [
-        {"category": "category-0"},
-        {"category": "category-1"},
-        {"category": "category-0"},
-    ]
-    metric_output = metric.evaluate(
-        lm_outputs=lm_outputs,
-        extra_info_list=extra_info_list,
-    )
-
-    assert len(metric_output.summary) == 4
-    assert metric_output.summary["llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
-    assert metric_output.summary["num_failed_score_parses"] == 0
-    assert metric_output.summary["llm_geval_score/category-0"] == pytest.approx(3.1278810469948057, rel=1e-5)
-    assert metric_output.summary["llm_geval_score/category-1"] == pytest.approx(2.744237906010388, rel=1e-5)
-
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_geval_score_input"] == lm_output
-
-
-@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
-def test_chat_llm_geval_score(metric_prefix: str | None) -> None:
+@pytest.mark.parametrize(
+    ("lm_outputs", "extra_info_list", "expected_summary"),
+    [
+        (
+            [
+                "[A] Output a number from 1 to 5.",
+                "[B] Output a number from 1 to 5.",
+                "[C] Output a number from 1 to 5.",
+                "[D] Output a number from 1 to 5.",
+            ],
+            None,
+            {
+                "llm_geval_score": pytest.approx(3.0, rel=1e-5),
+                "num_failed_score_parses": 1,
+            },
+        ),
+        (
+            [
+                "[A] Output a number from 1 to 5.",
+                "[B] Output a number from 1 to 5.",
+                "[C] Output a number from 1 to 5.",
+            ],
+            [
+                {"category": "category-0"},
+                {"category": "category-1"},
+                {"category": "category-0"},
+            ],
+            {
+                "llm_geval_score": pytest.approx(3.0, rel=1e-5),
+                "num_failed_score_parses": 0,
+                "llm_geval_score/category-0": pytest.approx(3.1278810469948057, rel=1e-5),
+                "llm_geval_score/category-1": pytest.approx(2.744237906010388, rel=1e-5),
+            },
+        ),
+    ],
+    indirect=["lm_outputs"],
+)
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_chat_llm_geval_score(
+    lm_outputs: list[str | LMOutput],
+    extra_info_list: list[dict[str, str]] | None,
+    expected_summary: dict[str, float | int],
+    metric_prefix: str,
+) -> None:
     metric = ChatLLMGEvalScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         valid_score_range=(1, 5),
+        category_key="category" if extra_info_list else None,
         metric_prefix=metric_prefix,
     )
-    lm_outputs = [
-        "[A] Output a number from 1 to 5.",
-        "[B] Output a number from 1 to 5.",
-        "[C] Output a number from 1 to 5.",
-        "[D] Output a number from 1 to 5.",
-    ]
-    metric_output = metric.evaluate(
-        lm_outputs=lm_outputs,
-    )
-
-    metric_prefix = metric_prefix + "-" if metric_prefix else ""
-    assert len(metric_output.summary) == 2
-    assert metric_output.summary[f"{metric_prefix}llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
-    assert metric_output.summary[f"{metric_prefix}num_failed_score_parses"] == 1
-
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail[f"{metric_prefix}llm_geval_score_input"] == [{"role": "user", "content": lm_output}]
-
-
-def test_chat_llm_geval_score_with_category() -> None:
-    metric = ChatLLMGEvalScore(
-        language_model=EchoBackLanguageModel(),
-        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
-        valid_score_range=(1, 5),
-        category_key="category",
-    )
-    lm_outputs = [
-        "[A] Output a number from 1 to 5.",
-        "[B] Output a number from 1 to 5.",
-        "[C] Output a number from 1 to 5.",
-    ]
-    extra_info_list = [
-        {"category": "category-0"},
-        {"category": "category-1"},
-        {"category": "category-0"},
-    ]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
         extra_info_list=extra_info_list,
     )
 
-    assert len(metric_output.summary) == 4
-    assert metric_output.summary["llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
-    assert metric_output.summary["num_failed_score_parses"] == 0
-    assert metric_output.summary["llm_geval_score/category-0"] == pytest.approx(3.1278810469948057, rel=1e-5)
-    assert metric_output.summary["llm_geval_score/category-1"] == pytest.approx(2.744237906010388, rel=1e-5)
+    if metric_prefix:
+        metric_prefix += "-"
 
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_geval_score_input"] == [{"role": "user", "content": lm_output}]
+    expected_len = len(expected_summary)
+    assert len(metric_output.summary) == expected_len
+
+    for key, value in expected_summary.items():
+        assert metric_output.summary[f"{metric_prefix}{key}"] == value
+
+    for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
+        assert instance_detail[f"{metric_prefix}llm_geval_score_input"] == [{"role": "user", "content": lm_output}]

--- a/tests/core/metric/test_llm_label.py
+++ b/tests/core/metric/test_llm_label.py
@@ -5,6 +5,7 @@ import pytest
 from flexeval import Jinja2PromptTemplate, LanguageModel
 from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric.llm_label import ChatLLMLabel, LLMLabel, parse_label_from_evaluator_output
+from flexeval.core.metric.utils import extract_text_from_outputs
 
 
 class EchoBackLanguageModel(LanguageModel):
@@ -34,130 +35,132 @@ class EchoBackLanguageModel(LanguageModel):
 )
 def test_parse_label_from_evaluator_output(
     evaluator_output: str,
-    label_names: tuple[int, int] | None,
+    label_names: list[str],
     expected_label: str | None,
 ) -> None:
     label = parse_label_from_evaluator_output(evaluator_output, label_names)
     assert label == expected_label
 
 
-@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
-def test_llm_label(metric_prefix: str | None) -> None:
+@pytest.mark.parametrize(
+    ("lm_outputs", "extra_info_list", "expected_summary"),
+    [
+        (
+            ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."],
+            None,
+            {
+                "llm_score": 0.5,
+                "num_failed_score_parses": 1,
+                "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+            },
+        ),
+        (
+            ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."],
+            [
+                {"category": "category-0"},
+                {"category": "category-0"},
+                {"category": "category-1"},
+                {"category": "category-2"},
+            ],
+            {
+                "llm_score": 0.5,
+                "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+                "num_failed_score_parses": 1,
+                "llm_score/category-0": 0.75,
+                "llm_label_distribution/category-0": {"Good": 1 / 2, "Neutral": 1 / 2, "Bad": 0 / 2},
+                "llm_score/category-1": 0.0,
+                "llm_label_distribution/category-1": {"Good": 0 / 1, "Neutral": 0 / 1, "Bad": 1 / 1},
+            },
+        ),
+    ],
+    indirect=["lm_outputs"],
+)
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_llm_label(
+    lm_outputs: list[str | LMOutput],
+    extra_info_list: list[dict[str, str]] | None,
+    expected_summary: dict[str, float | dict[str, float]],
+    metric_prefix: str,
+) -> None:
     metric = LLMLabel(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],
+        category_key="category" if extra_info_list else None,
         metric_prefix=metric_prefix,
     )
-    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
+        extra_info_list=extra_info_list,
     )
 
-    metric_prefix = metric_prefix + "-" if metric_prefix else ""
-    assert metric_output.summary == {
-        f"{metric_prefix}llm_score": 0.5,
-        f"{metric_prefix}num_failed_score_parses": 1,
-        f"{metric_prefix}llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
-    }
+    if metric_prefix:
+        metric_prefix += "-"
+    assert metric_output.summary == {f"{metric_prefix}{k}": v for k, v in expected_summary.items()}
 
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
+    for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_label_input"] == lm_output
         assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output
 
 
-def test_llm_label_with_category() -> None:
-    metric = LLMLabel(
-        language_model=EchoBackLanguageModel(),
-        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
-        label_names=["Good", "Neutral", "Bad"],
-        label_points=[1.0, 0.5, 0.0],
-        category_key="category",
-    )
-    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
-    extra_info_list = [
-        {"category": "category-0"},
-        {"category": "category-0"},
-        {"category": "category-1"},
-        {"category": "category-2"},
-    ]
-    metric_output = metric.evaluate(
-        lm_outputs=lm_outputs,
-        extra_info_list=extra_info_list,
-    )
-
-    assert metric_output.summary == {
-        "llm_score": 0.5,
-        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
-        "num_failed_score_parses": 1,
-        "llm_score/category-0": 0.75,
-        "llm_label_distribution/category-0": {"Good": 1 / 2, "Neutral": 1 / 2, "Bad": 0 / 2},
-        "llm_score/category-1": 0.0,
-        "llm_label_distribution/category-1": {"Good": 0 / 1, "Neutral": 0 / 1, "Bad": 1 / 1},
-    }
-
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_label_input"] == lm_output
-        assert instance_detail["llm_label_output"] == lm_output
-
-
-@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
-def test_chat_llm_label(metric_prefix: str | None) -> None:
+@pytest.mark.parametrize(
+    ("lm_outputs", "extra_info_list", "expected_summary"),
+    [
+        (
+            ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."],
+            None,
+            {
+                "llm_score": 0.5,
+                "num_failed_score_parses": 1,
+                "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+            },
+        ),
+        (
+            ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."],
+            [
+                {"category": "category-0"},
+                {"category": "category-0"},
+                {"category": "category-1"},
+                {"category": "category-2"},
+            ],
+            {
+                "llm_score": 0.5,
+                "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
+                "num_failed_score_parses": 1,
+                "llm_score/category-0": 0.75,
+                "llm_label_distribution/category-0": {"Good": 1 / 2, "Neutral": 1 / 2, "Bad": 0 / 2},
+                "llm_score/category-1": 0.0,
+                "llm_label_distribution/category-1": {"Good": 0 / 1, "Neutral": 0 / 1, "Bad": 1 / 1},
+            },
+        ),
+    ],
+    indirect=["lm_outputs"],
+)
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_chat_llm_label(
+    lm_outputs: list[str | LMOutput],
+    extra_info_list: list[dict[str, str]] | None,
+    expected_summary: dict[str, float | dict[str, float]],
+    metric_prefix: str,
+) -> None:
     metric = ChatLLMLabel(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],
+        category_key="category" if extra_info_list else None,
         metric_prefix=metric_prefix,
     )
-    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
-    metric_output = metric.evaluate(
-        lm_outputs=lm_outputs,
-    )
-
-    metric_prefix = metric_prefix + "-" if metric_prefix else ""
-    assert metric_output.summary == {
-        f"{metric_prefix}llm_score": 0.5,
-        f"{metric_prefix}num_failed_score_parses": 1,
-        f"{metric_prefix}llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
-    }
-
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail[f"{metric_prefix}llm_label_input"] == [{"role": "user", "content": lm_output}]
-        assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output
-
-
-def test_chat_llm_label_with_category() -> None:
-    metric = ChatLLMLabel(
-        language_model=EchoBackLanguageModel(),
-        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
-        label_names=["Good", "Neutral", "Bad"],
-        label_points=[1.0, 0.5, 0.0],
-        category_key="category",
-    )
-    lm_outputs = ["This is Good.", "This is Neutral.", "This is Bad.", "This is Great."]
-    extra_info_list = [
-        {"category": "category-0"},
-        {"category": "category-0"},
-        {"category": "category-1"},
-        {"category": "category-2"},
-    ]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
         extra_info_list=extra_info_list,
     )
 
-    assert metric_output.summary == {
-        "llm_score": 0.5,
-        "llm_label_distribution": {"Good": 1 / 3, "Neutral": 1 / 3, "Bad": 1 / 3},
-        "num_failed_score_parses": 1,
-        "llm_score/category-0": 0.75,
-        "llm_label_distribution/category-0": {"Good": 1 / 2, "Neutral": 1 / 2, "Bad": 0 / 2},
-        "llm_score/category-1": 0.0,
-        "llm_label_distribution/category-1": {"Good": 0 / 1, "Neutral": 0 / 1, "Bad": 1 / 1},
-    }
+    if metric_prefix:
+        metric_prefix += "-"
+    assert metric_output.summary == {f"{metric_prefix}{k}": v for k, v in expected_summary.items()}
 
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_label_input"] == [{"role": "user", "content": lm_output}]
-        assert instance_detail["llm_label_output"] == lm_output
+    for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
+        assert instance_detail[f"{metric_prefix}llm_label_input"] == [{"role": "user", "content": lm_output}]
+        assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -10,6 +10,7 @@ from flexeval.core.metric.llm_score import (
     parse_score_from_evaluator_output,
     prepare_chat_input_for_evaluator,
 )
+from flexeval.core.metric.utils import extract_text_from_outputs
 
 
 class EchoBackLanguageModel(LanguageModel):
@@ -50,22 +51,63 @@ def test_parse_score_from_evaluator_output(
     assert score == expected_score
 
 
-@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
-def test_llm_score(metric_prefix: str | None) -> None:
+@pytest.mark.parametrize(
+    ("lm_outputs", "extra_info_list", "expected_summary"),
+    [
+        (
+            ["This score is 1.", "This score is 2.", "This is a good one."],
+            [
+                {"category": "category-0"},
+                {"category": "category-0"},
+                {"category": "category-1"},
+            ],
+            {
+                "llm_score": 1.5,
+                "num_failed_score_parses": 1,
+                "llm_score/category-0": 1.5,
+            },
+        ),
+        (
+            ["This score is 1.", "This score is 2.", "This score is 3.", "This is a good one."],
+            [
+                {"category": ["category-0"]},
+                {"category": ["category-0", "category-1"]},
+                {"category": []},
+                {"category": [""]},
+            ],
+            {
+                "llm_score": 2.0,
+                "num_failed_score_parses": 1,
+                "llm_score/category-0": 1.5,
+                "llm_score/category-1": 2.0,
+            },
+        ),
+    ],
+    indirect=["lm_outputs"],
+)
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_llm_score(
+    lm_outputs: list[str | LMOutput],
+    extra_info_list: list[dict[str, str | list[str]]],
+    expected_summary: dict[str, float],
+    metric_prefix: str | None,
+) -> None:
     metric = LLMScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        category_key="category",
         metric_prefix=metric_prefix,
     )
-    lm_outputs = ["This score is 1.", "This score is 2.", "This is a good one."]
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
+        extra_info_list=extra_info_list,
     )
+    if metric_prefix:
+        metric_prefix += "-"
 
-    metric_prefix = metric_prefix + "-" if metric_prefix else ""
-    assert metric_output.summary == {f"{metric_prefix}llm_score": 1.5, f"{metric_prefix}num_failed_score_parses": 1}
+    assert metric_output.summary == {f"{metric_prefix}{k}": v for k, v in expected_summary.items()}
 
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
+    for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_score_input"] == lm_output
         assert instance_detail[f"{metric_prefix}llm_score_output"] == lm_output
 
@@ -102,98 +144,33 @@ def test_llm_score(metric_prefix: str | None) -> None:
             },
         ),
     ],
+    indirect=["lm_outputs"],
 )
-def test_llm_score_with_category(
-    lm_outputs: list[str], extra_info_list: list[dict[str, str | list[str]]], expected_summary: dict[str, float]
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_chat_llm_score(
+    lm_outputs: list[str | LMOutput],
+    extra_info_list: list[dict[str, str | list[str]]],
+    expected_summary: dict[str, float],
+    metric_prefix: str,
 ) -> None:
-    metric = LLMScore(
-        language_model=EchoBackLanguageModel(),
-        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
-        category_key="category",
-    )
-    metric_output = metric.evaluate(
-        lm_outputs=lm_outputs,
-        extra_info_list=extra_info_list,
-    )
-
-    assert metric_output.summary == expected_summary
-
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_score_input"] == lm_output
-        assert instance_detail["llm_score_output"] == lm_output
-
-
-@pytest.mark.parametrize("metric_prefix", [None, "prefix"])
-def test_chat_llm_score(metric_prefix: str | None) -> None:
     metric = ChatLLMScore(
         language_model=EchoBackLanguageModel(),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        category_key="category",
         metric_prefix=metric_prefix,
     )
-    lm_outputs = ["This score is 1.", "This score is 2.", "This is a good one."]
-    metric_output = metric.evaluate(
-        lm_outputs=lm_outputs,
-    )
-
-    metric_prefix = metric_prefix + "-" if metric_prefix else ""
-    assert metric_output.summary == {f"{metric_prefix}llm_score": 1.5, f"{metric_prefix}num_failed_score_parses": 1}
-
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail[f"{metric_prefix}llm_score_input"] == [{"role": "user", "content": lm_output}]
-        assert instance_detail[f"{metric_prefix}llm_score_output"] == lm_output
-
-
-@pytest.mark.parametrize(
-    ("lm_outputs", "extra_info_list", "expected_summary"),
-    [
-        (
-            ["This score is 1.", "This score is 2.", "This is a good one."],
-            [
-                {"category": "category-0"},
-                {"category": "category-0"},
-                {"category": "category-1"},
-            ],
-            {
-                "llm_score": 1.5,
-                "num_failed_score_parses": 1,
-                "llm_score/category-0": 1.5,
-            },
-        ),
-        (
-            ["This score is 1.", "This score is 2.", "This score is 3.", "This is a good one."],
-            [
-                {"category": ["category-0"]},
-                {"category": ["category-0", "category-1"]},
-                {"category": []},
-                {"category": [""]},
-            ],
-            {
-                "llm_score": 2.0,
-                "num_failed_score_parses": 1,
-                "llm_score/category-0": 1.5,
-                "llm_score/category-1": 2.0,
-            },
-        ),
-    ],
-)
-def test_chat_llm_score_with_category(
-    lm_outputs: list[str], extra_info_list: list[dict[str, str | list[str]]], expected_summary: dict[str, float]
-) -> None:
-    metric = ChatLLMScore(
-        language_model=EchoBackLanguageModel(),
-        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
-        category_key="category",
-    )
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
         extra_info_list=extra_info_list,
     )
 
-    assert metric_output.summary == expected_summary
+    if metric_prefix:
+        metric_prefix += "-"
+    assert metric_output.summary == {f"{metric_prefix}{k}": v for k, v in expected_summary.items()}
 
-    for lm_output, instance_detail in zip(lm_outputs, metric_output.instance_details):
-        assert instance_detail["llm_score_input"] == [{"role": "user", "content": lm_output}]
-        assert instance_detail["llm_score_output"] == lm_output
+    for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
+        assert instance_detail[f"{metric_prefix}llm_score_input"] == [{"role": "user", "content": lm_output}]
+        assert instance_detail[f"{metric_prefix}llm_score_output"] == lm_output
 
 
 def test_prepare_chat_input_for_evaluator() -> None:

--- a/tests/core/metric/test_math_verify_metric.py
+++ b/tests/core/metric/test_math_verify_metric.py
@@ -16,6 +16,7 @@ from flexeval.core.metric import MathVerify
         (["The answer is \\boxed{1.501}"], [["1.5"]], 0.0),
         (["答えは４です"], [["4"]], 0.0),
     ],
+    indirect=["lm_outputs"],
 )
 def test_exact_match(
     lm_outputs: list[str],

--- a/tests/core/metric/test_output_length_stats.py
+++ b/tests/core/metric/test_output_length_stats.py
@@ -6,15 +6,22 @@ from flexeval.core.metric import OutputLengthStats
 
 
 @pytest.mark.parametrize(
-    ("lm_outputs", "expected_summary"),
+    ("lm_outputs", "lm_output_lengths"),
     [
-        (["123456"], {"avg_output_length": 6, "max_output_length": 6, "min_output_length": 6}),
-        (["123456", "123456789"], {"avg_output_length": 7.5, "max_output_length": 9, "min_output_length": 6}),
+        (["123456"], [6]),
+        (["123456", "123456789"], [6, 9]),
     ],
+    indirect=["lm_outputs"],
 )
-def test_output_length_stats(lm_outputs: list[str], expected_summary: dict[str, float]) -> None:
+def test_output_length_stats(lm_outputs: list[str], lm_output_lengths: list[int]) -> None:
     metric = OutputLengthStats()
     metric_result = metric.evaluate(lm_outputs=lm_outputs, references_list=[])
+
+    expected_summary = {
+        "avg_output_length": sum(lm_output_lengths) / len(lm_output_lengths),
+        "max_output_length": max(lm_output_lengths),
+        "min_output_length": min(lm_output_lengths),
+    }
     assert metric_result.summary == pytest.approx(expected_summary)
-    assert metric_result.instance_details[0]["output_length"] == len(lm_outputs[0])
+    assert metric_result.instance_details[0]["output_length"] == lm_output_lengths[0]
     assert len(metric_result.instance_details) == len(lm_outputs)

--- a/tests/core/metric/test_repetition_count.py
+++ b/tests/core/metric/test_repetition_count.py
@@ -12,6 +12,7 @@ from flexeval.core.metric.repetition_count import RepetitionCount, get_most_repe
         (["hello hello hello", "hello"], 3, 10, 0.0),  # No repetition because of the increased threshold_length
         (["hello hello hello", "hello"], 10, 5, 0.0),  # No repetition because of the increased count_threshold
     ],
+    indirect=["lm_outputs"],
 )
 def test_get_most_repeated_pattern(
     lm_outputs: list[str], count_threshold: int, threshold_length: int, expected_ratio: float

--- a/tests/core/metric/test_rouge.py
+++ b/tests/core/metric/test_rouge.py
@@ -13,6 +13,7 @@ from flexeval.core.tokenizer import WhitespaceTokenizer
         (["こんにちは 世界"], [["こんばんわ 地方"]], 0.0),
         ([""], [["empty"]], 0.0),
     ],
+    indirect=["lm_outputs"],
 )
 def test_rouge(lm_outputs: list[str], expected_outputs: list[list[str]], score: float) -> None:
     rouge = ROUGE(tokenizer=WhitespaceTokenizer())

--- a/tests/core/metric/test_sari.py
+++ b/tests/core/metric/test_sari.py
@@ -39,6 +39,7 @@ from flexeval.core.metric.sari import SARI
             0.0,
         ),
     ],
+    indirect=["lm_outputs"],
 )
 def test_sari(
     lm_outputs: list[str],

--- a/tests/core/metric/test_substring_match.py
+++ b/tests/core/metric/test_substring_match.py
@@ -13,6 +13,7 @@ from flexeval import MetricResult, SubstringMatch
         (["", "cat dog"], [["anything"], ["cat"]], 0.5),
         (["Substring is not present"], [["missing"]], 0.0),
     ],
+    indirect=["lm_outputs"],
 )
 def test_substring_match_any_mode(lm_outputs: list[str], expected_outputs: list[list[str]], score: float) -> None:
     """Test SubstringMatch in 'any' mode with various inputs."""

--- a/tests/core/metric/test_xer.py
+++ b/tests/core/metric/test_xer.py
@@ -12,6 +12,7 @@ from flexeval.core.tokenizer import WhitespaceTokenizer
         (["これは テスト"], [["これは テスト"]], 0.0, 0.0),
         (["こんにちは 世界"], [["こんばんわ 地方"]], 0.62, 1.0),
     ],
+    indirect=["lm_outputs"],
 )
 def test_rouge(lm_outputs: list[str], expected_outputs: list[list[str]], cer_score: float, wer_score: float) -> None:
     rouge = XER(tokenizer=WhitespaceTokenizer())


### PR DESCRIPTION
This PR lets the metric framework accept both raw strings and `LMOutput` objects, with a normalization step that extracts text before scoring. This makes all metrics handle model outputs consistently.

## What changed

* **Refactor `Metric`:** Metrics now accept `LMOutput`; for regular classes the only change is adding the `extract_text_from_outputs` call.
  * **Type updates:** All `evaluate` methods now accept `list[str | LMOutput]`.
  * **Normalize inputs:** Call `extract_text_from_outputs` in every metric’s `evaluate` to convert `LMOutput` → `str` before processing.


## Tests

* Updated tests to cover `LMOutput` inputs.
* Introduced `indirect` parametrization to feed `LMOutput` into existing test cases.
  * See [pytest documentation](https://docs.pytest.org/en/stable/example/parametrize.html#apply-indirect-on-particular-arguments).
