### PR TITLE
 Refactor eval pipeline

### DIFF
--- a/flexeval/core/eval_setups.py
+++ b/flexeval/core/eval_setups.py
@@ -12,7 +12,7 @@ from .evaluate_perplexity import evaluate_perplexity
 from .few_shot_generator import FewShotGenerator
 from .generation_dataset import GenerationDataset
 from .language_model import LanguageModel
-from .metric import Metric
+from .metric import FinishReasonCount, Metric, OutputLengthStats
 from .multiple_choice_dataset import MultipleChoiceDataset
 from .prompt_template import PromptTemplate, instantiate_prompt_template_from_string
 from .text_dataset import TextDataset
@@ -58,6 +58,7 @@ class ChatResponse(EvalSetup):
         metrics = self.metrics or []
         if isinstance(metrics, Metric):
             metrics = [metrics]
+        metrics += [FinishReasonCount(), OutputLengthStats()]
 
         return evaluate_chat_response(
             language_model=language_model,
@@ -96,6 +97,7 @@ class Generation(EvalSetup):
         metrics = self.metrics or []
         if isinstance(metrics, Metric):
             metrics = [metrics]
+        metrics += [FinishReasonCount(), OutputLengthStats()]
 
         return evaluate_generation(
             language_model=language_model,

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -217,7 +217,7 @@ def evaluate_chat_response(  # noqa: C901
     # Restructure the output for backward compatibility
     # Maybe switch to the new structure sometime
     # new: `{"lm_output": LMOutput, "chat_instance": ChatInstance, "messages": [...], "metrics": {...}}`
-    # current: `{"lm_output": "...", "finish_reason": "...", "task_inputs": {...}, "references": [...], **metrics}`
+    # legacy: `{"lm_output": "...", "finish_reason": "...", "task_inputs": {...}, "references": [...], **metrics}`
     restructured_outputs: list[dict[str, Any]] = []
     for output in outputs:
         extra_info = output["chat_instance"].extra_info | {"messages": output["messages"]}

--- a/flexeval/core/evaluate_generation.py
+++ b/flexeval/core/evaluate_generation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any, Sequence
 
 from loguru import logger
@@ -76,7 +75,7 @@ def evaluate_generation(  # noqa: C901
     instance_metrics_list: list[dict[str, Any]] = [{} for _ in range(len(eval_instances))]
     for metric in metrics:
         metric_result = metric.evaluate(
-            lm_outputs=[lm_output.text for lm_output in lm_output_list],
+            lm_outputs=lm_output_list,
             references_list=[i.references for i in eval_instances],
             extra_info_list=[i.inputs for i in eval_instances],
         )
@@ -89,11 +88,6 @@ def evaluate_generation(  # noqa: C901
                 metric_result.instance_details,
             ):
                 instance_metrics_list[instance_idx].update(instance_details)
-
-    # Calculate the finish_reason statistics
-    finish_reason_counter = Counter([lm_output.finish_reason for lm_output in lm_output_list])
-    for finish_reason, count in finish_reason_counter.items():
-        metrics_summary_dict[f"finish_reason_ratio-{finish_reason}"] = count / len(lm_output_list)
 
     logger.info(metrics_summary_dict)
 

--- a/flexeval/core/metric/__init__.py
+++ b/flexeval/core/metric/__init__.py
@@ -6,6 +6,7 @@ from .common_prefix_length import CommonPrefixLength
 from .common_string_length import CommonStringLength
 from .correlation import Correlation
 from .exact_match import ExactMatch
+from .finish_reason import FinishReasonCount
 from .llm_geval_score import ChatLLMGEvalScore, LLMGEvalScore
 from .llm_label import ChatLLMLabel, LLMLabel
 from .llm_score import ChatLLMScore, LLMScore
@@ -16,4 +17,5 @@ from .repetition_count import RepetitionCount
 from .rouge import ROUGE
 from .sari import SARI
 from .substring_match import SubstringMatch
+from .tool_call import ToolCallCount
 from .xer import XER

--- a/flexeval/core/metric/finish_reason.py
+++ b/flexeval/core/metric/finish_reason.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from flexeval.core.language_model.base import LMOutput
+
+from .base import Metric, MetricResult
+from .utils import validate_inputs
+
+
+class FinishReasonCount(Metric):
+    """
+    Metric to compute the ratio of different finish_reason values.
+    """
+
+    def evaluate(
+        self,
+        lm_outputs: list[str | LMOutput],
+        references_list: list[list[str]],
+        extra_info_list: list[dict[str, str]] | None = None,
+    ) -> MetricResult:
+        validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Count finish_reason occurrences from messages
+        finish_reason_counter = Counter()
+        for lm_output in lm_outputs:
+            if not isinstance(lm_output, LMOutput):
+                msg = "FinishReasonMetric expects lm_outputs to be an LMOutput, but received a different type."
+                raise TypeError(msg)
+            finish_reason_counter[lm_output.finish_reason] += 1
+
+        total_count = sum(finish_reason_counter.values())
+        summary = {}
+        if total_count > 0:
+            for finish_reason, count in finish_reason_counter.items():
+                summary[f"finish_reason_ratio-{finish_reason}"] = count / total_count
+
+        return MetricResult(
+            summary=summary, instance_details=[{"finish_reason": lm_output.finish_reason} for lm_output in lm_outputs]
+        )

--- a/flexeval/core/metric/tool_call.py
+++ b/flexeval/core/metric/tool_call.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from flexeval.core.language_model.base import LMOutput
+
+from .base import Metric, MetricResult
+from .utils import validate_inputs
+
+
+class ToolCallCount(Metric):
+    """
+    Metric to compute the ratio of different tool_call_validation_result values.
+    """
+
+    def evaluate(
+        self,
+        lm_outputs: list[str | LMOutput],
+        references_list: list[list[str]],
+        extra_info_list: list[dict[str, str]] | None = None,
+    ) -> MetricResult:
+        validate_inputs(lm_outputs, references_list, extra_info_list)
+
+        # Calculate the finish_reason and validation statistics
+        tool_call_validation_result_counter = Counter()
+        for lm_output in lm_outputs:
+            if not isinstance(lm_output, LMOutput):
+                msg = "ToolCallCount expects lm_outputs to be an LMOutput, but received a different type."
+                raise TypeError(msg)
+            tool_call_validation_result_counter[lm_output.tool_call_validation_result] += 1
+
+        total_count = sum(tool_call_validation_result_counter.values())
+        summary = {}
+        if total_count > 0:
+            for validation_result, count in tool_call_validation_result_counter.items():
+                summary[f"tool_call_validation_result_ratio-{validation_result}"] = count / total_count
+        return MetricResult(
+            summary=summary,
+            instance_details=[
+                {"tool_call_validation_result": lm_output.tool_call_validation_result} for lm_output in lm_outputs
+            ],
+        )

--- a/tests/core/metric/test_finish_reason.py
+++ b/tests/core/metric/test_finish_reason.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from flexeval.core.language_model.base import LMOutput
+from flexeval.core.metric import MetricResult
+from flexeval.core.metric.finish_reason import FinishReasonCount
+
+
+@pytest.mark.parametrize(
+    ("finish_reasons", "expected_ratios", "expected_summary_len"),
+    [
+        (
+            ["stop", "length", "stop", "stop"],
+            {"finish_reason_ratio-stop": 3 / 4, "finish_reason_ratio-length": 1 / 4},
+            2,
+        ),
+        (
+            ["stop", "stop", "stop"],
+            {"finish_reason_ratio-stop": 1.0},
+            1,
+        ),
+        (
+            [None, "stop", None],
+            {"finish_reason_ratio-None": 2 / 3, "finish_reason_ratio-stop": 1 / 3},
+            2,
+        ),
+        (
+            ["stop", "length", "timeout", "error", "stop", "length"],
+            {
+                "finish_reason_ratio-stop": 2 / 6,
+                "finish_reason_ratio-length": 2 / 6,
+                "finish_reason_ratio-timeout": 1 / 6,
+                "finish_reason_ratio-error": 1 / 6,
+            },
+            4,
+        ),
+        ([], {}, 0),
+    ],
+)
+def test_finish_reason_count_functionality(
+    finish_reasons: list[str], expected_ratios: list[dict[str, float]], expected_summary_len: int
+) -> None:
+    """Test FinishReasonCount metric functionality with various finish reason combinations."""
+    metric = FinishReasonCount()
+
+    lm_outputs = [LMOutput(text=f"Response {i+1}", finish_reason=reason) for i, reason in enumerate(finish_reasons)]
+    references_list = [[f"ref{i+1}"] for i in range(len(finish_reasons))]
+
+    result = metric.evaluate(lm_outputs, references_list)
+
+    assert isinstance(result, MetricResult)
+    for key, expected_value in expected_ratios.items():
+        assert result.summary[key] == expected_value
+    assert len(result.summary) == expected_summary_len
+    assert result.instance_details == [{"finish_reason": reason} for reason in finish_reasons]
+
+
+def test_finish_reason_count_empty_list() -> None:
+    """Test FinishReasonCount with empty input lists."""
+    metric = FinishReasonCount()
+
+    lm_outputs = []
+    references_list = []
+
+    result = metric.evaluate(lm_outputs, references_list)
+
+    assert isinstance(result, MetricResult)
+    assert result.summary == {}
+    assert result.instance_details == []
+
+
+@pytest.mark.parametrize(
+    ("lm_outputs", "references_list"),
+    [
+        (["string output"], [["ref1"]]),
+    ],
+)
+def test_finish_reason_count_type_errors(lm_outputs: list[LMOutput], references_list: list[list[str]]) -> None:
+    """Test that FinishReasonCount raises TypeError for invalid input types."""
+    metric = FinishReasonCount()
+
+    with pytest.raises(TypeError) as exc_info:
+        metric.evaluate(lm_outputs, references_list)
+
+    assert "FinishReasonMetric expects lm_outputs to be an LMOutput" in str(exc_info.value)

--- a/tests/core/metric/test_tool_call.py
+++ b/tests/core/metric/test_tool_call.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from flexeval.core.language_model.base import LMOutput
+from flexeval.core.metric import MetricResult
+from flexeval.core.metric.tool_call import ToolCallCount
+
+
+@pytest.mark.parametrize(
+    ("validation_results", "expected_ratios"),
+    [
+        (
+            ["valid", "invalid", "valid", "valid"],
+            {"tool_call_validation_result_ratio-valid": 3 / 4, "tool_call_validation_result_ratio-invalid": 1 / 4},
+        ),
+        (
+            ["valid", "valid", "valid"],
+            {"tool_call_validation_result_ratio-valid": 1.0},
+        ),
+        (
+            [None, "valid", None],
+            {"tool_call_validation_result_ratio-None": 2 / 3, "tool_call_validation_result_ratio-valid": 1 / 3},
+        ),
+        (
+            [],
+            {},
+        ),
+        (
+            ["valid", "invalid", "parsing_error", "schema_error", "valid", "invalid"],
+            {
+                "tool_call_validation_result_ratio-valid": 2 / 6,
+                "tool_call_validation_result_ratio-invalid": 2 / 6,
+                "tool_call_validation_result_ratio-parsing_error": 1 / 6,
+                "tool_call_validation_result_ratio-schema_error": 1 / 6,
+            },
+        ),
+        (
+            ["", "partial_valid", "timeout", "unknown_error"],
+            {
+                "tool_call_validation_result_ratio-": 0.25,
+                "tool_call_validation_result_ratio-partial_valid": 0.25,
+                "tool_call_validation_result_ratio-timeout": 0.25,
+                "tool_call_validation_result_ratio-unknown_error": 0.25,
+            },
+        ),
+    ],
+)
+def test_tool_call_count_ratios(validation_results: list[str], expected_ratios: dict[str, float]) -> None:
+    """Test ToolCallCount ratio calculations with various validation result combinations."""
+    metric = ToolCallCount()
+
+    lm_outputs = [
+        LMOutput(text=f"Response {i}", tool_call_validation_result=result)
+        for i, result in enumerate(validation_results)
+    ]
+    references_list = [[f"ref{i}"] for i in range(len(validation_results))]
+
+    result = metric.evaluate(lm_outputs, references_list)
+
+    assert isinstance(result, MetricResult)
+    assert result.summary == expected_ratios
+    assert result.instance_details == [{"tool_call_validation_result": result} for result in validation_results]
+
+
+@pytest.mark.parametrize(
+    ("lm_outputs", "references_list"),
+    [
+        (["string output"], [["ref1"]]),
+    ],
+)
+def test_tool_call_count_type_errors(lm_outputs: list[str], references_list: list[list[str]]) -> None:
+    """Test that ToolCallCount raises TypeError for invalid input types."""
+    metric = ToolCallCount()
+
+    with pytest.raises(TypeError) as exc_info:
+        metric.evaluate(lm_outputs, references_list)
+
+    assert "ToolCallCount expects lm_outputs to be an LMOutput" in str(exc_info.value)

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -11,7 +11,7 @@ from flexeval.core.evaluate_pairwise import Match, evaluate_pairwise
 from flexeval.core.evaluate_perplexity import evaluate_perplexity
 from flexeval.core.evaluate_reward_model import evaluate_reward_model
 from flexeval.core.few_shot_generator import RandomFewShotGenerator
-from flexeval.core.metric import ExactMatch
+from flexeval.core.metric import ExactMatch, FinishReasonCount
 from flexeval.core.prompt_template import Jinja2PromptTemplate
 from flexeval.core.reward_model.pairwise_judge_reward_model import PairwiseJudgeRewardModel
 from tests.dummy_modules import (
@@ -41,7 +41,7 @@ def test_evaluate_generation(use_few_shot: bool) -> None:
         eval_dataset=DummyGenerationDataset(),
         prompt_template=Jinja2PromptTemplate("{{text}}"),
         few_shot_generator=few_shot_generator,
-        metrics=[ExactMatch()],
+        metrics=[ExactMatch(), FinishReasonCount()],
         batch_size=1,
     )
     assert isinstance(metrics, dict)

--- a/tests/scripts/test_flexeval_lm.py
+++ b/tests/scripts/test_flexeval_lm.py
@@ -278,7 +278,7 @@ def test_if_saved_config_can_be_reused_to_run_eval(command: list[str]) -> None:
 def test_if_flexeval_lm_loads_custom_module() -> None:
     custom_metric_code = """\
 from flexeval import Metric, MetricResult
-
+from flexeval.core.metric.utils import extract_text_from_outputs
 
 class MyCustomMetric(Metric):
     def evaluate(
@@ -287,6 +287,7 @@ class MyCustomMetric(Metric):
         extra_info_list,
         references_list,
     ) -> MetricResult:
+        lm_outputs = extract_text_from_outputs(lm_outputs)
         length_ratios = [
             len(lm_output) / len(references[0])  # Assuming a single reference
             for lm_output, references in zip(lm_outputs, references_list)


### PR DESCRIPTION
* Introduce `FinishReasonCount` and `ToolCallCount` metrics to compute ratios of `finish_reason` and `tool_call_validation_result` values from `LMOutput` objects.
  * This was previously computed in `evaluate_chat_response`. I moved it to `Metric` class for better modularity.
* Automatically include `FinishReasonCount` and `OutputLengthStats` in default metrics for chat and generation runs.
* Simplify `evaluate_chat_response`: remove manual counting and delegate to the new metrics. Restructure the output for backward compatibility and future extensibility.
* A bit of refactoring for `evaluate_generation`