### PR TITLE
Allow empty `gen_kwargs` for some `EvalSetup` classes

### DIFF
--- a/flexeval/core/eval_setups.py
+++ b/flexeval/core/eval_setups.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from .chat_dataset import ChatDataset
@@ -45,7 +45,7 @@ class ChatResponse(EvalSetup):
     """
 
     eval_dataset: ChatDataset
-    gen_kwargs: dict[str, Any]
+    gen_kwargs: dict[str, Any] = field(default_factory=dict)
     few_shot_generator: FewShotGenerator | None = None
     metrics: list[Metric] | Metric | None = None
     batch_size: int = 4
@@ -80,7 +80,7 @@ class Generation(EvalSetup):
 
     eval_dataset: GenerationDataset
     prompt_template: PromptTemplate | str
-    gen_kwargs: dict[str, Any]
+    gen_kwargs: dict[str, Any] = field(default_factory=dict)
     few_shot_generator: FewShotGenerator | None = None
     metrics: list[Metric] | Metric | None = None
     batch_size: int = 4


### PR DESCRIPTION
Now kwargs (e.g., `top_p`, `temperature`) can be set on the `LanguageModel` side ([example](https://github.com/sbintuitions/flexeval/blob/13e45cc92c43ec6a4b75f32fde3e028f2c9be2e6/flexeval/core/language_model/vllm_model.py#L109)).
We no longer need to enforce `gen_kwargs` on the `EvalSetup` side.

