### PR TITLE
Remove tool_call validation in `HuggingFaceLM` and fix typing

### DIFF
--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -93,7 +93,7 @@ class LanguageModel:
     def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
         """Generate chat responses based on the chat messages in the list.

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -388,12 +388,9 @@ class HuggingFaceLM(LanguageModel):
     def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
-        if tools_list and not self.tool_parser:
-            msg = "tool_parser is not set but tools are provided."
-            raise ValueError(msg)
         if tools_list is None:
             tools_list = [None] * len(chat_messages_list)
         if self.system_message is not None:

--- a/flexeval/core/language_model/litellm_api.py
+++ b/flexeval/core/language_model/litellm_api.py
@@ -76,7 +76,7 @@ class LiteLLMChatAPI(OpenAIChatAPI):
     def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
         if "seed" in kwargs and self.ignore_seed:

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -107,7 +107,7 @@ class OpenAIChatAPI(LanguageModel):
     async def _async_batch_run_chatgpt(
         self,
         messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         stop_sequences: str | list[str] | None = None,
         max_new_tokens: int | None = None,
         **kwargs,
@@ -195,7 +195,7 @@ class OpenAIChatAPI(LanguageModel):
     def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
         api_responses = asyncio.run(

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -178,7 +178,7 @@ class OpenAIChatBatchAPI(LanguageModel):
     def _execute_batch_requests(  # noqa: C901
         self,
         messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[Any]:
         if tools_list is None:
@@ -262,7 +262,7 @@ class OpenAIChatBatchAPI(LanguageModel):
     def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
         api_responses = self._execute_batch_requests(

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -235,7 +235,7 @@ class VLLM(LanguageModel):
     def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
         if tools_list is None:

--- a/flexeval/core/language_model/vllm_serve_lm.py
+++ b/flexeval/core/language_model/vllm_serve_lm.py
@@ -223,7 +223,7 @@ class VLLMServeLM(OpenAIChatAPI):
     def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
-        tools_list: list[list[dict[str, Any]]] | None = None,
+        tools_list: list[list[dict[str, Any]] | None] | None = None,
         **kwargs,
     ) -> list[LMOutput]:
         return super()._batch_generate_chat_response(


### PR DESCRIPTION
The following line may return [None, None, ...], which is interpreted as True.

https://github.com/sbintuitions/flexeval/blob/a74486951ae3c51b2a4e4191e7bf3d10871aa824/flexeval/core/evaluate_chat_response.py#L120

As a result, the if clause incorrectly assumes that tools are available.

https://github.com/sbintuitions/flexeval/blob/a74486951ae3c51b2a4e4191e7bf3d10871aa824/flexeval/core/language_model/hf_lm.py#L394-L396

To fix this issue, remove the validation step.