### PR TITLE
Improve data handling in json.dumps used for logging

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, is_dataclass
-from typing import Any, Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Any
 
 from loguru import logger
 from tqdm import tqdm
 
 from flexeval.core.utils.chat_util import find_first_turn_for_response
+from flexeval.core.utils.json_util import truncated_default
 
 from .chat_dataset import ChatInstance
 from .few_shot_generator import FewShotGenerator
@@ -80,13 +81,6 @@ def _find_response_context_index(incomplete_messages: list[dict[str, Any]]) -> i
         return len(incomplete_messages)
 
     return None
-
-
-def dataclass_default(o: Any) -> Any:  # noqa: ANN401
-    if is_dataclass(o):
-        return asdict(o)
-    msg = f"Object of type {type(o).__name__} is not JSON serializable"
-    raise TypeError(msg)
 
 
 def execute_conversation_flow(
@@ -184,7 +178,7 @@ def evaluate_chat_response(  # noqa: C901
     ):
         if i == 0:
             logger.info("Example of the output")
-            logger.info(json.dumps(output, ensure_ascii=False, indent=4, default=dataclass_default))
+            logger.info(json.dumps(output, ensure_ascii=False, indent=4, default=truncated_default))
         outputs.append(output)
 
     language_model.cleanup_resources()

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -8,7 +8,7 @@ from loguru import logger
 from tqdm import tqdm
 
 from flexeval.core.utils.chat_util import find_first_turn_for_response
-from flexeval.core.utils.json_util import truncated_default
+from flexeval.core.utils.json_util import truncate_base64
 
 from .chat_dataset import ChatInstance
 from .few_shot_generator import FewShotGenerator
@@ -178,7 +178,7 @@ def evaluate_chat_response(  # noqa: C901
     ):
         if i == 0:
             logger.info("Example of the output")
-            logger.info(json.dumps(output, ensure_ascii=False, indent=4, default=truncated_default))
+            logger.info(json.dumps(output, ensure_ascii=False, indent=4, default=truncate_base64))
         outputs.append(output)
 
     language_model.cleanup_resources()

--- a/flexeval/core/result_recorder/local_recorder.py
+++ b/flexeval/core/result_recorder/local_recorder.py
@@ -35,7 +35,7 @@ def save_jsonl(
 def save_json(json_dict: dict[str, Any], save_path: str | PathLike[str]) -> None:
     Path(save_path).parent.mkdir(parents=True, exist_ok=True)
     with open(save_path, "w") as f:
-        json.dump(json_dict, f, indent=4, ensure_ascii=False, default=truncated_default)
+        json.dump(json_dict, f, indent=4, ensure_ascii=False, default=str)
 
 
 class LocalRecorder(ResultRecorder):

--- a/flexeval/core/result_recorder/local_recorder.py
+++ b/flexeval/core/result_recorder/local_recorder.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from loguru import logger
 
-from flexeval.core.utils.json_util import truncated_default
+from flexeval.core.utils.json_util import truncate_base64
 
 from .base import ResultRecorder
 
@@ -24,7 +24,7 @@ def save_jsonl(
     Path(save_path).parent.mkdir(parents=True, exist_ok=True)
     with open(save_path, "w") as f:
         for d in data:
-            dump_line = json.dumps(d, ensure_ascii=False, default=truncated_default)
+            dump_line = json.dumps(d, ensure_ascii=False, default=truncate_base64)
             try:
                 f.write(f"{dump_line}\n")
             except UnicodeEncodeError:

--- a/flexeval/core/result_recorder/local_recorder.py
+++ b/flexeval/core/result_recorder/local_recorder.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from os import PathLike
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from loguru import logger
+
+from flexeval.core.utils.json_util import truncated_default
 
 from .base import ResultRecorder
 
@@ -21,7 +24,7 @@ def save_jsonl(
     Path(save_path).parent.mkdir(parents=True, exist_ok=True)
     with open(save_path, "w") as f:
         for d in data:
-            dump_line = json.dumps(d, ensure_ascii=False, default=str)
+            dump_line = json.dumps(d, ensure_ascii=False, default=truncated_default)
             try:
                 f.write(f"{dump_line}\n")
             except UnicodeEncodeError:
@@ -32,7 +35,7 @@ def save_jsonl(
 def save_json(json_dict: dict[str, Any], save_path: str | PathLike[str]) -> None:
     Path(save_path).parent.mkdir(parents=True, exist_ok=True)
     with open(save_path, "w") as f:
-        json.dump(json_dict, f, indent=4, ensure_ascii=False, default=str)
+        json.dump(json_dict, f, indent=4, ensure_ascii=False, default=truncated_default)
 
 
 class LocalRecorder(ResultRecorder):

--- a/flexeval/core/utils/json_util.py
+++ b/flexeval/core/utils/json_util.py
@@ -1,0 +1,12 @@
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+
+def truncated_default(o: Any, max_length: int = 512) -> Any:  # noqa: ANN401
+    if is_dataclass(o):
+        return asdict(o)
+
+    s = str(o)
+    if len(s) > max_length:
+        return s[:max_length] + f"... [truncated, {len(s)} chars total]"
+    return s

--- a/flexeval/core/utils/json_util.py
+++ b/flexeval/core/utils/json_util.py
@@ -1,12 +1,17 @@
+import re
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
+base64_pattern = re.compile(r"^data:\w+\/\w+;base64,.+")
 
-def truncated_default(o: Any, max_length: int = 512) -> Any:  # noqa: ANN401
+
+def truncate_base64(o: Any) -> Any:  # noqa: ANN401
     if is_dataclass(o):
         return asdict(o)
 
     s = str(o)
-    if len(s) > max_length:
-        return s[:max_length] + f"... [truncated, {len(s)} chars total]"
+
+    if base64_pattern.match(s):
+        return f"{s[:50]}... [truncated, {len(s)} chars total]"
+
     return s

--- a/tests/core/utils/test_json_util.py
+++ b/tests/core/utils/test_json_util.py
@@ -1,0 +1,37 @@
+import dataclasses
+
+from flexeval.core.utils.json_util import truncate_base64
+
+
+@dataclasses.dataclass
+class TestDataClass:
+    field1: str
+    field2: int
+
+
+class TestData:
+    def __repr__(self) -> str:
+        return "TestData"
+
+
+test_base64 = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/"
+    "AAAGACAIAAABUQk3oAAEAAElEQVR4nMz9SZgtSXYeiJ1zzMynO0bEizfmPFRW1pAFoFATpmIDLTb"
+    "VX5P8WuPXG26p75O2WqillTbSQtroU6sXWojaSE2qG+"
+)
+
+
+def test_truncate_base64() -> None:
+    assert truncate_base64(TestDataClass("example", 123)) == {"field1": "example", "field2": 123}
+
+    assert truncate_base64(TestData()) == "TestData"
+
+    assert (
+        truncate_base64(test_base64)
+        == "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]"
+    )
+
+    assert (
+        truncate_base64(f"This is an example of base64: {test_base64}")
+        == f"This is an example of base64: {test_base64}"
+    )


### PR DESCRIPTION
When using flexeval with multimodal data, the default `json.dumps` suffers from
1. binary data and others that are not supported by json, and
2. bae64 data that are very long and hinders the readability of logs.

This PR adds a customized data handling to overcome these problems by
1. converting binary data and others to str by using `str`, and
2. truncating strings that are longer than 512.

This data handler will be used in the output logging in `LocalRecorder` and the logging of the first instance in `evaluate_chat_response`.

Thanks @ryokan0123 for the feedback!