### PR TITLE
Add `tools` parameter to language models

### DIFF
--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -186,6 +186,7 @@ class HuggingFaceLM(LanguageModel):
             an empty string is returned instead of raising an error.
             If set to “default”, the value will be automatically determined when possible.
         tool_parser: A ToolParser object to extract the tool_calls from the model's output.
+        tools: Default tools to use in chat responses when no tools are explicitly provided.
     """
 
     def __init__(
@@ -205,6 +206,7 @@ class HuggingFaceLM(LanguageModel):
         string_processors: StringProcessor | list[StringProcessor] | None = None,
         model_limit_tokens: int | None | Literal["default"] = "default",
         tool_parser: ToolParser | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(string_processors=string_processors)
         self._model_name_or_path = model
@@ -223,6 +225,7 @@ class HuggingFaceLM(LanguageModel):
         self.amp_dtype = amp_dtype
         self.model_limit_tokens = model_limit_tokens
         self.tool_parser = tool_parser
+        self.tools = tools
         logger.info(f"amp_dtype: {amp_dtype}")
         logger.info(f"random seed: {random_seed}")
         transformers.set_seed(random_seed)
@@ -392,7 +395,7 @@ class HuggingFaceLM(LanguageModel):
         **kwargs,
     ) -> list[LMOutput]:
         if tools_list is None:
-            tools_list = [None] * len(chat_messages_list)
+            tools_list = [self.tools] * len(chat_messages_list)
         if self.system_message is not None:
             for chat_messages in chat_messages_list:
                 chat_messages.insert(0, {"role": "system", "content": self.system_message})

--- a/flexeval/core/language_model/litellm_api.py
+++ b/flexeval/core/language_model/litellm_api.py
@@ -31,6 +31,7 @@ class LiteLLMChatAPI(OpenAIChatAPI):
         model_limit_completion_tokens: An upper limit on the number of tokens the model can generate.
             For example, if a too-large `max_new_tokens` is given to generate_chat_response(), this value will cap it.
         max_parallel_requests: Maximum number of parallel requests to send to the API.
+        tools: Default tools to use in chat responses when no tools are explicitly provided.
     """
 
     def __init__(
@@ -42,6 +43,7 @@ class LiteLLMChatAPI(OpenAIChatAPI):
         ignore_seed: bool = False,
         model_limit_completion_tokens: int | None = None,
         max_parallel_requests: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(
             model=model,
@@ -51,6 +53,7 @@ class LiteLLMChatAPI(OpenAIChatAPI):
             string_processors=string_processors,
             model_limit_new_tokens=model_limit_completion_tokens,
             max_parallel_requests=max_parallel_requests,
+            tools=tools,
         )
         self.model = model
         self.default_gen_kwargs = default_gen_kwargs or {}

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -79,6 +79,7 @@ class OpenAIChatAPI(LanguageModel):
         model_limit_new_tokens: An upper limit on the number of tokens the model can generate.
             For example, if a too-large `max_new_tokens` is given to generate_chat_response(), this value will cap it.
         max_parallel_requests: Maximum number of parallel requests to send to the OpenAI API.
+        tools: Default tools to use in chat responses when no tools are explicitly provided.
     """
 
     def __init__(
@@ -90,6 +91,7 @@ class OpenAIChatAPI(LanguageModel):
         string_processors: StringProcessor | list[StringProcessor] | None = None,
         model_limit_new_tokens: int | None = None,
         max_parallel_requests: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(string_processors=string_processors)
         self.model = model
@@ -106,6 +108,7 @@ class OpenAIChatAPI(LanguageModel):
         self.developer_message = developer_message
         self.model_limit_new_tokens = model_limit_new_tokens
         self.max_parallel_requests = max_parallel_requests
+        self.tools = tools
 
     def _parallel_run_chatgpt(
         self,
@@ -151,7 +154,7 @@ class OpenAIChatAPI(LanguageModel):
         )
 
         if tools_list is None:
-            tools_list = [None] * len(messages_list)
+            tools_list = [self.tools] * len(messages_list)
 
         max_workers = self.max_parallel_requests or len(messages_list)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -61,6 +61,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         string_processors: A single or a list of StringProcessor objects to process the model's output.
         model_limit_new_tokens: An upper limit on the number of tokens the model can generate.
             For example, if a too-large `max_new_tokens` is given to generate_chat_response(), this value will cap it.
+        tools: Default tools to use in chat responses when no tools are explicitly provided.
     """
 
     def __init__(
@@ -72,6 +73,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         developer_message: str | None = None,
         string_processors: StringProcessor | list[StringProcessor] | None = None,
         model_limit_new_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(string_processors=string_processors)
         self.model = model
@@ -87,6 +89,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         self.polling_interval_seconds = polling_interval_seconds
         self.developer_message = developer_message
         self.model_limit_new_tokens = model_limit_new_tokens
+        self.tools = tools
 
     def create_batch_file(self, custom_id_2_input: dict[str, list[dict[str, list[dict[str, Any]]]]], **kwargs) -> None:
         with open(self.temp_jsonl_file.name, mode="w") as f:
@@ -182,7 +185,7 @@ class OpenAIChatBatchAPI(LanguageModel):
         **kwargs,
     ) -> list[Any]:
         if tools_list is None:
-            tools_list = [None] * len(messages_list)
+            tools_list = [self.tools] * len(messages_list)
         custom_id_2_input: dict[str, list[dict[str, list[dict[str, Any]]]]] = {
             str(uuid.uuid4()): {"messages": messages, "tools": tools}
             for messages, tools in zip(messages_list, tools_list)

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -94,6 +94,7 @@ class VLLM(LanguageModel):
             an empty string is returned instead of raising an error.
             If set to “default”, the value will be automatically determined when possible.
         tool_parser: A ToolParser object to extract the tool_calls from the model's output.
+        tools: Default tools to use in chat responses when no tools are explicitly provided.
     """
 
     def __init__(
@@ -110,6 +111,7 @@ class VLLM(LanguageModel):
         string_processors: StringProcessor | list[StringProcessor] | None = None,
         model_limit_tokens: int | None | Literal["default"] = "default",
         tool_parser: ToolParser | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(string_processors=string_processors)
         self.model_name = model
@@ -138,6 +140,7 @@ class VLLM(LanguageModel):
         self.llm: LLM | None = None
         self.model_limit_tokens = model_limit_tokens
         self.tool_parser = tool_parser
+        self.tools = tools
 
     @staticmethod
     def load_model(method: Callable) -> Callable:
@@ -239,7 +242,7 @@ class VLLM(LanguageModel):
         **kwargs,
     ) -> list[LMOutput]:
         if tools_list is None:
-            tools_list = [None] * len(chat_messages_list)
+            tools_list = [self.tools] * len(chat_messages_list)
         if self.system_message is not None:
             for chat_messages in chat_messages_list:
                 chat_messages.insert(0, {"role": "system", "content": self.system_message})

--- a/flexeval/core/language_model/vllm_serve_lm.py
+++ b/flexeval/core/language_model/vllm_serve_lm.py
@@ -167,6 +167,7 @@ class VLLMServeLM(OpenAIChatAPI):
         string_processors: A single or a list of StringProcessor objects to process the model's output.
         model_limit_new_tokens: An upper limit on the number of tokens the model can generate.
             For example, if a too-large `max_new_tokens` is given to generate_chat_response(), this value will cap it.
+        tools: Default tools to use in chat responses when no tools are explicitly provided.
     """
 
     def __init__(
@@ -179,6 +180,7 @@ class VLLMServeLM(OpenAIChatAPI):
         developer_message: str | None = None,
         string_processors: StringProcessor | list[StringProcessor] | None = None,
         model_limit_new_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> None:
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -196,6 +198,7 @@ class VLLMServeLM(OpenAIChatAPI):
             developer_message=developer_message,
             string_processors=string_processors,
             model_limit_new_tokens=model_limit_new_tokens,
+            tools=tools,
         )
 
     @staticmethod


### PR DESCRIPTION
This pull request adds support for specifying default `tools` in chat-based language model APIs. Now, if no tools are explicitly provided for a chat response, the default tools specified in the model initialization will be used automatically.