### PR TITLE
Add a custom JSON encoder to truncate base64 strings

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -8,7 +8,7 @@ from loguru import logger
 from tqdm import tqdm
 
 from flexeval.core.utils.chat_util import find_first_turn_for_response
-from flexeval.core.utils.json_util import truncate_base64
+from flexeval.core.utils.json_util import Base64TruncatingJSONEncoder
 
 from .chat_dataset import ChatInstance
 from .few_shot_generator import FewShotGenerator
@@ -178,7 +178,7 @@ def evaluate_chat_response(  # noqa: C901
     ):
         if i == 0:
             logger.info("Example of the output")
-            logger.info(json.dumps(output, ensure_ascii=False, indent=4, default=truncate_base64))
+            logger.info(json.dumps(output, ensure_ascii=False, indent=4, cls=Base64TruncatingJSONEncoder))
         outputs.append(output)
 
     language_model.cleanup_resources()

--- a/flexeval/core/result_recorder/local_recorder.py
+++ b/flexeval/core/result_recorder/local_recorder.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from loguru import logger
 
-from flexeval.core.utils.json_util import truncate_base64
+from flexeval.core.utils.json_util import Base64TruncatingJSONEncoder
 
 from .base import ResultRecorder
 
@@ -24,7 +24,7 @@ def save_jsonl(
     Path(save_path).parent.mkdir(parents=True, exist_ok=True)
     with open(save_path, "w") as f:
         for d in data:
-            dump_line = json.dumps(d, ensure_ascii=False, default=truncate_base64)
+            dump_line = json.dumps(d, ensure_ascii=False, cls=Base64TruncatingJSONEncoder)
             try:
                 f.write(f"{dump_line}\n")
             except UnicodeEncodeError:

--- a/flexeval/core/utils/json_util.py
+++ b/flexeval/core/utils/json_util.py
@@ -1,3 +1,4 @@
+import json
 import re
 from dataclasses import asdict, is_dataclass
 from typing import Any
@@ -5,9 +6,13 @@ from typing import Any
 base64_pattern = re.compile(r"^data:\w+\/\w+;base64,.+")
 
 
-def truncate_base64(o: Any) -> Any:  # noqa: ANN401
+def _truncate_base64(o: Any) -> str:  # noqa: ANN401
     if is_dataclass(o):
-        return asdict(o)
+        return _truncate_base64(asdict(o))
+    if isinstance(o, (list, tuple, set)):
+        return type(o)(_truncate_base64(item) for item in o)
+    if isinstance(o, dict):
+        return {k: _truncate_base64(v) for k, v in o.items()}
 
     s = str(o)
 
@@ -15,3 +20,9 @@ def truncate_base64(o: Any) -> Any:  # noqa: ANN401
         return f"{s[:50]}... [truncated, {len(s)} chars total]"
 
     return s
+
+
+class Base64TruncatingJSONEncoder(json.JSONEncoder):
+    def encode(self, o: Any) -> str:  # noqa: ANN401
+        o = _truncate_base64(o)
+        return super().encode(o)

--- a/tests/core/utils/test_json_util.py
+++ b/tests/core/utils/test_json_util.py
@@ -26,7 +26,7 @@ def test_truncate_base64() -> None:
     def _json_dumps(x):  # noqa: ANN001, ANN202
         return json.dumps(x, cls=Base64TruncatingJSONEncoder)
 
-    assert _json_dumps(TestDataClass("example", 123)) == {"field1": "example", "field2": 123}
+    assert _json_dumps(TestDataClass("example", 123)) == '{"field1": "example", "field2": 123}'
 
     assert _json_dumps(TestData()) == "TestData"
 
@@ -39,10 +39,13 @@ def test_truncate_base64() -> None:
         "normal string",
     ]
 
-    assert _json_dumps(TestDataClass(base64_string, 456)) == {
+    assert (
+        _json_dumps(TestDataClass(base64_string, 456))
+        == """{
         "field1": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]",
         "field2": 456,
-    }
+    }"""
+    )
 
     image_url = _json_dumps({"messages": [{"content": {"type": "image_url", "image_url": {"url": base64_string}}}]})
     assert (

--- a/tests/core/utils/test_json_util.py
+++ b/tests/core/utils/test_json_util.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+from ast import literal_eval
 
 from flexeval.core.utils.json_util import Base64TruncatingJSONEncoder
 
@@ -26,7 +27,7 @@ def test_truncate_base64() -> None:
     def _json_dumps(x):  # noqa: ANN001, ANN202
         return json.dumps(x, cls=Base64TruncatingJSONEncoder)
 
-    assert _json_dumps(TestDataClass("example", 123)) == '{"field1": "example", "field2": 123}'
+    assert literal_eval(_json_dumps(TestDataClass("example", 123))) == {"field1": "example", "field2": 123}
 
     assert _json_dumps(TestData()) == "TestData"
 
@@ -34,20 +35,19 @@ def test_truncate_base64() -> None:
         "key": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]"
     }
 
-    assert _json_dumps([base64_string, "normal string"]) == [
+    assert literal_eval(_json_dumps([base64_string, "normal string"])) == [
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]",
         "normal string",
     ]
 
-    assert (
-        _json_dumps(TestDataClass(base64_string, 456))
-        == """{
+    assert literal_eval(_json_dumps(TestDataClass(base64_string, 456))) == {
         "field1": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]",
         "field2": 456,
-    }"""
-    )
+    }
 
-    image_url = _json_dumps({"messages": [{"content": {"type": "image_url", "image_url": {"url": base64_string}}}]})
+    image_url = literal_eval(
+        _json_dumps({"messages": [{"content": {"type": "image_url", "image_url": {"url": base64_string}}}]})
+    )
     assert (
         image_url["messages"][0]["content"]["image_url"]["url"]
         == "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]"

--- a/tests/core/utils/test_json_util.py
+++ b/tests/core/utils/test_json_util.py
@@ -1,6 +1,7 @@
 import dataclasses
+import json
 
-from flexeval.core.utils.json_util import truncate_base64
+from flexeval.core.utils.json_util import Base64TruncatingJSONEncoder
 
 
 @dataclasses.dataclass
@@ -14,7 +15,7 @@ class TestData:
         return "TestData"
 
 
-test_base64 = (
+base64_string = (
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/"
     "AAAGACAIAAABUQk3oAAEAAElEQVR4nMz9SZgtSXYeiJ1zzMynO0bEizfmPFRW1pAFoFATpmIDLTb"
     "VX5P8WuPXG26p75O2WqillTbSQtroU6sXWojaSE2qG+"
@@ -22,16 +23,29 @@ test_base64 = (
 
 
 def test_truncate_base64() -> None:
-    assert truncate_base64(TestDataClass("example", 123)) == {"field1": "example", "field2": 123}
+    def _json_dumps(x):
+        return json.dumps(x, cls=Base64TruncatingJSONEncoder)
 
-    assert truncate_base64(TestData()) == "TestData"
+    assert _json_dumps(TestDataClass("example", 123)) == {"field1": "example", "field2": 123}
 
+    assert _json_dumps(TestData()) == "TestData"
+
+    assert _json_dumps({"key": base64_string}) == {
+        "key": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]"
+    }
+
+    assert _json_dumps([base64_string, "normal string"]) == [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]",
+        "normal string",
+    ]
+
+    assert _json_dumps(TestDataClass(base64_string, 456)) == {
+        "field1": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]",
+        "field2": 456,
+    }
+
+    image_url = _json_dumps({"messages": [{"content": {"type": "image_url", "image_url": {"url": base64_string}}}]})
     assert (
-        truncate_base64(test_base64)
+        image_url["messages"][0]["content"]["image_url"]["url"]
         == "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]"
-    )
-
-    assert (
-        truncate_base64(f"This is an example of base64: {test_base64}")
-        == f"This is an example of base64: {test_base64}"
     )

--- a/tests/core/utils/test_json_util.py
+++ b/tests/core/utils/test_json_util.py
@@ -27,11 +27,11 @@ def test_truncate_base64() -> None:
     def _json_dumps(x):  # noqa: ANN001, ANN202
         return json.dumps(x, cls=Base64TruncatingJSONEncoder)
 
-    assert literal_eval(_json_dumps(TestDataClass("example", 123))) == {"field1": "example", "field2": 123}
+    assert literal_eval(_json_dumps(TestDataClass("example", 123))) == {"field1": "example", "field2": "123"}
 
-    assert _json_dumps(TestData()) == "TestData"
+    assert literal_eval(_json_dumps(TestData())) == "TestData"
 
-    assert _json_dumps({"key": base64_string}) == {
+    assert literal_eval(_json_dumps({"key": base64_string})) == {
         "key": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]"
     }
 
@@ -42,7 +42,7 @@ def test_truncate_base64() -> None:
 
     assert literal_eval(_json_dumps(TestDataClass(base64_string, 456))) == {
         "field1": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgA/... [truncated, 169 chars total]",
-        "field2": 456,
+        "field2": "456",
     }
 
     image_url = literal_eval(

--- a/tests/core/utils/test_json_util.py
+++ b/tests/core/utils/test_json_util.py
@@ -23,7 +23,7 @@ base64_string = (
 
 
 def test_truncate_base64() -> None:
-    def _json_dumps(x):
+    def _json_dumps(x):  # noqa: ANN001, ANN202
         return json.dumps(x, cls=Base64TruncatingJSONEncoder)
 
     assert _json_dumps(TestDataClass("example", 123)) == {"field1": "example", "field2": 123}


### PR DESCRIPTION
https://github.com/sbintuitions/flexeval/pull/230 failed to achieve its goal to truncate base64 strings in JSON by using `default` in `json.dumps`, as default data types such as `str` bypassed `default`.
This PR fixes this issue by customizing `JSONEncoder` to modify inputs of such data types.