### PR TITLE
Relax the version requirement of `scipy`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8370,4 +8370,4 @@ wandb = ["wandb"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "247fc1f1c9129716fbc4d6953a21437d24ce12f7b78d4742234b25602d8d0684"
+content-hash = "b628b93fd9377d66b3f5528be3f8138ae34d6c0c5ac87f9c42535a2abca03969"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ loguru = "^0.7.2"
 wandb = {version = "^0.17.2", optional = true}
 pyarrow = "16.1.0"  # set the version because we get "Unable to find installation candidates" with 17.0.0
 litellm = "^1.52.9"
-scipy = "1.13.0"
+scipy = "^1.13.0"
 smart-open = "^7.1.0"
 # The "ja" component of Transformers depends on sudachipy 0.6.6 or later. For aarch64 Linux h
 # environment, the pre-built binary of sudachi.rs is not available from PyPI. Pip downloads the


### PR DESCRIPTION
This pull request makes a minor update to the dependency specification for `scipy` in `pyproject.toml`.
The change switches from requiring exactly version 1.13.0 to allowing any compatible version starting from 1.13.0, which increases flexibility for dependency resolution.