### PR TITLE
Allow the regex for parsing *Chat*LLMScore to be configurable.

### DIFF
--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -311,6 +311,7 @@ class ChatLLMScore(Metric):
         category_key: A key to create category-wise mean score.
             The category key is expected to be in extra_info.
         metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
+        regex_to_parse_score: A regular expression to parse score.
 
     Examples:
         >>> from flexeval import ChatLLMScore, OpenAIChatAPI, Jinja2PromptTemplate
@@ -347,6 +348,7 @@ class ChatLLMScore(Metric):
         valid_score_range: tuple[int, int] | None = None,
         category_key: str | None = None,
         metric_prefix: str | None = None,
+        regex_to_parse_score: str = r"(\d+)",
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -356,6 +358,7 @@ class ChatLLMScore(Metric):
         self.valid_score_range = valid_score_range
         self.category_key = category_key
         self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
+        self.regex_to_parse_score = regex_to_parse_score
 
     def evaluate(
         self,
@@ -384,6 +387,7 @@ class ChatLLMScore(Metric):
             evaluator_score = parse_score_from_evaluator_output(
                 evaluator_output.text,
                 valid_score_range=self.valid_score_range,
+                regex_to_parse_score=self.regex_to_parse_score,
             )
             if evaluator_score is None:
                 logger.warning(f"Failed to parse score from evaluator output: {evaluator_output}")

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -56,7 +56,7 @@ def test_parse_score_from_evaluator_output(
 
 
 @pytest.mark.parametrize(
-    ("lm_outputs", "extra_info_list", "expected_summary"),
+    ("lm_outputs", "extra_info_list", "regex_to_parse_score", "expected_summary"),
     [
         (
             ["This score is 1.", "This score is 2.", "This is a good one."],
@@ -65,6 +65,7 @@ def test_parse_score_from_evaluator_output(
                 {"category": "category-0"},
                 {"category": "category-1"},
             ],
+            r"(\d+)",
             {
                 "llm_score": 1.5,
                 "num_failed_score_parses": 1,
@@ -79,11 +80,27 @@ def test_parse_score_from_evaluator_output(
                 {"category": []},
                 {"category": [""]},
             ],
+            r"(\d+)",
             {
                 "llm_score": 2.0,
                 "num_failed_score_parses": 1,
                 "llm_score/category-0": 1.5,
                 "llm_score/category-1": 2.0,
+            },
+        ),
+        (
+            ["This score is [[1]].", "This score is 2.", "This score is 3.", "This is a good one."],
+            [
+                {"category": ["category-0"]},
+                {"category": ["category-0", "category-1"]},
+                {"category": []},
+                {"category": [""]},
+            ],
+            r"\[\[(\d+)\]\]",
+            {
+                "llm_score": 1.0,
+                "num_failed_score_parses": 3,
+                "llm_score/category-0": 1.0,
             },
         ),
     ],
@@ -94,6 +111,7 @@ def test_llm_score(
     lm_outputs: list[str | LMOutput],
     extra_info_list: list[dict[str, str | list[str]]],
     expected_summary: dict[str, float],
+    regex_to_parse_score: str,
     metric_prefix: str | None,
 ) -> None:
     metric = LLMScore(
@@ -101,6 +119,7 @@ def test_llm_score(
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         category_key="category",
         metric_prefix=metric_prefix,
+        regex_to_parse_score=regex_to_parse_score
     )
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
@@ -117,7 +136,7 @@ def test_llm_score(
 
 
 @pytest.mark.parametrize(
-    ("lm_outputs", "extra_info_list", "expected_summary"),
+    ("lm_outputs", "extra_info_list", "regex_to_parse_score", "expected_summary"),
     [
         (
             ["This score is 1.", "This score is 2.", "This is a good one."],
@@ -126,6 +145,7 @@ def test_llm_score(
                 {"category": "category-0"},
                 {"category": "category-1"},
             ],
+            r"(\d+)",
             {
                 "llm_score": 1.5,
                 "num_failed_score_parses": 1,
@@ -140,11 +160,27 @@ def test_llm_score(
                 {"category": []},
                 {"category": [""]},
             ],
+            r"(\d+)",
             {
                 "llm_score": 2.0,
                 "num_failed_score_parses": 1,
                 "llm_score/category-0": 1.5,
                 "llm_score/category-1": 2.0,
+            },
+        ),
+        (
+            ["This score is [[1]].", "This score is 2.", "This score is 3.", "This is a good one."],
+            [
+                {"category": ["category-0"]},
+                {"category": ["category-0", "category-1"]},
+                {"category": []},
+                {"category": [""]},
+            ],
+            r"\[\[(\d+)\]\]",
+            {
+                "llm_score": 1.0,
+                "num_failed_score_parses": 3,
+                "llm_score/category-0": 1.0,
             },
         ),
     ],
@@ -155,6 +191,7 @@ def test_chat_llm_score(
     lm_outputs: list[str | LMOutput],
     extra_info_list: list[dict[str, str | list[str]]],
     expected_summary: dict[str, float],
+    regex_to_parse_score: str,
     metric_prefix: str,
 ) -> None:
     metric = ChatLLMScore(
@@ -162,6 +199,7 @@ def test_chat_llm_score(
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         category_key="category",
         metric_prefix=metric_prefix,
+        regex_to_parse_score=regex_to_parse_score
     )
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -119,7 +119,7 @@ def test_llm_score(
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         category_key="category",
         metric_prefix=metric_prefix,
-        regex_to_parse_score=regex_to_parse_score
+        regex_to_parse_score=regex_to_parse_score,
     )
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,
@@ -199,7 +199,7 @@ def test_chat_llm_score(
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         category_key="category",
         metric_prefix=metric_prefix,
-        regex_to_parse_score=regex_to_parse_score
+        regex_to_parse_score=regex_to_parse_score,
     )
     metric_output = metric.evaluate(
         lm_outputs=lm_outputs,


### PR DESCRIPTION
Continuation of #237  (I forgot to apply it to ChatLLMScore...).
Add some tests as well.