### PR TITLE
Fanction calling非対応OpenAIモデルのエラー対応

### DIFF
--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -163,7 +163,7 @@ class OpenAIChatAPI(LanguageModel):
                     openai_call=lambda messages=messages, tools=tools: self.api_call_func(
                         model=self.model,
                         messages=messages,
-                        tools=tools,
+                        tools=tools or NotGiven(),
                         stop=stop_sequences or NotGiven(),
                         **gen_kwargs,
                     ),


### PR DESCRIPTION
# 概要
`gpt-5-chat-latest` のようなFanction calling非対応なOpenAIモデルでのエラー対応．

```
# エラー内容
tools is not supported in this model. For a list of supported models, refer to https://platform.openai.com/docs/guides/function-calling#models-supporting-function-calling.
```

# 対応詳細
toolsが`[]`もしくは`None`の場合，OpenAI APIに渡すtoolsフィールドを削除する．(stop_sequencesと同じ動作)
`gpt-5-chat-latest`にて動作確認済み．