### PR TITLE
ChatResponseでFew-shotが挿入されない不具合対応

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -156,9 +156,13 @@ def evaluate_chat_response(  # noqa: C901
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     logger.info(f"Evaluate the model with gen_kwargs: {gen_kwargs}")
 
-    eval_instances: Sequence[ChatInstance] = eval_dataset
+    # eval_instances: Sequence[ChatInstance] = eval_dataset
     if max_instances is not None:
-        eval_instances = [eval_dataset[i] for i in range(min(max_instances, len(eval_instances)))]
+        # eval_instances = [eval_dataset[i] for i in range(min(max_instances, len(eval_instances)))]
+        max_instances = min(max_instances, len(eval_dataset))
+    else:
+        max_instances = len(eval_dataset)
+    eval_instances: list[ChatInstance] = [eval_dataset[i] for i in range(max_instances)]
 
     if few_shot_generator:
         for eval_instance in eval_instances:

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -140,7 +140,6 @@ def execute_conversation_flow(
                 "lm_output": lm_output,
                 "chat_instance": chat_instance,
                 "messages": messages[:-1],  # exclude the final output
-                "original_messages": chat_instance.messages,
             }
             yield output
 
@@ -156,9 +155,7 @@ def evaluate_chat_response(  # noqa: C901
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     logger.info(f"Evaluate the model with gen_kwargs: {gen_kwargs}")
 
-    # eval_instances: Sequence[ChatInstance] = eval_dataset
     if max_instances is not None:
-        # eval_instances = [eval_dataset[i] for i in range(min(max_instances, len(eval_instances)))]
         max_instances = min(max_instances, len(eval_dataset))
     else:
         max_instances = len(eval_dataset)
@@ -219,10 +216,7 @@ def evaluate_chat_response(  # noqa: C901
     # legacy: `{"lm_output": "...", "finish_reason": "...", "task_inputs": {...}, "references": [...], **metrics}`
     restructured_outputs: list[dict[str, Any]] = []
     for output in outputs:
-        extra_info = output["chat_instance"].extra_info | {
-            "messages": output["messages"],
-            "original_messages": output["chat_instance"].messages
-        }
+        extra_info = output["chat_instance"].extra_info | {"messages": output["messages"]}
         if output["lm_output"].tool_calls:
             extra_info["tool_calls"] = output["lm_output"].tool_calls
         if output["chat_instance"].tools:

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -140,6 +140,7 @@ def execute_conversation_flow(
                 "lm_output": lm_output,
                 "chat_instance": chat_instance,
                 "messages": messages[:-1],  # exclude the final output
+                "original_messages": chat_instance.messages,
             }
             yield output
 
@@ -214,7 +215,10 @@ def evaluate_chat_response(  # noqa: C901
     # legacy: `{"lm_output": "...", "finish_reason": "...", "task_inputs": {...}, "references": [...], **metrics}`
     restructured_outputs: list[dict[str, Any]] = []
     for output in outputs:
-        extra_info = output["chat_instance"].extra_info | {"messages": output["messages"]}
+        extra_info = output["chat_instance"].extra_info | {
+            "messages": output["messages"],
+            "original_messages": output["chat_instance"].messages
+        }
         if output["lm_output"].tool_calls:
             extra_info["tool_calls"] = output["lm_output"].tool_calls
         if output["chat_instance"].tools:


### PR DESCRIPTION
# 概要
ChatResponseでの評価時に，FewShotGeneratorを設定してもFew-shotが挿入されない不具合への対応

- outputs.jsonlのextra_info.messagesにFew-shotが挿入されない
- 実行ログのExample of the outputにFew-shotが挿入されない

# 原因
`_add_few_shot_messages_to_chat_instance()`でFew-shotを挿入するChatInstanceと，`execute_conversation_flow()`内の
`batch_iter()`でbatchにappendされたChatInstanceが別個体のため．

# 対応詳細
eval_instancesとしてeval_dataset: Sequence[ChatInstance]をlist化し，`_add_few_shot_messages_to_chat_instance()`や`batch_iter()`で同一のChatInstanceが使用されるように修正．  
上記の不具合が解消されていることを確認済み．