### PR TITLE
Restore raw_lm_output in evaluation outputs

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -225,6 +225,8 @@ def evaluate_chat_response(  # noqa: C901
             "references": output["chat_instance"].references,
             **output["metrics"],
         }
+        if output["lm_output"].raw_text:
+            restructured_output["raw_lm_output"] = output["lm_output"].raw_text
         restructured_outputs.append(restructured_output)
 
     return metrics_summary_dict, restructured_outputs

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -24,6 +24,7 @@ class AddTagProcessor(StringProcessor):
     """
     StringProcessor for testing that appends a tag to the input text.
     """
+
     def __init__(self) -> None:
         self.tag = " [processed]"
 
@@ -36,13 +37,8 @@ class AddTagProcessor(StringProcessor):
     list(itertools.product([True, False], [None, 1], [True, False], [1, 3], [True, False])),
 )
 def test_evaluate_chat_response(
-    use_few_shot: bool, 
-    max_instances: int, 
-    use_tools: bool, 
-    batch_size: int, 
-    use_processor: bool
+    use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int, use_processor: bool
 ) -> None:
-
     few_shot_generator = None
     if use_few_shot:
         few_shot_generator = RandomFewShotGenerator(dataset=DummyChatDataset(), num_shots=1, num_trials_to_avoid_leak=0)

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -22,7 +22,7 @@ from tests.dummy_modules import (
 
 class AddTagProcessor(StringProcessor):
     """
-    StringProcessor for testing that appends a tag to the input text.
+    Dummy StringProcessor for testing that appends a tag to the input text.
     """
 
     def __init__(self) -> None:

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -17,19 +17,33 @@ from tests.dummy_modules import (
     DummyChatDataset,
     DummyLanguageModel,
 )
+from flexeval.core.string_processor import StringProcessor
+
+
+class AddTagProcessor(StringProcessor):
+    """
+    StringProcessor for testing that appends a tag to the input text.
+    """
+    def __init__(self) -> None:
+        self.tag = " [processed]"
+
+    def __call__(self, text: str) -> str:
+        return text + self.tag
 
 
 @pytest.mark.parametrize(
-    ("use_few_shot", "max_instances", "use_tools", "batch_size"),
-    list(itertools.product([True, False], [None, 1], [True, False], [1, 3])),
+    ("use_few_shot", "max_instances", "use_tools", "batch_size", "use_processor"),
+    list(itertools.product([True, False], [None, 1], [True, False], [1, 3], [True, False])),
 )
-def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int) -> None:
+def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int, use_processor: bool) -> None:
+    
     few_shot_generator = None
     if use_few_shot:
         few_shot_generator = RandomFewShotGenerator(dataset=DummyChatDataset(), num_shots=1, num_trials_to_avoid_leak=0)
 
+    add_tag_processor = AddTagProcessor()
     metrics, outputs = evaluate_chat_response(
-        language_model=DummyLanguageModel(),
+        language_model=DummyLanguageModel(string_processors=[add_tag_processor] if use_processor else None),
         gen_kwargs={},
         eval_dataset=DummyChatDataset(
             use_tools=use_tools,
@@ -58,6 +72,13 @@ def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tool
         assert "tool_calls" not in outputs[0]["extra_info"]
         assert "tools" not in outputs[0]["extra_info"]
         assert metrics["tool_call_validation_result_ratio-TextOnly"] == 1.0
+    
+    if use_processor:
+        assert "raw_lm_output" in outputs[0]
+        assert outputs[0]["lm_output"].endswith(add_tag_processor.tag)
+        assert outputs[0]["lm_output"] != outputs[0]["raw_lm_output"]
+    else:
+        assert "raw_lm_output" not in outputs[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -35,7 +35,13 @@ class AddTagProcessor(StringProcessor):
     ("use_few_shot", "max_instances", "use_tools", "batch_size", "use_processor"),
     list(itertools.product([True, False], [None, 1], [True, False], [1, 3], [True, False])),
 )
-def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int, use_processor: bool) -> None:
+def test_evaluate_chat_response(
+    use_few_shot: bool, 
+    max_instances: int, 
+    use_tools: bool, 
+    batch_size: int, 
+    use_processor: bool
+) -> None:
 
     few_shot_generator = None
     if use_few_shot:

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -13,11 +13,11 @@ from flexeval.core.evaluate_chat_response import (
 )
 from flexeval.core.few_shot_generator import RandomFewShotGenerator
 from flexeval.core.metric import FinishReasonCount, ToolCallCount
+from flexeval.core.string_processor import StringProcessor
 from tests.dummy_modules import (
     DummyChatDataset,
     DummyLanguageModel,
 )
-from flexeval.core.string_processor import StringProcessor
 
 
 class AddTagProcessor(StringProcessor):
@@ -36,7 +36,7 @@ class AddTagProcessor(StringProcessor):
     list(itertools.product([True, False], [None, 1], [True, False], [1, 3], [True, False])),
 )
 def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tools: bool, batch_size: int, use_processor: bool) -> None:
-    
+
     few_shot_generator = None
     if use_few_shot:
         few_shot_generator = RandomFewShotGenerator(dataset=DummyChatDataset(), num_shots=1, num_trials_to_avoid_leak=0)
@@ -72,7 +72,7 @@ def test_evaluate_chat_response(use_few_shot: bool, max_instances: int, use_tool
         assert "tool_calls" not in outputs[0]["extra_info"]
         assert "tools" not in outputs[0]["extra_info"]
         assert metrics["tool_call_validation_result_ratio-TextOnly"] == 1.0
-    
+
     if use_processor:
         assert "raw_lm_output" in outputs[0]
         assert outputs[0]["lm_output"].endswith(add_tag_processor.tag)


### PR DESCRIPTION
### Summary

This PR restores the `raw_lm_output` field in the output JSONL file.
The field existed before https://github.com/sbintuitions/flexeval/pull/225, but appears to have been removed during the refactoring in that PR.

### Changes

- Add `raw_lm_output` to the outputs when `LMOutput.raw_text` is available, which occurs when `string_processors` is provided to the `LanguageModel`.
- Add a test to ensure that `raw_lm_output` is included in the output and that its content differs from `lm_output`.