### PR TITLE
Remove `__del__` method

### DIFF
--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -261,9 +261,6 @@ class LanguageModel:
         This method is called when the language model is no longer needed.
         """
 
-    def __del__(self) -> None:
-        self.cleanup_resources()
-
 
 def normalize_stop_sequences(
     stop_sequences_list: list[str | list[str] | None],


### PR DESCRIPTION
`__del__` causes unintended Exception as follows:

```
Exception ignored in: <function LanguageModel.__del__ at 0x125a1273a340>
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/flexeval/core/language_model/base.py", line 265, in __del__
  File "/usr/local/lib/python3.12/dist-packages/flexeval/core/language_model/hf_lm.py", line 555, in cleanup_resources
AttributeError: 'NoneType' object has no attribute 'is_available'
```