### PR TITLE
LiteLLMChatAPIのtoolsバグ修正

### DIFF
--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -9,7 +9,6 @@ import openai
 import tiktoken
 from loguru import logger
 from openai import BaseModel, OpenAI
-from openai._types import NotGiven
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 


### PR DESCRIPTION
# 概要
LiteLLMChatAPIクラスでclaude-3-7-sonnet@20250219を評価しようとした際に出力された，以下のエラーへの対策を実施する．

```
LiteLLM completion() model= claude-3-7-sonnet@20250219; provider = vertex_ai
2025-09-16 17:04:44.391 | WARNING  | flexeval.core.language_model.openai_api:_retry_on_error:57 - We got an error: litellm.APIConnectionError: 'NotGiven' object is not iterable
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/litellm/main.py", line 1239, in completion
    optional_params = get_optional_params(
  File "/usr/local/lib/python3.10/dist-packages/litellm/utils.py", line 3450, in get_optional_params
    optional_params = litellm.VertexAIAnthropicConfig().map_openai_params(
  File "/usr/local/lib/python3.10/dist-packages/litellm/llms/anthropic/chat/transformation.py", line 448, in map_openai_params
    anthropic_tools, mcp_servers = self._map_tools(value)
  File "/usr/local/lib/python3.10/dist-packages/litellm/llms/anthropic/chat/transformation.py", line 314, in _map_tools
    for tool in tools:
TypeError: 'NotGiven' object is not iterable
```

# 原因
#242 の対応で，モデル側にtoolsの設定がない場合，tools=NotGiven()とするように修正していた．(OpenAI APIの場合は実行時にNotGiven()のパラメータを渡さないようにするため，これでOK)  
LiteLLMではtoolsにNotGiven()が入ることを想定していないため，後続のforで展開しようとしてエラーになった．

# 対応内容
パラメータの設定がない場合，NotGivenは使用せずkeyそのものが追加されないように修正した．

上記の不具合が解消されていることをclaudeとgpt-5-chat(tools非対応モデル)で確認済み．