### PR TITLE
OpenAIChatAPIのretryパラメータのexpose

### DIFF
--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -43,10 +43,13 @@ EMPTY_RESPONSE = ChatCompletion(
 def _retry_on_error(
     openai_call: Callable[[], T],
     empty_response: BaseModel,
-    max_num_trials: int | None = 5,
-    first_wait_time: int | None = 10,
-    max_wait_time: int | None = 80,
+    max_num_trials: int | None = None,
+    first_wait_time: int | None = None,
+    max_wait_time: int | None = None,
 ) -> T:
+    max_num_trials = max_num_trials or 5
+    first_wait_time = first_wait_time or 10
+    max_wait_time = max_wait_time or 80
     for i in range(max_num_trials):
         try:
             return openai_call()

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -42,7 +42,7 @@ EMPTY_RESPONSE = ChatCompletion(
 def _retry_on_error(
     openai_call: Callable[[], T],
     empty_response: BaseModel,
-    max_num_trials: int = 5,
+    max_num_trials: int | None = 5,
     first_wait_time: int = 10,
 ) -> T:
     for i in range(max_num_trials):
@@ -91,6 +91,7 @@ class OpenAIChatAPI(LanguageModel):
         model_limit_new_tokens: int | None = None,
         max_parallel_requests: int | None = None,
         tools: list[dict[str, Any]] | None = None,
+        max_num_trials: int | None = None,
     ) -> None:
         super().__init__(string_processors=string_processors, tools=tools)
         self.model = model
@@ -107,6 +108,7 @@ class OpenAIChatAPI(LanguageModel):
         self.developer_message = developer_message
         self.model_limit_new_tokens = model_limit_new_tokens
         self.max_parallel_requests = max_parallel_requests
+        self.max_num_trials = max_num_trials
 
     def _parallel_run_chatgpt(
         self,
@@ -167,6 +169,7 @@ class OpenAIChatAPI(LanguageModel):
                         }
                     ),
                     empty_response=self.empty_response,
+                    max_num_trials=self.max_num_trials,
                 )
                 for messages, tools in zip(messages_list, tools_list)
             ]

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import itertools
-import time
 import os
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, TypeVar
 
@@ -190,11 +190,9 @@ class OpenAIChatAPI(LanguageModel):
                 future_to_idx[future] = idx
 
             results: list[ChatCompletion] = [self.empty_response] * total
-            done_count = 0
-            for future in as_completed(future_to_idx.keys()):
+            for done_count, future in enumerate(as_completed(future_to_idx.keys()), start=1):
                 idx = future_to_idx[future]
                 results[idx] = future.result()
-                done_count += 1
                 if prog_every_n and (done_count % prog_every_n == 0 or done_count == total):
                     logger.info(f"[progress] {done_count}/{total} ({done_count/total:.1%}) done")
 


### PR DESCRIPTION
# 概要
- gpt-5-nano評価時にタイムアウト散見され出力が空になってしまった
- 再実行に関するパラメータをexposeし，設定ファイルから指定できるようにしたい

# 原因
確認しているAPIエラー(多い順)

- `500 Internal Server Error`(8~9割このエラー)
- `429 Too Many Requests`(1割程度このエラー，service_tier:flex起因のエラー)
- `503 Service Unavailable`(たまに見かけるエラー)

現行の仕様だと最大5回トライしNGだった場合，空の出力`""`を返すようになっている．
特に500が発生する場合は5回以内に収まらないことが多く，空の出力となってしまっていた．

# 対応内容
- リトライ関連のパラメータ（`max_num_trials`,`first_wait_time`,`max_wait_time`）をexpose，未指定時は従来の設定値がデフォルト値となるように修正
- 追加で，batch_size=10000などの大きい値が設定されるようになっているため，batch内の進捗確認するためのログを追加（環境変数`OPENAI_PROGRESS_EVERY_N`でログを出力する完了件数を設定可能，未設定時は従来同様batch内の進捗ログ出力なし）
