### PR TITLE
perplexity計算時にbosトークンがない場合にeosトークンを代わりに使う

### DIFF
--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -439,7 +439,7 @@ class HuggingFaceLM(LanguageModel):
         # This is needed to correctly calculate the log probabilities of the first token.
         for i in range(batch_size):
             if prefix_list[i] == "":
-                prefix_list[i] = self.tokenizer.bos_token
+                prefix_list[i] = self.tokenizer.bos_token or self.tokenizer.eos_token
 
         prefix_encoding = tokenize_text_for_lm_prefix(
             prefix_list,

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -282,7 +282,7 @@ class VLLM(LanguageModel):
         # This is needed to correctly calculate the log probabilities of the first token.
         for i in range(batch_size):
             if prefix_list[i] == "":
-                prefix_list[i] = self.tokenizer.bos_token
+                prefix_list[i] = self.tokenizer.bos_token or self.tokenizer.eos_token
 
         batch_prefix_ids = tokenize_text_for_lm_prefix(
             prefix_list,
@@ -321,7 +321,8 @@ class VLLM(LanguageModel):
             chunk_end = min(chunk_start + max_length, sequence_length)
             chunk_batch_input_ids = [input_ids[chunk_start:chunk_end] for input_ids in batch_input_ids]
             chunk_batch_input_ids = [
-                [self.tokenizer.bos_token_id] if len(chunk_input_ids) == 0 else chunk_input_ids
+                [self.tokenizer.bos_token_id or self.tokenizer.eos_token]
+                if len(chunk_input_ids) == 0 else chunk_input_ids
                 for chunk_input_ids in chunk_batch_input_ids
             ]
             chunk_batch_outputs: list[RequestOutput] = self.llm.generate(

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -322,7 +322,8 @@ class VLLM(LanguageModel):
             chunk_batch_input_ids = [input_ids[chunk_start:chunk_end] for input_ids in batch_input_ids]
             chunk_batch_input_ids = [
                 [self.tokenizer.bos_token_id or self.tokenizer.eos_token]
-                if len(chunk_input_ids) == 0 else chunk_input_ids
+                if len(chunk_input_ids) == 0
+                else chunk_input_ids
                 for chunk_input_ids in chunk_batch_input_ids
             ]
             chunk_batch_outputs: list[RequestOutput] = self.llm.generate(

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from transformers import AutoTokenizer
 
-from flexeval.core.language_model import VLLM, HuggingFaceLM, LanguageModel
+from flexeval.core.language_model import VLLM, HuggingFaceLM
 from tests.conftest import is_vllm_enabled
 from tests.dummy_modules.tool_parser import DummyToolParser
 
@@ -24,6 +24,23 @@ def chat_lm() -> Generator[VLLM, None, None]:
             "disable_custom_all_reduce": True,
         },
         tokenizer_kwargs={"use_fast": False},
+    )
+    yield llm
+    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
+    cleanup_dist_env_and_memory()
+
+
+@pytest.fixture(scope="module")
+def chat_lm_qwen() -> Generator[VLLM, None, None]:
+    llm = VLLM(
+        model="Qwen/Qwen3-0.6B-Base",
+        model_kwargs={
+            "seed": 42,
+            "gpu_memory_utilization": 0.1,
+            "enforce_eager": True,
+            "disable_custom_all_reduce": True,
+        },
     )
     yield llm
     from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
@@ -60,7 +77,13 @@ def hf_lm(model_name: str = "sbintuitions/tiny-lm-chat") -> HuggingFaceLM:
 
 
 @pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
-def test_batch_compute_log_probs_approximates_hf_lm(chat_lm: LanguageModel, hf_lm: HuggingFaceLM) -> None:
+@pytest.mark.parametrize("chat_lm_name", ["chat_lm", "chat_lm_qwen"])
+def test_batch_compute_log_probs_approximates_hf_lm(
+    request: pytest.FixtureRequest,
+    chat_lm_name: str,
+    hf_lm: HuggingFaceLM,
+) -> None:
+    chat_lm = request.getfixturevalue(chat_lm_name)
     prefix_list = ["それは正しい日本語ですか？"]
     text_list = ["これは正しい日本語です。"]
 


### PR DESCRIPTION
### 概要
- bosトークンがないモデル(Qwen系)に対してperplexityを計算しようとするとモデルの入力にNoneが混入し落ちます。
- bosトークンがない場合には代わりにeosトークンを入れることで、落ちるのを防ぎます

### 詳細
- bosトークンがないモデルはtokenizer.bos_tokenがNoneなので、[入力セグメント全てのprefix](https://github.com/sbintuitions/flexeval/blob/18f51b881e098f4e0f5a56afa828f1689998c99d/flexeval/core/language_model/vllm_model.py#L285)がNoneになってしまい、vllmやhfモデルへの入力がNoneになります。
- bosトークンがない場合にはだいたい `文章1<eos>文章2` という形で事前学習がなされているはずなので、今回の変更を入れることで上のchunkの `<eos>文章2` という部分をとってきた場合のperplexityを計算するようにします。