### PR TITLE
Disable saving cache in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "poetry"
-          cache-dependency-path: "poetry.lock"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
In this PR, we disable saving python's cache in each CI.
The purpose is to fix `no space left disk` error.

Recently, run-tests CIs are failing due to `no space left disk` error.
Part of the reason is that in each test, we attempt to save python cache to disk.
However, the saved cache is [never used](https://github.com/sbintuitions/flexeval/actions/runs/19161986224/job/54863402441) for some reason.
--> Let's disable the cache


