### PR TITLE
Add truncate_middle to jinja env

### DIFF
--- a/flexeval/core/utils/jinja2_utils.py
+++ b/flexeval/core/utils/jinja2_utils.py
@@ -10,9 +10,19 @@ def regex_replace(s: str, pattern: str, replace: str) -> str:
     return re.sub(pattern, replace, s)
 
 
+def truncate_middle(s: str, length: int, filler: str = "..."):
+    if len(s) + len(filler) <= length:
+        return s
+    extract_len = length - len(filler)
+    prefix_len = extract_len // 2
+    suffix_len = extract_len // 2 + extract_len % 2
+    return s[:prefix_len] + filler + s[-suffix_len:]
+
+
 JINJA2_ENV = sandbox.ImmutableSandboxedEnvironment(
     undefined=jinja2.StrictUndefined,
     autoescape=False,  # important for not escaping double quotations
     keep_trailing_newline=True,
 )
 JINJA2_ENV.filters["regex_replace"] = regex_replace
+JINJA2_ENV.filters["truncate_middle"] = truncate_middle

--- a/flexeval/core/utils/jinja2_utils.py
+++ b/flexeval/core/utils/jinja2_utils.py
@@ -10,7 +10,7 @@ def regex_replace(s: str, pattern: str, replace: str) -> str:
     return re.sub(pattern, replace, s)
 
 
-def truncate_middle(s: str, length: int, filler: str = "..."):
+def truncate_middle(s: str, length: int, filler: str = "...") -> str:
     if len(s) + len(filler) <= length:
         return s
     extract_len = length - len(filler)

--- a/tests/core/utils/test_jinja2_env.py
+++ b/tests/core/utils/test_jinja2_env.py
@@ -9,7 +9,9 @@ def test_regex_replace() -> None:
 
 
 def test_truncate_middle() -> None:
-    s = "This is a pen"  # len(s) = 13
-    assert truncate_middle(s, length=14, filler="+") == "This is a pen"
-    assert truncate_middle(s, length=13, filler="+") == "This i+ a pen"
-    assert truncate_middle(s, length=12, filler="+") == "This + a pen"
+    template = JINJA2_ENV.from_string("{{ text | truncate_middle(14, '+') }}")
+    assert template.render(text="This is a pen") == "This is a pen"
+    template = JINJA2_ENV.from_string("{{ text | truncate_middle(13, '+') }}")
+    assert template.render(text="This is a pen") == "This i+ a pen"
+    template = JINJA2_ENV.from_string("{{ text | truncate_middle(12, '+') }}")
+    assert template.render(text="This is a pen") == "This + a pen"

--- a/tests/core/utils/test_jinja2_env.py
+++ b/tests/core/utils/test_jinja2_env.py
@@ -6,3 +6,10 @@ from flexeval.core.utils.jinja2_utils import JINJA2_ENV
 def test_regex_replace() -> None:
     template = "{{ text | regex_replace('<<.*?>>', '') }}"
     assert JINJA2_ENV.from_string(template).render(text="<<a>>Hello <<dummy>>world!") == "Hello world!"
+
+
+def test_truncate_middle() -> None:
+    s = "This is a pen"  # len(s) = 13
+    assert truncate_middle(s, length=14, filler="+") == "This is a pen"
+    assert truncate_middle(s, length=13, filler="+") == "This i+ a pen"
+    assert truncate_middle(s, length=12, filler="+") == "This + a pen"


### PR DESCRIPTION
Some long context evals truncate inputs by taking head and tail of them. This PR implements `truncate_middle` function, a variant of `truncate` function of jinja2, to make it easier to implement these types of evals.