### PR TITLE
Fix an issue triggered by long input to `load_jinja2_template`

### DIFF
--- a/flexeval/core/chat_dataset/template_based.py
+++ b/flexeval/core/chat_dataset/template_based.py
@@ -17,8 +17,12 @@ from .base import ChatDataset, ChatInstance
 
 def load_jinja2_template(template: str | PathLike[str]) -> Template:
     path = Path(template)
-    if path.exists():
-        return JINJA2_ENV.from_string(path.read_text(encoding="utf-8"))
+    try:
+        if path.exists():
+            return JINJA2_ENV.from_string(path.read_text(encoding="utf-8"))
+    except OSError:
+        # If the template is a very long string, path.exists() emits an OSError.
+        pass
     return JINJA2_ENV.from_string(template)
 
 

--- a/tests/core/chat_dataset/test_template_based.py
+++ b/tests/core/chat_dataset/test_template_based.py
@@ -221,3 +221,8 @@ def test_load_jinja2_template(dummy_template_file: Path) -> None:
     embed_result = template_from_string.render(name="flexeval")
     assert isinstance(template_from_string, Template)
     assert embed_result == "Hello flexeval!"
+
+    template_from_string = load_jinja2_template("a" * 1000)
+    embed_result = template_from_string.render()
+    assert isinstance(template_from_string, Template)
+    assert embed_result == "a" * 1000


### PR DESCRIPTION
#252 enhanced load_jinja2_template to accept either a file path or raw text as input. The updated function first checks if the provided string corresponds to an existing file. If a file exists at that path, its content is used as the template; otherwise, the input string itself is treated as the template.

However, when the input is a long raw template string (exceeding file name length limits), attempting to validate the path via `path.exists()` could trigger an `OSError`. To address this, this PR introduces a try-except block to bypass such errors, ensuring the function remains functional even for a long input.