### PR TITLE
Add length check for template path in load_jinja2_template

### DIFF
--- a/flexeval/core/chat_dataset/template_based.py
+++ b/flexeval/core/chat_dataset/template_based.py
@@ -17,7 +17,7 @@ from .base import ChatDataset, ChatInstance
 
 def load_jinja2_template(template: str | PathLike[str]) -> Template:
     path = Path(template)
-    if path.exists():
+    if len(str(path)) <= 255 and path.exists():
         return JINJA2_ENV.from_string(path.read_text(encoding="utf-8"))
     return JINJA2_ENV.from_string(template)
 


### PR DESCRIPTION
Recently introduced `load_jinja2_template` function checks the type of `template` (if it is Path or Template) by `path.exists`, but this causes `OSError: [Errno 36] File name too long:` if the file name is longer than 255.
This PR fixes this problem.