### PR TITLE
Reduce disk space usage of the unit test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --only main,dev --all-extras
+          poetry install --only main,dev --extras wandb
 
       - name: Run tests
         run: |


### PR DESCRIPTION
When running the unit tests, the installation of vllm consumes an excessive amount of disk space, causing the tests to fail due to error `No space left on device`. Since vllm is not strictly necessary during the unit tests, this PR modifies the tests to skip its installation entirely.

An alternative approach would be to increase the disk capacity of the test runners. However, providing paid runners to the public isn’t ideal at this stage, as it could risk misuse or abuse of resources. While omitting vllm might introduce subtle bugs due to environmental differences between the unit tests and actual evaluations, I believe avoiding the installation of vllm is a better path for now.