### PR TITLE
[add] truncation options for ROUGE

### DIFF
--- a/flexeval/core/metric/rouge.py
+++ b/flexeval/core/metric/rouge.py
@@ -16,6 +16,8 @@ class ROUGE(Metric):
 
     Args:
         tokenizer: An instance of `Tokenizer` to tokenize the input and output strings.
+        max_output_tokens: Maximum number of tokens to consider from model outputs.
+            If specified, only model outputs will be truncated to this length.
 
     Examples:
         >>> from flexeval import ROUGE
@@ -35,8 +37,9 @@ class ROUGE(Metric):
         )
     """
 
-    def __init__(self, tokenizer: Tokenizer) -> None:
+    def __init__(self, tokenizer: Tokenizer, max_output_tokens: int | None = None) -> None:
         self._tokenizer = tokenizer
+        self._max_output_tokens = max_output_tokens
 
     def evaluate(
         self,
@@ -56,6 +59,12 @@ class ROUGE(Metric):
         tokenized_target_summaries = [
             " ".join(self._tokenizer.tokenize(target_summary)) for target_summary in target_summaries
         ]
+
+        # Truncate model outputs if max_output_tokens is specified
+        if self._max_output_tokens is not None:
+            tokenized_lm_outputs = [
+                " ".join(output.split()[: self._max_output_tokens]) for output in tokenized_lm_outputs
+            ]
 
         # replace empty string with " " to avoid "ValueError: Hypothesis is empty" from rouge
         tokenized_lm_outputs = [o if o else " " for o in tokenized_lm_outputs]

--- a/flexeval/core/metric/utils.py
+++ b/flexeval/core/metric/utils.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import sys
 from collections import defaultdict
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import TypeVar
 
 from flexeval.core.language_model.base import LMOutput
@@ -79,8 +82,7 @@ def validate_inputs(
 
     if extra_info_list is not None and len(extra_info_list) != len(lm_outputs):
         msg = (
-            f"Number of extra_info entries ({len(extra_info_list)}) should match "
-            f"number of outputs ({len(lm_outputs)})."
+            f"Number of extra_info entries ({len(extra_info_list)}) should match number of outputs ({len(lm_outputs)})."
         )
         raise ValueError(msg)
 
@@ -103,3 +105,18 @@ def extract_text_from_outputs(lm_outputs: list[str | LMOutput]) -> list[str]:
         else:
             text_outputs.append(output.text or "")
     return text_outputs
+
+
+@contextmanager
+def recursion_limit(limit: int | None) -> Generator[None, None, None]:
+    """Context manager to temporarily set recursion limit."""
+    if limit is None:
+        yield
+        return
+
+    original_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(limit)
+    try:
+        yield
+    finally:
+        sys.setrecursionlimit(original_limit)

--- a/tests/core/metric/test_rouge.py
+++ b/tests/core/metric/test_rouge.py
@@ -34,8 +34,7 @@ def test_rouge(lm_outputs: list[str], expected_outputs: list[list[str]], score: 
     ("lm_outputs", "expected_outputs", "max_output_tokens", "score"),
     [
         (["これは テスト です"], [["これは テスト"]], 2, 1.0),  # Exact match after truncation
-        (["こんにちは 世界 です"], [["こんばんわ 地方"]], 2, 0.0),  # No match after truncation
-        (["同じ 単語 ではない"], [["同じ 単語"]], 2, 1.0),  # Match after truncation
+        (["こんにちは 世界 です"], [["こんばんわ 地方"]], 2, 0.0),  # No match even after truncation
     ],
     indirect=["lm_outputs"],
 )

--- a/tests/core/metric/test_rouge.py
+++ b/tests/core/metric/test_rouge.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from unittest.mock import patch
+
 import pytest
 
 from flexeval.core.metric import ROUGE
@@ -51,3 +54,41 @@ def test_rouge_with_max_output_tokens(
         assert metric_result.summary[key] == pytest.approx(score)
         assert metric_result.instance_details[0][key] == pytest.approx(score)
         assert len(metric_result.instance_details) == len(lm_outputs)
+
+
+def test_rouge_with_recursion_limit() -> None:
+    """Test that recursion limit is properly set and restored."""
+    original_limit = sys.getrecursionlimit()
+    custom_limit = 10000
+
+    rouge = ROUGE(tokenizer=WhitespaceTokenizer(), recursion_limit=custom_limit)
+    lm_outputs = ["これは テスト"]
+    references_list = [["これは テスト"]]
+
+    metric_result = rouge.evaluate(lm_outputs=lm_outputs, references_list=references_list)
+
+    # Verify that recursion limit is restored after evaluation
+    assert sys.getrecursionlimit() == original_limit
+
+    # Verify basic functionality
+    for key in ["rouge1", "rouge2", "rougeL"]:
+        assert key in metric_result.summary
+        assert isinstance(metric_result.summary[key], float)
+
+
+def test_rouge_recursion_limit_is_set() -> None:
+    """Test that sys.setrecursionlimit is called with the specified limit."""
+    custom_limit = 10000
+
+    with (
+        patch("flexeval.core.metric.utils.sys.setrecursionlimit") as mock_setrecursionlimit,
+        patch("flexeval.core.metric.utils.sys.getrecursionlimit", return_value=3000),
+    ):
+        rouge = ROUGE(tokenizer=WhitespaceTokenizer(), recursion_limit=custom_limit)
+        rouge.evaluate(lm_outputs=["test"], references_list=[["test"]])
+
+        # Verify setrecursionlimit was called with custom_limit
+        assert mock_setrecursionlimit.call_count == 2
+        mock_setrecursionlimit.assert_any_call(custom_limit)
+        # Verify it was restored to original value
+        mock_setrecursionlimit.assert_any_call(3000)

--- a/tests/core/metric/test_rouge.py
+++ b/tests/core/metric/test_rouge.py
@@ -25,3 +25,29 @@ def test_rouge(lm_outputs: list[str], expected_outputs: list[list[str]], score: 
         assert metric_result.summary[key] == pytest.approx(score)
         assert metric_result.instance_details[0][key] == pytest.approx(score)
         assert len(metric_result.instance_details) == len(lm_outputs)
+
+
+@pytest.mark.parametrize(
+    ("lm_outputs", "expected_outputs", "max_output_tokens", "score"),
+    [
+        (["これは テスト です"], [["これは テスト"]], 2, 1.0),  # Exact match after truncation
+        (["こんにちは 世界 です"], [["こんばんわ 地方"]], 2, 0.0),  # No match after truncation
+        (["同じ 単語 ではない"], [["同じ 単語"]], 2, 1.0),  # Match after truncation
+    ],
+    indirect=["lm_outputs"],
+)
+def test_rouge_with_max_output_tokens(
+    lm_outputs: list[str],
+    expected_outputs: list[list[str]],
+    max_output_tokens: int,
+    score: float,
+) -> None:
+    rouge = ROUGE(tokenizer=WhitespaceTokenizer(), max_output_tokens=max_output_tokens)
+    metric_result = rouge.evaluate(lm_outputs=lm_outputs, references_list=expected_outputs)
+
+    for key in ["rouge1", "rouge2", "rougeL"]:
+        assert key in metric_result.summary
+        assert isinstance(metric_result.summary[key], float)
+        assert metric_result.summary[key] == pytest.approx(score)
+        assert metric_result.instance_details[0][key] == pytest.approx(score)
+        assert len(metric_result.instance_details) == len(lm_outputs)


### PR DESCRIPTION
When recursive calculations for ROUGE-L are performed, if the output length becomes extremely long, it may exceed the recursion limit and terminate abnormally.  

In this PR, the following options are introduced:  
1. By specifying the `max_output_tokens` parameter, the maximum output token length of the model will be truncated to the specified number or higher.  
2. By specifying the `recursion_limit` parameter, the system's default recursion limit can be changed.  
    1. To apply this only during score calculation, control is managed using `with`.