### PR TITLE
Add exit code to flexeval_lm

### DIFF
--- a/flexeval/scripts/flexeval_lm.py
+++ b/flexeval/scripts/flexeval_lm.py
@@ -10,7 +10,7 @@ import traceback
 from collections import defaultdict
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 import _jsonnet
 from jsonargparse import ActionConfigFile, ArgumentParser, Namespace
@@ -121,7 +121,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
     )
     parser.add_argument(
         "--eval_setups",
-        type=dict[str, EvalSetup],
+        type=Dict[str, EvalSetup],
         help="A dictionary of evaluation setups. "
         "The key is the folder name where the outputs will be saved, and the value is the EvalSetup object. ",
         enable_path=True,
@@ -154,7 +154,7 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
     # Metadata
     parser.add_argument(
         "--metadata",
-        type=dict[str, Any],
+        type=Dict[str, Any],
         default={},
         help="Metadata to save in config.json",
     )

--- a/tests/scripts/test_flexeval_lm.py
+++ b/tests/scripts/test_flexeval_lm.py
@@ -326,7 +326,7 @@ class MyCustomMetric(Metric):
         check_if_eval_results_are_correctly_saved(f)
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_eval_data() -> dict:
     return {"setup": "dummy_setup_object", "config": {"task": "test", "metric": "acc"}, "group": "test_group"}
 


### PR DESCRIPTION
The current `flexeval_lm` implementation hides errors during evaluation and only logs the tracebacks.
This PR enables `flexeval_lm` to raise exit code 1 if exceptions happen during evaluation so that the unexpected event can be detected externally.
I believe this is useful especially when `flexeval_lm` is called in other programs.