### PR TITLE
Output reasoning_text

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -128,7 +128,6 @@ def execute_conversation_flow(
                         if lm_output.tool_call_validation_result
                         else {}
                     )
-                    | ({"reasoning_text": lm_output.reasoning_text} if lm_output.reasoning_text else {})
                 )
                 current_chat_history[batch_i].insert(response_context_indices[batch_i], lm_output_message)
                 last_lm_outputs[batch_i] = lm_output
@@ -217,8 +216,6 @@ def evaluate_chat_response(  # noqa: C901, PLR0912
     restructured_outputs: list[dict[str, Any]] = []
     for output in outputs:
         extra_info = output["chat_instance"].extra_info | {"messages": output["messages"]}
-        if output["lm_output"].reasoning_text:
-            extra_info["reasoning_text"] = output["lm_output"].reasoning_text
         if output["lm_output"].tool_calls:
             extra_info["tool_calls"] = output["lm_output"].tool_calls
         if output["chat_instance"].tools:
@@ -232,6 +229,8 @@ def evaluate_chat_response(  # noqa: C901, PLR0912
         }
         if output["lm_output"].raw_text:
             restructured_output["raw_lm_output"] = output["lm_output"].raw_text
+        if output["lm_output"].reasoning_text:
+            restructured_output["reasoning_text"] = output["lm_output"].reasoning_text
         restructured_outputs.append(restructured_output)
 
     return metrics_summary_dict, restructured_outputs

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -128,6 +128,7 @@ def execute_conversation_flow(
                         if lm_output.tool_call_validation_result
                         else {}
                     )
+                    | ({"reasoning_text": lm_output.reasoning_text} if lm_output.reasoning_text else {})
                 )
                 current_chat_history[batch_i].insert(response_context_indices[batch_i], lm_output_message)
                 last_lm_outputs[batch_i] = lm_output
@@ -216,6 +217,8 @@ def evaluate_chat_response(  # noqa: C901, PLR0912
     restructured_outputs: list[dict[str, Any]] = []
     for output in outputs:
         extra_info = output["chat_instance"].extra_info | {"messages": output["messages"]}
+        if output["lm_output"].reasoning_text:
+            extra_info["reasoning_text"] = output["lm_output"].reasoning_text
         if output["lm_output"].tool_calls:
             extra_info["tool_calls"] = output["lm_output"].tool_calls
         if output["chat_instance"].tools:

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -66,6 +66,8 @@ def test_evaluate_chat_response(
     # Therefore, in any case the system message should be in the first turn.
     assert outputs[0]["extra_info"]["messages"][0]["role"] == "system"
 
+    assert outputs[0]["extra_info"]["reasoning_text"] == "reasoning_text"
+
     if use_tools:
         assert isinstance(outputs[0]["extra_info"]["tool_calls"], list)
         assert isinstance(outputs[0]["extra_info"]["tools"], list)

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -66,7 +66,7 @@ def test_evaluate_chat_response(
     # Therefore, in any case the system message should be in the first turn.
     assert outputs[0]["extra_info"]["messages"][0]["role"] == "system"
 
-    assert outputs[0]["extra_info"]["reasoning_text"] == "reasoning_text"
+    assert outputs[0]["reasoning_text"] == "reasoning_text"
 
     if use_tools:
         assert isinstance(outputs[0]["extra_info"]["tool_calls"], list)

--- a/tests/dummy_modules/lm.py
+++ b/tests/dummy_modules/lm.py
@@ -45,6 +45,7 @@ class DummyLanguageModel(LanguageModel):
         return [
             LMOutput(
                 text=f"This is response to `{messages[-1]['content']}` with kwargs {kwargs}",
+                reasoning_text="reasoning_text",
                 finish_reason="length",
                 tool_calls=tc,
                 tool_call_validation_result="CompleteToolCall" if tc else "TextOnly",


### PR DESCRIPTION
This PR is a follow-up to #259. 

Although the `reasoning_text` field was added to `LMOutput` in #259, it was not included in the output of `evaluate_chat_response.py`. 

This change ensures the field is correctly output.