### PR TITLE
Enable access to `reasoning_text` and `tool_calls` in post-hoc LLM judges via `flexeval_file`.

### DIFF
--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -122,6 +122,7 @@ def execute_conversation_flow(
                         "finish_reason": lm_output.finish_reason,
                     }
                     | ({"raw_content": lm_output.raw_text} if lm_output.raw_text else {})
+                    | ({"reasoning_content": lm_output.reasoning_content} if lm_output.reasoning_content else {})
                     | ({"tool_calls": lm_output.tool_calls} if lm_output.tool_calls else {})
                     | (
                         {"tool_call_validation_result": lm_output.tool_call_validation_result}
@@ -216,8 +217,6 @@ def evaluate_chat_response(  # noqa: C901, PLR0912
     restructured_outputs: list[dict[str, Any]] = []
     for output in outputs:
         extra_info = output["chat_instance"].extra_info | {"messages": output["messages"]}
-        if output["lm_output"].tool_calls:
-            extra_info["tool_calls"] = output["lm_output"].tool_calls
         if output["chat_instance"].tools:
             extra_info["tools"] = output["chat_instance"].tools
         restructured_output = {
@@ -231,6 +230,8 @@ def evaluate_chat_response(  # noqa: C901, PLR0912
             restructured_output["raw_lm_output"] = output["lm_output"].raw_text
         if output["lm_output"].reasoning_text:
             restructured_output["reasoning_text"] = output["lm_output"].reasoning_text
+        if output["lm_output"].tool_calls:
+            restructured_output["tool_calls"] = output["lm_output"].tool_calls
         restructured_outputs.append(restructured_output)
 
     return metrics_summary_dict, restructured_outputs

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -122,7 +122,7 @@ def execute_conversation_flow(
                         "finish_reason": lm_output.finish_reason,
                     }
                     | ({"raw_content": lm_output.raw_text} if lm_output.raw_text else {})
-                    | ({"reasoning_content": lm_output.reasoning_content} if lm_output.reasoning_content else {})
+                    | ({"reasoning_content": lm_output.reasoning_text} if lm_output.reasoning_text else {})
                     | ({"tool_calls": lm_output.tool_calls} if lm_output.tool_calls else {})
                     | (
                         {"tool_call_validation_result": lm_output.tool_call_validation_result}
@@ -216,22 +216,25 @@ def evaluate_chat_response(  # noqa: C901, PLR0912
     # legacy: `{"lm_output": "...", "finish_reason": "...", "task_inputs": {...}, "references": [...], **metrics}`
     restructured_outputs: list[dict[str, Any]] = []
     for output in outputs:
+        lm_output: LMOutput = output["lm_output"]
         extra_info = output["chat_instance"].extra_info | {"messages": output["messages"]}
         if output["chat_instance"].tools:
             extra_info["tools"] = output["chat_instance"].tools
         restructured_output = {
-            "lm_output": output["lm_output"].text,
+            "lm_output": lm_output.text,
             "finish_reason": output["lm_output"].finish_reason,
             "extra_info": extra_info,
             "references": output["chat_instance"].references,
             **output["metrics"],
         }
-        if output["lm_output"].raw_text:
-            restructured_output["raw_lm_output"] = output["lm_output"].raw_text
-        if output["lm_output"].reasoning_text:
-            restructured_output["reasoning_text"] = output["lm_output"].reasoning_text
-        if output["lm_output"].tool_calls:
-            restructured_output["tool_calls"] = output["lm_output"].tool_calls
+        if lm_output.raw_text:
+            restructured_output["raw_lm_output"] = lm_output.raw_text
+        if lm_output.reasoning_text:
+            restructured_output["reasoning_text"] = lm_output.reasoning_text
+        if lm_output.tool_calls:
+            restructured_output["tool_calls"] = lm_output.tool_calls
+        if lm_output.tool_call_validation_result:
+            restructured_output["tool_call_validation_result"] = lm_output.tool_call_validation_result
         restructured_outputs.append(restructured_output)
 
     return metrics_summary_dict, restructured_outputs

--- a/flexeval/core/evaluate_from_data.py
+++ b/flexeval/core/evaluate_from_data.py
@@ -18,7 +18,7 @@ def evaluate_from_data(
     eval_dataset: GenerationDataset | ChatDataset | None = None,
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     extra_info_list: list[dict[str, Any]] = []
-    lm_output_list: list[str|LMOutput] = []
+    lm_output_list: list[str | LMOutput] = []
     references_list: list[list[str]] = []
     for item in eval_data:
         # ignore extra info if empty for backward compatibility

--- a/flexeval/core/evaluate_from_data.py
+++ b/flexeval/core/evaluate_from_data.py
@@ -26,7 +26,16 @@ def evaluate_from_data(
         if "extra_info" not in item:
             item["extra_info"] = {}
         extra_info_list.append(item["extra_info"])
-        lm_output_list.append(item["lm_output"])
+        # We adapt the current output format of evaluate_chat_response(). This will be changed in the future.
+        lm_output = LMOutput(
+            text=item.pop("lm_output"),
+            raw_text=item.pop("raw_lm_output", None),
+            reasoning_text=item.pop("reasoning_text", None),
+            finish_reason=item.pop("finish_reason", None),
+            tool_calls=item.pop("tool_calls", None),
+            tool_call_validation_result=item.pop("tool_call_validation_result", None),
+        )
+        lm_output_list.append(lm_output)
         references_list.append(item["references"])
 
     if eval_dataset is not None:

--- a/flexeval/core/evaluate_from_data.py
+++ b/flexeval/core/evaluate_from_data.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from loguru import logger
 
+from flexeval.core.language_model.base import LMOutput
+
 from .chat_dataset import ChatDataset
 from .generation_dataset import GenerationDataset
 from .metric import Metric
@@ -16,7 +18,7 @@ def evaluate_from_data(
     eval_dataset: GenerationDataset | ChatDataset | None = None,
 ) -> tuple[dict[str, float], list[dict[str, Any]]]:
     extra_info_list: list[dict[str, Any]] = []
-    lm_output_list: list[str] = []
+    lm_output_list: list[str|LMOutput] = []
     references_list: list[list[str]] = []
     for item in eval_data:
         # ignore extra info if empty for backward compatibility

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -46,6 +46,17 @@ class LMOutput:
                 msg = "Both `text` and `tool_calls` are empty."
                 logger.warning(msg)
 
+    def __str__(self) -> str:
+        """Return the `text` attribute as a string for backward compatibility.
+
+        Before `LMOutput` was introduced, outputs were saved as plain strings.
+        Therefore, several existing configs using LLM-judge metrics such as `ChatLLMScore` assume
+        that `lm_output` is a plain string. By implementing `__str__`, an `LMOutput`
+        instance embedded in a Jinja2 template renders as its `text` attribute,
+        preserving that contract.
+        """
+        return self.text if self.text is not None else ""
+
 
 class LanguageModel:
     """LanguageModel is what you want to evaluate with this library.

--- a/flexeval/core/metric/llm_geval_score.py
+++ b/flexeval/core/metric/llm_geval_score.py
@@ -15,7 +15,7 @@ from flexeval.core.utils.data_util import batch_iter
 
 from .base import Metric, MetricResult
 from .llm_score import prepare_chat_input_for_evaluator, prepare_text_input_for_evaluator
-from .utils import extract_text_from_outputs, validate_inputs
+from .utils import validate_inputs
 
 
 def calculate_weighted_average(
@@ -238,8 +238,6 @@ class LLMGEvalScore(Metric):
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        lm_outputs = extract_text_from_outputs(lm_outputs)
-
         # Compute metrics
         evaluator_input_list: list[str] = prepare_text_input_for_evaluator(
             lm_outputs, references_list, extra_info_list, self.prompt_template
@@ -410,8 +408,6 @@ class ChatLLMGEvalScore(Metric):
             extra_info_list = [{} for _ in lm_outputs]
         if references_list is None:
             references_list = [[] for _ in lm_outputs]
-
-        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list = prepare_chat_input_for_evaluator(

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -14,7 +14,7 @@ from flexeval.core.metric.llm_score import (
 from flexeval.core.prompt_template import PromptTemplate
 
 from .base import Metric, MetricResult
-from .utils import extract_text_from_outputs, validate_inputs
+from .utils import validate_inputs
 
 
 def parse_label_from_evaluator_output(evaluator_output: str, label_names: list[str]) -> str | None:
@@ -180,9 +180,6 @@ class LLMLabel(Metric):
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        # Extract text from LMOutput objects
-        lm_outputs = extract_text_from_outputs(lm_outputs)
-
         # Compute metrics
         evaluator_input_list: list[str] = prepare_text_input_for_evaluator(
             lm_outputs, references_list, extra_info_list, self.prompt_template
@@ -330,9 +327,6 @@ class ChatLLMLabel(Metric):
             references_list = [[] for _ in lm_outputs]
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
-
-        # Extract text from LMOutput objects
-        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list = prepare_chat_input_for_evaluator(

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -71,7 +71,7 @@ def summarize_evaluator_scores(
 
 
 def prepare_text_input_for_evaluator(
-    lm_outputs: list[str],
+    lm_outputs: list[LMOutput | str],
     references_list: list[list[str]],
     extra_info_list: list[dict[str, str]],
     prompt_template: PromptTemplate,

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -11,7 +11,7 @@ from flexeval.core.prompt_template import PromptTemplate
 from flexeval.core.utils.data_util import batch_iter
 
 from .base import Metric, MetricResult
-from .utils import extract_text_from_outputs, validate_inputs
+from .utils import validate_inputs
 
 
 def parse_score_from_evaluator_output(
@@ -246,9 +246,6 @@ class LLMScore(Metric):
 
         validate_inputs(lm_outputs, references_list, extra_info_list)
 
-        # Extract text from LMOutput objects
-        lm_outputs = extract_text_from_outputs(lm_outputs)
-
         # Compute metrics
         evaluator_input_list: list[str] = prepare_text_input_for_evaluator(
             lm_outputs, references_list, extra_info_list, self.prompt_template
@@ -373,9 +370,6 @@ class ChatLLMScore(Metric):
             extra_info_list = [{} for _ in lm_outputs]
         if references_list is None:
             references_list = [[] for _ in lm_outputs]
-
-        # Extract text from LMOutput objects
-        lm_outputs = extract_text_from_outputs(lm_outputs)
 
         # Compute metrics
         evaluator_input_list = prepare_chat_input_for_evaluator(

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -80,6 +80,10 @@ def prepare_text_input_for_evaluator(
     by integrating the extra_info, the model outputs, and the prompt template for evaluator.
     """
 
+    lm_outputs: list[LMOutput] = [
+        LMOutput(text=lm_output) if isinstance(lm_output, str) else lm_output for lm_output in lm_outputs
+    ]
+
     evaluator_input_list: list[str] = []
     for lm_output, extra_info, references in zip(
         lm_outputs,
@@ -97,7 +101,7 @@ def prepare_text_input_for_evaluator(
 
 
 def prepare_chat_input_for_evaluator(
-    lm_outputs: list[str],
+    lm_outputs: list[LMOutput | str],
     references_list: list[list[str]],
     extra_info_list: list[dict[str, str]],
     prompt_template: PromptTemplate,
@@ -106,6 +110,10 @@ def prepare_chat_input_for_evaluator(
     """Create input chat messages for the evaluator
     by integrating the extra_info, the model outputs, and the prompt template for evaluator.
     """
+
+    lm_outputs: list[LMOutput] = [
+        LMOutput(text=lm_output) if isinstance(lm_output, str) else lm_output for lm_output in lm_outputs
+    ]
 
     evaluator_input_list: list[list[dict[str, str]]] = []
     for lm_output, extra_info, references in zip(

--- a/flexeval/scripts/flexeval_file.py
+++ b/flexeval/scripts/flexeval_file.py
@@ -13,6 +13,7 @@ from jsonargparse import ActionConfigFile, ArgumentParser
 from loguru import logger
 
 from flexeval import ChatDataset, GenerationDataset, LocalRecorder, Metric, ResultRecorder, evaluate_from_data
+from flexeval.core.language_model.base import LMOutput
 from flexeval.utils.module_utils import ConfigNameResolver
 
 from .common import (
@@ -26,7 +27,7 @@ class EvalDataLoader(ABC):
     A class to load evaluation data.
     The evaluation data should be a list of dictionaries with the following keys:
     - extra_info (dict[str, Any]): A dictionary containing the input data for the task and any other informations.
-    - lm_output (str): The output of the language model.
+    - lm_output (str|LMOutput): The output of the language model.
     - references (list[str]): A list of reference outputs.
     - extra_info (dict[str, Any]): alias for "extra_info". Older versions used this key.
     """
@@ -51,6 +52,12 @@ class JsonlEvalDataLoader(EvalDataLoader):
                 item = json.loads(line)
                 if "task_inputs" in item:
                     item["extra_info"] = item.pop("task_inputs")
+                item["lm_output"] = LMOutput(
+                    text=item.pop("lm_output"),
+                    raw_text=item.pop("raw_lm_output", None),
+                    reasoning_text=item.pop("reasoning_text", None),
+                    tool_calls=item.pop("tool_calls", None),
+                )
                 items.append(item)
         return items
 

--- a/flexeval/scripts/flexeval_file.py
+++ b/flexeval/scripts/flexeval_file.py
@@ -13,7 +13,6 @@ from jsonargparse import ActionConfigFile, ArgumentParser
 from loguru import logger
 
 from flexeval import ChatDataset, GenerationDataset, LocalRecorder, Metric, ResultRecorder, evaluate_from_data
-from flexeval.core.language_model.base import LMOutput
 from flexeval.utils.module_utils import ConfigNameResolver
 
 from .common import (
@@ -52,12 +51,6 @@ class JsonlEvalDataLoader(EvalDataLoader):
                 item = json.loads(line)
                 if "task_inputs" in item:
                     item["extra_info"] = item.pop("task_inputs")
-                item["lm_output"] = LMOutput(
-                    text=item.pop("lm_output"),
-                    raw_text=item.pop("raw_lm_output", None),
-                    reasoning_text=item.pop("reasoning_text", None),
-                    tool_calls=item.pop("tool_calls", None),
-                )
                 items.append(item)
         return items
 

--- a/tests/core/metric/test_llm_geval_score.py
+++ b/tests/core/metric/test_llm_geval_score.py
@@ -199,3 +199,32 @@ def test_chat_llm_geval_score(
 
     for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_geval_score_input"] == [{"role": "user", "content": lm_output}]
+
+
+def test_llm_geval_score_reasoning() -> None:
+    lm_outputs = [
+        LMOutput(text="[C] Output a number from 1 to 5.", reasoning_text="[B] Output a number from 1 to 5."),
+    ]
+    metric_for_text_explicit = LLMGEvalScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output.text }}"),
+        valid_score_range=(1, 5),
+    )
+    metric_output_for_text_explicit = metric_for_text_explicit.evaluate(lm_outputs=lm_outputs)
+    assert metric_output_for_text_explicit.summary["llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
+
+    metric_for_text_implicit = LLMGEvalScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        valid_score_range=(1, 5),
+    )
+    metric_output_for_text_implicit = metric_for_text_implicit.evaluate(lm_outputs=lm_outputs)
+    assert metric_output_for_text_implicit.summary["llm_geval_score"] == pytest.approx(3.0, rel=1e-5)
+
+    metric_for_reasoning = LLMGEvalScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output.reasoning_text }}"),
+        valid_score_range=(1, 5),
+    )
+    metric_output_for_reasoning = metric_for_reasoning.evaluate(lm_outputs=lm_outputs)
+    assert metric_output_for_reasoning.summary["llm_geval_score"] == pytest.approx(2.744237906010388, rel=1e-5)

--- a/tests/core/metric/test_llm_label.py
+++ b/tests/core/metric/test_llm_label.py
@@ -164,3 +164,35 @@ def test_chat_llm_label(
     for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_label_input"] == [{"role": "user", "content": lm_output}]
         assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output
+
+
+def test_llm_label_reasoning() -> None:
+    lm_outputs = [
+        LMOutput(text="This label is Good.", reasoning_text="This label is Neutral."),
+    ]
+    metric_for_text_explicit = LLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output.text }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+    )
+    metric_output_for_text_explicit = metric_for_text_explicit.evaluate(lm_outputs=lm_outputs)
+    assert metric_output_for_text_explicit.summary["llm_score"] == 1.0
+
+    metric_for_text_implicit = LLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+    )
+    metric_output_for_text_implicit = metric_for_text_implicit.evaluate(lm_outputs=lm_outputs)
+    assert metric_output_for_text_implicit.summary["llm_score"] == 1.0
+
+    metric_for_reasoning = LLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output.reasoning_text }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+    )
+    metric_output_for_reasoning = metric_for_reasoning.evaluate(lm_outputs=lm_outputs)
+    assert metric_output_for_reasoning.summary["llm_score"] == 0.5

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -291,6 +291,38 @@ def test_chat_llm_score(
         assert instance_detail["llm_score_output"] == lm_output
 
 
+def test_chat_llm_score_reasoning() -> None:
+    lm_outputs = [
+        LMOutput(text="This score is 1.", reasoning_text="Reasoning for score 2."),
+    ]
+    metric_for_text_explicit = ChatLLMScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output.text }}"),
+    )
+    metric_output_for_text_explicit = metric_for_text_explicit.evaluate(
+        lm_outputs=lm_outputs,
+    )
+    assert metric_output_for_text_explicit.summary["llm_score"] == 1.0
+
+    metric_for_text_implicit = ChatLLMScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+    )
+    metric_output_for_text_implicit = metric_for_text_implicit.evaluate(
+        lm_outputs=lm_outputs,
+    )
+    assert metric_output_for_text_implicit.summary["llm_score"] == 1.0
+
+    metric_for_reasoning = ChatLLMScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output.reasoning_text }}"),
+    )
+    metric_output_for_reasoning = metric_for_reasoning.evaluate(
+        lm_outputs=lm_outputs,
+    )
+    assert metric_output_for_reasoning.summary["llm_score"] == 2.0
+
+
 @pytest.mark.parametrize(
     ("lm_outputs", "extra_info_list", "category_key", "expected_summary"),
     [
@@ -449,7 +481,7 @@ def test_chat_llm_score_metric_prefix(lm_outputs: list[str | LMOutput], metric_p
 
 
 def test_prepare_chat_input_for_evaluator() -> None:
-    lm_outputs = ["Output1", "Output2"]
+    lm_outputs = ["Output1", LMOutput("Output2", reasoning_text="Reasoning2")]
     references_list = [
         ["Reference1"],
         [],
@@ -459,7 +491,7 @@ def test_prepare_chat_input_for_evaluator() -> None:
         {"messages": [{"role": "user", "content": "Input2"}]},
     ]
     prompt_template = Jinja2PromptTemplate(
-        "{{ messages[0]['content'] }}, {{ lm_output }}{%- if references|length > 0 -%}, {{ references[0] }}{%- endif -%}"  # noqa: E501
+        "{{ messages[0]['content'] }}, {{ lm_output }}{%- if references|length > 0 -%}, {{ references[0] }}{%- endif -%}{%- if lm_output.reasoning_text -%}, {{ lm_output.reasoning_text }}{%- endif -%}"  # noqa: E501
     )
     system_messsage = Jinja2PromptTemplate(
         "{%- if references|length > 0 -%}With Reference{%- else -%}Without Reference{%- endif -%}"
@@ -473,4 +505,4 @@ def test_prepare_chat_input_for_evaluator() -> None:
     assert evaluator_input_list[0][1] == {"role": "user", "content": "Input1, Output1, Reference1"}
 
     assert evaluator_input_list[1][0] == {"role": "system", "content": "Without Reference"}
-    assert evaluator_input_list[1][1] == {"role": "user", "content": "Input2, Output2"}
+    assert evaluator_input_list[1][1] == {"role": "user", "content": "Input2, Output2, Reasoning2"}

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -69,11 +69,11 @@ def test_evaluate_chat_response(
     assert outputs[0]["reasoning_text"] == "reasoning_text"
 
     if use_tools:
-        assert isinstance(outputs[0]["extra_info"]["tool_calls"], list)
+        assert isinstance(outputs[0]["tool_calls"], list)
         assert isinstance(outputs[0]["extra_info"]["tools"], list)
         assert metrics["tool_call_validation_result_ratio-CompleteToolCall"] == 1.0
     else:
-        assert "tool_calls" not in outputs[0]["extra_info"]
+        assert "tool_calls" not in outputs[0]
         assert "tools" not in outputs[0]["extra_info"]
         assert metrics["tool_call_validation_result_ratio-TextOnly"] == 1.0
 

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+from typing import Any
 
 import pytest
 
@@ -11,7 +12,9 @@ from flexeval.core.evaluate_pairwise import Match, evaluate_pairwise
 from flexeval.core.evaluate_perplexity import evaluate_perplexity
 from flexeval.core.evaluate_reward_model import evaluate_reward_model
 from flexeval.core.few_shot_generator import RandomFewShotGenerator
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric import ExactMatch, FinishReasonCount
+from flexeval.core.metric.base import Metric, MetricResult
 from flexeval.core.prompt_template import Jinja2PromptTemplate
 from flexeval.core.reward_model.pairwise_judge_reward_model import PairwiseJudgeRewardModel
 from tests.dummy_modules import (
@@ -90,18 +93,105 @@ def test_evaluate_perplexity(max_instances: int) -> None:
     assert isinstance(metrics, dict)
 
 
+class LMOutputStats(Metric):
+    def evaluate(
+        self,
+        lm_outputs: list[str | LMOutput],
+        references_list: list[list[str]],
+        extra_info_list: list[dict[str, Any]],
+    ) -> MetricResult:
+        instance_details: list[dict[str, Any]] = []
+        for maybe_lm_output in lm_outputs:
+            if isinstance(maybe_lm_output, LMOutput):
+                instance_details.append(
+                    {
+                        "is_LMOutput_instance": True,
+                        "has_finish_reason": maybe_lm_output.finish_reason is not None,
+                        "has_raw_text": maybe_lm_output.raw_text is not None,
+                        "has_reasoning": maybe_lm_output.reasoning_text is not None,
+                        "has_tool_calls": maybe_lm_output.tool_calls is not None,
+                    }
+                )
+            elif isinstance(maybe_lm_output, str):
+                instance_details.append(
+                    {
+                        "is_LMOutput_instance": False,
+                        "has_finish_reason": False,
+                        "has_raw_text": False,
+                        "has_reasoning": False,
+                        "has_tool_calls": False,
+                    }
+                )
+
+        summary = {}
+        for instance_detail in instance_details:
+            for key, value in instance_detail.items():
+                summary[f"count_{key}"] = summary.get(f"count_{key}", 0) + value
+
+        return MetricResult(
+            summary=summary,
+            instance_details=instance_details,
+        )
+
+
 def test_evaluate_from_data() -> None:
     items = [
-        {"lm_output": "This is test", "references": ["This is test"]},
-        {"lm_output": "This is test", "references": ["This is not test"]},
+        {"lm_output": "This is test", "references": ["This is test"], "finish_reason": "stop"},
+        {"lm_output": "This is test", "references": ["This is test"], "raw_lm_output": "This is raw text."},
+        {"lm_output": "This is test", "references": ["This is not test"], "reasoning_text": "This is reasoning"},
+        {
+            "lm_output": "This is test",
+            "references": ["This is not test"],
+            "tool_calls": [{"id": "call_1", "function": {"name": "add", "arguments": '{"x": 1, "y": 2}'}}],
+        },
     ]
     metrics_summary_dict, instance_metrics_list = evaluate_from_data(
         eval_data=items,
-        metrics=[ExactMatch()],
+        metrics=[ExactMatch(), LMOutputStats()],
     )
 
-    assert metrics_summary_dict == {"exact_match": 0.5}
-    assert instance_metrics_list == [{"exact_match": 1.0}, {"exact_match": 0.0}]
+    assert metrics_summary_dict == {
+        "exact_match": 0.5,
+        "count_is_LMOutput_instance": 4,
+        "count_has_raw_text": 1,
+        "count_has_reasoning": 1,
+        "count_has_tool_calls": 1,
+        "count_has_finish_reason": 1,
+    }
+    assert instance_metrics_list == [
+        {
+            "exact_match": 1.0,
+            "is_LMOutput_instance": True,
+            "has_finish_reason": True,
+            "has_raw_text": False,
+            "has_reasoning": False,
+            "has_tool_calls": False,
+        },
+        {
+            "exact_match": 1.0,
+            "is_LMOutput_instance": True,
+            "has_finish_reason": False,
+            "has_raw_text": True,
+            "has_reasoning": False,
+            "has_tool_calls": False,
+        },
+        {
+            "exact_match": 0.0,
+            "is_LMOutput_instance": True,
+            "has_finish_reason": False,
+            "has_raw_text": False,
+            "has_reasoning": True,
+            "has_tool_calls": False,
+        },
+        {
+            "exact_match": 0.0,
+            "is_LMOutput_instance": True,
+            "has_finish_reason": False,
+            "has_raw_text": False,
+            "has_reasoning": False,
+            "has_tool_calls": True,
+        },
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_flexeval_file.py
+++ b/tests/scripts/test_flexeval_file.py
@@ -84,6 +84,7 @@ def test_with_eval_data_loader() -> None:
 def test_if_flexeval_file_loads_custom_module() -> None:
     custom_metric_code = """\
 from flexeval import Metric, MetricResult
+from flexeval.core.metric.utils import extract_text_from_outputs
 
 
 class MyCustomMetric(Metric):
@@ -93,6 +94,7 @@ class MyCustomMetric(Metric):
         extra_info_list,
         references_list,
     ) -> MetricResult:
+        lm_outputs = extract_text_from_outputs(lm_outputs)
         length_ratios = [
             len(lm_output) / len(references[0])  # Assuming a single reference
             for lm_output, references in zip(lm_outputs, references_list)


### PR DESCRIPTION
`flexeval_lm` passes `LMOutput` objects to `Metric.evaluate()`, giving metrics access to the full generation output including `reasoning_text` and `tool_calls`. However, `flexeval_file`, used for post-hoc evaluation of saved results, only passed the plain `lm_output` string, discarding all other fields. This made it impossible to apply LLM-judge metrics to reasoning content or tool call data after the fact.

This PR closes that gap: `flexeval_file` now reconstructs `LMOutput` from the saved fields, making post-hoc evaluation with LLM judges behave consistently with online evaluation via `flexeval_lm`.

## Implementation summary

- `evaluate_from_data()` now reconstructs `LMOutput` objects from flat eval data dicts, picking up `raw_lm_output`, `reasoning_text`, `finish_reason`, `tool_calls`, and `tool_call_validation_result` fields
- LLM judge metrics (`ChatLLMScore`, `ChatLLMGEvalScore`, `ChatLLMLabel`) now receive `LMOutput` objects directly instead of plain strings, enabling Jinja2 templates to access fields like `{{ lm_output.reasoning_text }}`
- Added `LMOutput.__str__` so that existing templates using `{{ lm_output }}` continue to render the `text` field without modification (backward compatibility)

