### PR TITLE
Add `ReasoningParser`

### DIFF
--- a/flexeval/__init__.py
+++ b/flexeval/__init__.py
@@ -13,6 +13,7 @@ from .core.metric import *
 from .core.multiple_choice_dataset import *
 from .core.pairwise_comparison import *
 from .core.prompt_template import *
+from .core.reasoning_parser import *
 from .core.result_recorder import *
 from .core.reward_bench_dataset import *
 from .core.reward_model import *

--- a/flexeval/core/language_model/base.py
+++ b/flexeval/core/language_model/base.py
@@ -237,7 +237,10 @@ class LanguageModel:
         # Post-process the generated text
         if self.string_processors:
             for lm_output in lm_outputs:
-                lm_output.raw_text = lm_output.text
+                # If a subclass preprocesses the output (e.g., via ToolParser or ReasoningParser),
+                # lm_output.raw_text should already hold the unprocessed text.
+                if lm_output.raw_text is None:
+                    lm_output.raw_text = lm_output.text
                 for string_processor in self.string_processors:
                     lm_output.text = string_processor(lm_output.text)
 

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -13,6 +13,7 @@ import transformers
 from loguru import logger
 from transformers import AutoModelForCausalLM, AutoTokenizer, BatchEncoding, PreTrainedModel, PreTrainedTokenizer
 
+from flexeval.core.reasoning_parser.base import ReasoningParser
 from flexeval.core.string_processor import StringProcessor
 from flexeval.core.tool_parser.base import ToolParser
 from flexeval.utils.hf_utils import get_default_model_kwargs
@@ -186,6 +187,7 @@ class HuggingFaceLM(LanguageModel):
             If this value is set to less than or equal to the model's capacity and the input exceeds it,
             an empty string is returned instead of raising an error.
             If set to “default”, the value will be automatically determined when possible.
+        reasoning_parser: A ReasoningParser object to extract the reasoning_text from the model's output.
         tool_parser: A ToolParser object to extract the tool_calls from the model's output.
         tools: Default tools to use in chat responses when no tools are explicitly provided.
         prefix_str_for_chat: A string to prepend to the assistant's response in chat generation.
@@ -210,6 +212,7 @@ class HuggingFaceLM(LanguageModel):
         default_gen_kwargs: dict[str, Any] | None = None,
         string_processors: StringProcessor | list[StringProcessor] | None = None,
         model_limit_tokens: int | None | Literal["default"] = "default",
+        reasoning_parser: ReasoningParser | None = None,
         tool_parser: ToolParser | None = None,
         tools: list[dict[str, Any]] | None = None,
         prefix_str_for_chat: str = "",
@@ -230,6 +233,7 @@ class HuggingFaceLM(LanguageModel):
         self.load_peft = load_peft
         self.amp_dtype = amp_dtype
         self.model_limit_tokens = model_limit_tokens
+        self.reasoning_parser = reasoning_parser
         self.tool_parser = tool_parser
         self.prefix_str_for_chat = prefix_str_for_chat
         logger.info(f"amp_dtype: {amp_dtype}")
@@ -397,7 +401,7 @@ class HuggingFaceLM(LanguageModel):
         return lm_outputs
 
     @load_model
-    def _batch_generate_chat_response(
+    def _batch_generate_chat_response(  # noqa: C901
         self,
         chat_messages_list: list[list[dict[str, Any]]],
         tools_list: list[list[dict[str, Any]] | None] | None = None,
@@ -422,16 +426,30 @@ class HuggingFaceLM(LanguageModel):
         ]
         lm_outputs = self._batch_complete_text(chat_messages_as_string, **kwargs)
         for lm_output in lm_outputs:
+            if lm_output.text is None:
+                continue
             lm_output.text = self.prefix_str_for_chat + lm_output.text
+
+        if self.reasoning_parser:
+            for lm_output in lm_outputs:
+                if lm_output.raw_text is None:
+                    lm_output.raw_text = lm_output.text
+                reasoning = self.reasoning_parser(lm_output.text)
+                lm_output.text = reasoning.text
+                lm_output.reasoning_text = reasoning.reasoning_text
+
         if self.tool_parser:
             for lm_output, tools in zip(lm_outputs, tools_list):
                 if tools is None:
                     continue
                 lm_output: LMOutput
+                if lm_output.text is None:
+                    continue
                 parsed_tool_calling_message = self.tool_parser(lm_output.text)
                 lm_output.tool_calls = parsed_tool_calling_message.tool_call_dicts
-                lm_output.raw_text = parsed_tool_calling_message.raw_text
                 lm_output.text = parsed_tool_calling_message.text
+                if lm_output.raw_text is None:
+                    lm_output.raw_text = parsed_tool_calling_message.raw_text
                 lm_output.tool_call_validation_result = parsed_tool_calling_message.validation_result
 
         return lm_outputs

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -401,7 +401,7 @@ class HuggingFaceLM(LanguageModel):
         return lm_outputs
 
     @load_model
-    def _batch_generate_chat_response(  # noqa: C901
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
         tools_list: list[list[dict[str, Any]] | None] | None = None,
@@ -425,26 +425,21 @@ class HuggingFaceLM(LanguageModel):
             for chat_messages, tools in zip(chat_messages_list, tools_list)
         ]
         lm_outputs = self._batch_complete_text(chat_messages_as_string, **kwargs)
-        for lm_output in lm_outputs:
+
+        for lm_output, tools in zip(lm_outputs, tools_list):
             if lm_output.text is None:
                 continue
+
             lm_output.text = self.prefix_str_for_chat + lm_output.text
 
-        if self.reasoning_parser:
-            for lm_output in lm_outputs:
+            if self.reasoning_parser:
                 if lm_output.raw_text is None:
                     lm_output.raw_text = lm_output.text
                 reasoning = self.reasoning_parser(lm_output.text)
                 lm_output.text = reasoning.text
                 lm_output.reasoning_text = reasoning.reasoning_text
 
-        if self.tool_parser:
-            for lm_output, tools in zip(lm_outputs, tools_list):
-                if tools is None:
-                    continue
-                lm_output: LMOutput
-                if lm_output.text is None:
-                    continue
+            if self.tool_parser and tools is not None:
                 parsed_tool_calling_message = self.tool_parser(lm_output.text)
                 lm_output.tool_calls = parsed_tool_calling_message.tool_call_dicts
                 lm_output.text = parsed_tool_calling_message.text

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -8,6 +8,7 @@ import torch
 from loguru import logger
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
+from flexeval.core.reasoning_parser.base import ReasoningParser
 from flexeval.core.string_processor import StringProcessor
 from flexeval.core.tool_parser.base import ToolParser
 
@@ -94,6 +95,7 @@ class VLLM(LanguageModel):
             If this value is set to less than or equal to the model's capacity and the input exceeds it,
             an empty string is returned instead of raising an error.
             If set to “default”, the value will be automatically determined when possible.
+        reasoning_parser: A ReasoningParser object to extract the reasoning and content from the model's output.
         tool_parser: A ToolParser object to extract the tool_calls from the model's output.
         tools: Default tools to use in chat responses when no tools are explicitly provided.
         prefix_str_for_chat: A string to prepend to the assistant's response in chat generation.
@@ -115,6 +117,7 @@ class VLLM(LanguageModel):
         default_gen_kwargs: dict[str, Any] | None = None,
         string_processors: StringProcessor | list[StringProcessor] | None = None,
         model_limit_tokens: int | None | Literal["default"] = "default",
+        reasoning_parser: ReasoningParser | None = None,
         tool_parser: ToolParser | None = None,
         tools: list[dict[str, Any]] | None = None,
         prefix_str_for_chat: str = "",
@@ -146,6 +149,7 @@ class VLLM(LanguageModel):
         self.llm: LLM | None = None
         self.model_limit_tokens = model_limit_tokens
         self.tool_parser = tool_parser
+        self.reasoning_parser = reasoning_parser
         self.prefix_str_for_chat = prefix_str_for_chat
 
     @staticmethod
@@ -245,7 +249,7 @@ class VLLM(LanguageModel):
         return outputs
 
     @load_model
-    def _batch_generate_chat_response(
+    def _batch_generate_chat_response(  # noqa: C901
         self,
         chat_messages_list: list[list[dict[str, Any]]],
         tools_list: list[list[dict[str, Any]] | None] | None = None,
@@ -270,15 +274,28 @@ class VLLM(LanguageModel):
         ]
         lm_outputs = self._batch_complete_text(chat_messages_as_string, **kwargs)
         for lm_output in lm_outputs:
+            if lm_output.text is None:
+                continue
             lm_output.text = self.prefix_str_for_chat + lm_output.text
+
+        if self.reasoning_parser:
+            for lm_output in lm_outputs:
+                if lm_output.raw_text is None:
+                    lm_output.raw_text = lm_output.text
+                reasoning = self.reasoning_parser(lm_output.text)
+                lm_output.text = reasoning.text
+                lm_output.reasoning_text = reasoning.reasoning_text
 
         if self.tool_parser:
             for lm_output, tools in zip(lm_outputs, tools_list):
                 if tools is None:
                     continue
+                if lm_output.text is None:
+                    continue
                 parsed_tool_calling_message = self.tool_parser(lm_output.text)
                 lm_output.tool_calls = parsed_tool_calling_message.tool_call_dicts
-                lm_output.raw_text = parsed_tool_calling_message.raw_text
+                if lm_output.raw_text is None:
+                    lm_output.raw_text = parsed_tool_calling_message.raw_text
                 lm_output.text = parsed_tool_calling_message.text
                 lm_output.tool_call_validation_result = parsed_tool_calling_message.validation_result
 

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -249,7 +249,7 @@ class VLLM(LanguageModel):
         return outputs
 
     @load_model
-    def _batch_generate_chat_response(  # noqa: C901
+    def _batch_generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, Any]]],
         tools_list: list[list[dict[str, Any]] | None] | None = None,
@@ -273,30 +273,26 @@ class VLLM(LanguageModel):
             for chat_messages, tools in zip(chat_messages_list, tools_list)
         ]
         lm_outputs = self._batch_complete_text(chat_messages_as_string, **kwargs)
-        for lm_output in lm_outputs:
+
+        for lm_output, tools in zip(lm_outputs, tools_list):
             if lm_output.text is None:
                 continue
+
             lm_output.text = self.prefix_str_for_chat + lm_output.text
 
-        if self.reasoning_parser:
-            for lm_output in lm_outputs:
+            if self.reasoning_parser:
                 if lm_output.raw_text is None:
                     lm_output.raw_text = lm_output.text
                 reasoning = self.reasoning_parser(lm_output.text)
                 lm_output.text = reasoning.text
                 lm_output.reasoning_text = reasoning.reasoning_text
 
-        if self.tool_parser:
-            for lm_output, tools in zip(lm_outputs, tools_list):
-                if tools is None:
-                    continue
-                if lm_output.text is None:
-                    continue
+            if self.tool_parser and tools is not None:
                 parsed_tool_calling_message = self.tool_parser(lm_output.text)
                 lm_output.tool_calls = parsed_tool_calling_message.tool_call_dicts
+                lm_output.text = parsed_tool_calling_message.text
                 if lm_output.raw_text is None:
                     lm_output.raw_text = parsed_tool_calling_message.raw_text
-                lm_output.text = parsed_tool_calling_message.text
                 lm_output.tool_call_validation_result = parsed_tool_calling_message.validation_result
 
         return lm_outputs

--- a/flexeval/core/reasoning_parser/__init__.py
+++ b/flexeval/core/reasoning_parser/__init__.py
@@ -1,0 +1,2 @@
+from .base import Reasoning, ReasoningParser
+from .regex_reasoning_parser import SeparatedRegexReasoningParser, UnifiedRegexReasoningParser

--- a/flexeval/core/reasoning_parser/base.py
+++ b/flexeval/core/reasoning_parser/base.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class Reasoning:
+    text: str | None
+    reasoning_text: str | None
+
+
+class ReasoningParser(ABC):
+    """Base class for parsing raw LLM output text into reasoning and content parts.
+
+    Subclasses must implement `__call__`, which receives the raw text and returns
+    an instance of `Reasoning` class.
+    """
+
+    @abstractmethod
+    def __call__(self, raw_text: str) -> Reasoning:
+        """Parse raw LLM output and return the reasoning and content parts.
+
+        Args:
+            raw_text: Raw output string produced by the language model.
+
+        Returns:
+            An instance of `Reasoning` class.
+        """
+        raise NotImplementedError

--- a/flexeval/core/reasoning_parser/regex_reasoning_parser.py
+++ b/flexeval/core/reasoning_parser/regex_reasoning_parser.py
@@ -1,0 +1,56 @@
+import re
+
+from flexeval.core.reasoning_parser.base import Reasoning, ReasoningParser
+
+
+class UnifiedRegexReasoningParser(ReasoningParser):
+    """Extracts reasoning and content using a single regex with named groups.
+
+    The pattern must contain named groups ``(?P<reasoning_content>...)`` and/or
+    ``(?P<content>...)`` to populate the corresponding fields of :class:`Reasoning`.
+    """
+
+    def __init__(self, pattern: str) -> None:
+        super().__init__()
+        self.pattern = pattern
+
+    def __call__(self, raw_text: str) -> Reasoning:
+        m = re.search(self.pattern, raw_text, re.DOTALL)
+        if m is None:
+            return Reasoning(text=None, reasoning_text=None)
+        gd = m.groupdict()
+        return Reasoning(
+            text=gd.get("content"),
+            reasoning_text=gd.get("reasoning_content"),
+        )
+
+
+class SeparatedRegexReasoningParser(ReasoningParser):
+    """Extracts reasoning and content using two independent regex patterns.
+
+    Each pattern is applied separately.  If a pattern has a capture group,
+    the last group is used; otherwise the full match is used.
+    """
+
+    def __init__(
+        self,
+        pattern_for_content: str,
+        pattern_for_reasoning_content: str,
+    ) -> None:
+        super().__init__()
+        self.pattern_for_content = re.compile(pattern_for_content, re.DOTALL)
+        self.pattern_for_reasoning_content = re.compile(pattern_for_reasoning_content, re.DOTALL)
+
+    def __call__(self, raw_text: str) -> Reasoning:
+        content = None
+        reasoning_text = None
+
+        found_content = self.pattern_for_content.findall(raw_text)
+        if found_content:
+            content = found_content[-1]
+
+        found_reasoning = self.pattern_for_reasoning_content.findall(raw_text)
+        if found_reasoning:
+            reasoning_text = found_reasoning[-1]
+
+        return Reasoning(text=content, reasoning_text=reasoning_text)

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -588,7 +588,8 @@ def test_no_reasoning_parser_leaves_chat_output_unchanged(chat_lm: HuggingFaceLM
     with patch.object(chat_lm, "_batch_complete_text", return_value=[LMOutput(text=raw_output, finish_reason="stop")]):
         response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
     assert response.text == raw_output
-    assert response.raw_text == raw_output
+    # If there's no post-processing, raw_text should be None.
+    assert response.raw_text is None
     assert response.reasoning_text is None
 
 

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -20,6 +20,7 @@ from flexeval.core.language_model.hf_lm import (
     tokenize_text_for_lm_continuation,
     tokenize_text_for_lm_prefix,
 )
+from flexeval.core.reasoning_parser import UnifiedRegexReasoningParser
 from tests.dummy_modules.tool_parser import DummyToolParser
 
 from .base import BaseLanguageModelTest
@@ -518,6 +519,77 @@ def test_system_message_prepended_to_batch_chat_messages(chat_lm_with_system_mes
 def test_set_random_seed(lm: HuggingFaceLM) -> None:
     # check that method is implemented
     assert lm.set_random_seed(42) is None
+
+
+def test_reasoning_parser_sets_fields_on_chat_response(chat_lm: HuggingFaceLM) -> None:
+    reasoning_parser = UnifiedRegexReasoningParser(pattern=r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)")
+    raw_output = "<think>step by step</think>final answer"
+    original_parser = chat_lm.reasoning_parser
+    chat_lm.reasoning_parser = reasoning_parser
+    try:
+        with patch.object(
+            chat_lm, "_batch_complete_text", return_value=[LMOutput(text=raw_output, finish_reason="stop")]
+        ):
+            response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
+        assert response.raw_text == raw_output
+        assert response.text == "final answer"
+        assert response.reasoning_text == "step by step"
+    finally:
+        chat_lm.reasoning_parser = original_parser
+
+
+def test_reasoning_parser_handles_batch_chat_response(chat_lm: HuggingFaceLM) -> None:
+    reasoning_parser = UnifiedRegexReasoningParser(pattern=r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)")
+    raw_outputs = [
+        "<think>reasoning A</think>answer A",
+        "<think>reasoning B</think>answer B",
+    ]
+    original_parser = chat_lm.reasoning_parser
+    chat_lm.reasoning_parser = reasoning_parser
+    try:
+        with patch.object(
+            chat_lm,
+            "_batch_complete_text",
+            return_value=[LMOutput(text=t, finish_reason="stop") for t in raw_outputs],
+        ):
+            responses = chat_lm.generate_chat_response(
+                [[{"role": "user", "content": f"q{i}"}] for i in range(2)], max_new_tokens=1
+            )
+        assert responses[0].raw_text == raw_outputs[0]
+        assert responses[0].text == "answer A"
+        assert responses[0].reasoning_text == "reasoning A"
+        assert responses[1].raw_text == raw_outputs[1]
+        assert responses[1].text == "answer B"
+        assert responses[1].reasoning_text == "reasoning B"
+    finally:
+        chat_lm.reasoning_parser = original_parser
+
+
+def test_reasoning_parser_unmatched_pattern_sets_none(chat_lm: HuggingFaceLM) -> None:
+    reasoning_parser = UnifiedRegexReasoningParser(pattern=r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)")
+    raw_output = "no think tags here"
+    original_parser = chat_lm.reasoning_parser
+    chat_lm.reasoning_parser = reasoning_parser
+    try:
+        with patch.object(
+            chat_lm, "_batch_complete_text", return_value=[LMOutput(text=raw_output, finish_reason="stop")]
+        ):
+            response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
+        assert response.raw_text == raw_output
+        assert response.text is None
+        assert response.reasoning_text is raw_output
+    finally:
+        chat_lm.reasoning_parser = original_parser
+
+
+def test_no_reasoning_parser_leaves_chat_output_unchanged(chat_lm: HuggingFaceLM) -> None:
+    assert chat_lm.reasoning_parser is None
+    raw_output = "<think>step by step</think>final answer"
+    with patch.object(chat_lm, "_batch_complete_text", return_value=[LMOutput(text=raw_output, finish_reason="stop")]):
+        response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
+    assert response.text == raw_output
+    assert response.raw_text == raw_output
+    assert response.reasoning_text is None
 
 
 def test_prefix_str_for_chat(chat_lm: HuggingFaceLM) -> None:

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -577,7 +577,7 @@ def test_reasoning_parser_unmatched_pattern_sets_none(chat_lm: HuggingFaceLM) ->
             response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
         assert response.raw_text == raw_output
         assert response.text is None
-        assert response.reasoning_text is raw_output
+        assert response.reasoning_text is None
     finally:
         chat_lm.reasoning_parser = original_parser
 

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -321,7 +321,8 @@ def test_no_reasoning_parser_leaves_chat_output_unchanged(chat_lm: VLLM) -> None
     with patch.object(chat_lm, "_batch_complete_text", return_value=[LMOutput(text=raw_output, finish_reason="stop")]):
         response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
     assert response.text == raw_output
-    assert response.raw_text == raw_output
+    # If there's no post-processing, raw_text should be None.
+    assert response.raw_text is None
     assert response.reasoning_text is None
 
 

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -326,6 +326,7 @@ def test_no_reasoning_parser_leaves_chat_output_unchanged(chat_lm: VLLM) -> None
     assert response.reasoning_text is None
 
 
+@pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
 def test_prefix_str_for_chat(chat_lm: VLLM) -> None:
     chat_messages = [{"role": "user", "content": "Please output the numbers from 1 to 5, separated by spaces."}]
     prefix = "1 2 3 4"

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -10,6 +10,7 @@ from transformers import AutoTokenizer
 
 from flexeval.core.language_model import VLLM, HuggingFaceLM
 from flexeval.core.language_model.base import LMOutput
+from flexeval.core.reasoning_parser import UnifiedRegexReasoningParser
 from tests.conftest import is_vllm_enabled
 from tests.dummy_modules.tool_parser import DummyToolParser
 
@@ -268,6 +269,62 @@ def test_set_random_seed(chat_lm: VLLM) -> None:
 
 
 @pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
+def test_reasoning_parser_sets_fields_on_chat_response(chat_lm: VLLM) -> None:
+    reasoning_parser = UnifiedRegexReasoningParser(pattern=r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)")
+    raw_output = "<think>step by step</think>final answer"
+    original_parser = chat_lm.reasoning_parser
+    chat_lm.reasoning_parser = reasoning_parser
+    try:
+        with patch.object(
+            chat_lm, "_batch_complete_text", return_value=[LMOutput(text=raw_output, finish_reason="stop")]
+        ):
+            response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
+        assert response.raw_text == raw_output
+        assert response.text == "final answer"
+        assert response.reasoning_text == "step by step"
+    finally:
+        chat_lm.reasoning_parser = original_parser
+
+
+@pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
+def test_reasoning_parser_handles_batch_chat_response(chat_lm: VLLM) -> None:
+    reasoning_parser = UnifiedRegexReasoningParser(pattern=r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)")
+    raw_outputs = [
+        "<think>reasoning A</think>answer A",
+        "<think>reasoning B</think>answer B",
+    ]
+    original_parser = chat_lm.reasoning_parser
+    chat_lm.reasoning_parser = reasoning_parser
+    try:
+        with patch.object(
+            chat_lm,
+            "_batch_complete_text",
+            return_value=[LMOutput(text=t, finish_reason="stop") for t in raw_outputs],
+        ):
+            responses = chat_lm.generate_chat_response(
+                [[{"role": "user", "content": f"q{i}"}] for i in range(2)], max_new_tokens=1
+            )
+        assert responses[0].raw_text == raw_outputs[0]
+        assert responses[0].text == "answer A"
+        assert responses[0].reasoning_text == "reasoning A"
+        assert responses[1].raw_text == raw_outputs[1]
+        assert responses[1].text == "answer B"
+        assert responses[1].reasoning_text == "reasoning B"
+    finally:
+        chat_lm.reasoning_parser = original_parser
+
+
+@pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
+def test_no_reasoning_parser_leaves_chat_output_unchanged(chat_lm: VLLM) -> None:
+    assert chat_lm.reasoning_parser is None
+    raw_output = "<think>step by step</think>final answer"
+    with patch.object(chat_lm, "_batch_complete_text", return_value=[LMOutput(text=raw_output, finish_reason="stop")]):
+        response = chat_lm.generate_chat_response([{"role": "user", "content": "test"}], max_new_tokens=1)
+    assert response.text == raw_output
+    assert response.raw_text == raw_output
+    assert response.reasoning_text is None
+
+
 def test_prefix_str_for_chat(chat_lm: VLLM) -> None:
     chat_messages = [{"role": "user", "content": "Please output the numbers from 1 to 5, separated by spaces."}]
     prefix = "1 2 3 4"

--- a/tests/core/reasoning_parser/test_regex_reasoning_parser.py
+++ b/tests/core/reasoning_parser/test_regex_reasoning_parser.py
@@ -1,0 +1,103 @@
+import pytest
+
+from flexeval.core.reasoning_parser import Reasoning, SeparatedRegexReasoningParser, UnifiedRegexReasoningParser
+
+
+@pytest.mark.parametrize(
+    ("pattern", "raw_text", "expected"),
+    [
+        (
+            r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)",
+            "<think>step by step</think>final answer",
+            Reasoning(text="final answer", reasoning_text="step by step"),
+        ),
+        (
+            r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)",
+            "<think>reasoning</think>",
+            Reasoning(text="", reasoning_text="reasoning"),
+        ),
+        (
+            r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)",
+            "no tags here",
+            Reasoning(text=None, reasoning_text=None),
+        ),
+        (
+            r"(?P<reasoning_content>.*)",
+            "only reasoning",
+            Reasoning(text=None, reasoning_text="only reasoning"),
+        ),
+        (
+            r"(?P<content>.*)",
+            "only content",
+            Reasoning(text="only content", reasoning_text=None),
+        ),
+        (
+            r"<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)",
+            "<think>line1\nline2</think>answer",
+            Reasoning(text="answer", reasoning_text="line1\nline2"),
+        ),
+    ],
+)
+def test_unified_regex_reasoning_parser(pattern: str, raw_text: str, expected: Reasoning) -> None:
+    parser = UnifiedRegexReasoningParser(pattern=pattern)
+    assert parser(raw_text) == expected
+
+
+@pytest.mark.parametrize(
+    ("pattern_for_content", "pattern_for_reasoning_content", "raw_text", "expected"),
+    [
+        (
+            r"<answer>(.*?)</answer>",
+            r"<think>(.*?)</think>",
+            "<think>step by step</think><answer>final answer</answer>",
+            Reasoning(text="final answer", reasoning_text="step by step"),
+        ),
+        (
+            r"<answer>(.*?)</answer>",
+            r"<think>(.*?)</think>",
+            "<think>reasoning</think>",
+            Reasoning(text=None, reasoning_text="reasoning"),
+        ),
+        (
+            r"<answer>(.*?)</answer>",
+            r"<think>(.*?)</think>",
+            "<answer>answer</answer>",
+            Reasoning(text="answer", reasoning_text=None),
+        ),
+        (
+            r"<answer>(.*?)</answer>",
+            r"<think>(.*?)</think>",
+            "no tags",
+            Reasoning(text=None, reasoning_text=None),
+        ),
+        (
+            r"<answer>(.*?)</answer>",
+            r"<think>(.*?)</think>",
+            "<think>r1</think><think>r2</think><answer>a1</answer><answer>a2</answer>",
+            Reasoning(text="a2", reasoning_text="r2"),
+        ),
+        (
+            r"<answer>.*?</answer>",
+            r"<think>.*?</think>",
+            "<think>reasoning</think><answer>answer</answer>",
+            Reasoning(text="<answer>answer</answer>", reasoning_text="<think>reasoning</think>"),
+        ),
+        (
+            r"<answer>(.*?)</answer>",
+            r"<think>(.*?)</think>",
+            "<think>line1\nline2</think><answer>result</answer>",
+            Reasoning(text="result", reasoning_text="line1\nline2"),
+        ),
+    ],
+)
+def test_separated_regex_reasoning_parser(
+    pattern_for_content: str,
+    pattern_for_reasoning_content: str,
+    raw_text: str,
+    expected: Reasoning,
+) -> None:
+    parser = SeparatedRegexReasoningParser(
+        pattern_for_content=pattern_for_content,
+        pattern_for_reasoning_content=pattern_for_reasoning_content,
+    )
+    assert parser(raw_text) == expected


### PR DESCRIPTION
Add a mechanism to the `VLLM` and `HuggingFaceLM` classes to extract the reasoning content and store it in `LMOutput.reasoning_text`.

Example
```bash
flexeval_lm --eval_setup rakuda-v2-ja --language_model VLLM --language_model.model Qwen/Qwen3-4B --language_model.reasoning_parser UnifiedRegexReasoningParser --language_model.reasoning_parser.pattern="<think>(?P<reasoning_content>.*?)</think>(?P<content>.*)"
```

```
...
2026-05-21 21:04:48.236 | INFO     | flexeval.core.evaluate_chat_response:evaluate_chat_response:181 - Example of the output
2026-05-21 21:04:48.236 | INFO     | flexeval.core.evaluate_chat_response:evaluate_chat_response:182 - {
    "lm_output": {
        "text": "\n\n四国地方には以下の4つの都道府県があります。それぞれの県庁所在地を以下に列挙します。\n\n1. **香川県（かわかん）**  \n   - **県庁所在地**：香川市（かわかし）\n\n2. **岡山県（おうさんけん）**  \n   - **県庁所在地**：岡山市（おうさんし）\n\n3. **徳島県（とくしまけん）**  \n   - **県庁所在地**：徳島市（とくしまし）\n\n4. **広島県（ひろしまけん）**  \n   - **県庁所在地**：広島市（ひろしまし）\n\n※四国地方は日本の四つの地方の一つで、これらの4県が含まれます。",
        "raw_text": "<think>\nOkay, the user is asking for the four prefectures in the Shikoku region and their respective prefectural capitals. Let me start by recalling the four prefectures in Shikoku. I think they are Kagawa, Okayama, Tokushima, and Hiroshima. Wait, but I need to make sure. Let me think again. Shikoku is the fourth largest island in Japan, right? The four prefectures there are Kagawa, Okayama, Tokushima, and Hiroshima. Yes, that's correct.\n\nNow, the prefectural capitals. For Kagawa, I believe the capital is Kagawa City. Okayama's capital is Okayama City. Tokushima's capital is Tokushima City. And Hiroshima's capital is Hiroshima City. Let me double-check each one to be sure. Kagawa City is indeed the capital of Kagawa Prefecture. Okayama City is the capital of Okayama Prefecture. Tokushima City is the capital of Tokushima Prefecture. Hiroshima City is the capital of Hiroshima Prefecture. That seems right. \n\nWait, but sometimes people might confuse the capitals. For example, Hiroshima is a major city, but is it the capital? Yes, Hiroshima City is the capital of Hiroshima Prefecture. Okay, so the answer should be the four prefectures and their capitals as listed. I think that's all. Let me just confirm once more. Yes, those are the four prefectures in Shikoku, and their capitals are as mentioned. No mistakes there.\n</think>\n\n四国地方には以下の4つの都道府県があります。それぞれの県庁所在地を以下に列挙します。\n\n1. **香川県（かわかん）**  \n   - **県庁所在地**：香川市（かわかし）\n\n2. **岡山県（おうさんけん）**  \n   - **県庁所在地**：岡山市（おうさんし）\n\n3. **徳島県（とくしまけん）**  \n   - **県庁所在地**：徳島市（とくしまし）\n\n4. **広島県（ひろしまけん）**  \n   - **県庁所在地**：広島市（ひろしまし）\n\n※四国地方は日本の四つの地方の一つで、これらの4県が含まれます。",
        "reasoning_text": "\nOkay, the user is asking for the four prefectures in the Shikoku region and their respective prefectural capitals. Let me start by recalling the four prefectures in Shikoku. I think they are Kagawa, Okayama, Tokushima, and Hiroshima. Wait, but I need to make sure. Let me think again. Shikoku is the fourth largest island in Japan, right? The four prefectures there are Kagawa, Okayama, Tokushima, and Hiroshima. Yes, that's correct.\n\nNow, the prefectural capitals. For Kagawa, I believe the capital is Kagawa City. Okayama's capital is Okayama City. Tokushima's capital is Tokushima City. And Hiroshima's capital is Hiroshima City. Let me double-check each one to be sure. Kagawa City is indeed the capital of Kagawa Prefecture. Okayama City is the capital of Okayama Prefecture. Tokushima City is the capital of Tokushima Prefecture. Hiroshima City is the capital of Hiroshima Prefecture. That seems right. \n\nWait, but sometimes people might confuse the capitals. For example, Hiroshima is a major city, but is it the capital? Yes, Hiroshima City is the capital of Hiroshima Prefecture. Okay, so the answer should be the four prefectures and their capitals as listed. I think that's all. Let me just confirm once more. Yes, those are the four prefectures in Shikoku, and their capitals are as mentioned. No mistakes there.\n",
...
```
