### PR TITLE
Added a feature to `VLLM` and `HuggingFaceLM` that forces a response prefix

### DIFF
--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -188,6 +188,10 @@ class HuggingFaceLM(LanguageModel):
             If set to “default”, the value will be automatically determined when possible.
         tool_parser: A ToolParser object to extract the tool_calls from the model's output.
         tools: Default tools to use in chat responses when no tools are explicitly provided.
+        prefix_str_for_chat: A string to prepend to the assistant's response in chat generation.
+            This string is appended to the prompt (after `apply_chat_template`) so that the model
+            continues generation from it. The same string is also prepended to the final output
+            so that the returned text includes the forced prefix.
     """
 
     def __init__(
@@ -208,6 +212,7 @@ class HuggingFaceLM(LanguageModel):
         model_limit_tokens: int | None | Literal["default"] = "default",
         tool_parser: ToolParser | None = None,
         tools: list[dict[str, Any]] | None = None,
+        prefix_str_for_chat: str = "",
     ) -> None:
         super().__init__(string_processors=string_processors, tools=tools)
         self._model_name_or_path = model
@@ -226,6 +231,7 @@ class HuggingFaceLM(LanguageModel):
         self.amp_dtype = amp_dtype
         self.model_limit_tokens = model_limit_tokens
         self.tool_parser = tool_parser
+        self.prefix_str_for_chat = prefix_str_for_chat
         logger.info(f"amp_dtype: {amp_dtype}")
         logger.info(f"random seed: {random_seed}")
         transformers.set_seed(random_seed)
@@ -414,6 +420,8 @@ class HuggingFaceLM(LanguageModel):
             for chat_messages, tools in zip(chat_messages_list, tools_list)
         ]
         lm_outputs = self._batch_complete_text(chat_messages_as_string, **kwargs)
+        for lm_output in lm_outputs:
+            lm_output.text = self.prefix_str_for_chat + lm_output.text
         if self.tool_parser:
             for lm_output, tools in zip(lm_outputs, tools_list):
                 if tools is None:

--- a/flexeval/core/language_model/hf_lm.py
+++ b/flexeval/core/language_model/hf_lm.py
@@ -417,6 +417,7 @@ class HuggingFaceLM(LanguageModel):
                 chat_template=self.custom_chat_template,
                 **self.chat_template_kwargs,
             )
+            + self.prefix_str_for_chat
             for chat_messages, tools in zip(chat_messages_list, tools_list)
         ]
         lm_outputs = self._batch_complete_text(chat_messages_as_string, **kwargs)

--- a/flexeval/core/language_model/vllm_model.py
+++ b/flexeval/core/language_model/vllm_model.py
@@ -96,6 +96,10 @@ class VLLM(LanguageModel):
             If set to “default”, the value will be automatically determined when possible.
         tool_parser: A ToolParser object to extract the tool_calls from the model's output.
         tools: Default tools to use in chat responses when no tools are explicitly provided.
+        prefix_str_for_chat: A string to prepend to the assistant's response in chat generation.
+            This string is appended to the prompt (after `apply_chat_template`) so that the model
+            continues generation from it. The same string is also prepended to the final output
+            so that the returned text includes the forced prefix.
     """
 
     def __init__(
@@ -113,6 +117,7 @@ class VLLM(LanguageModel):
         model_limit_tokens: int | None | Literal["default"] = "default",
         tool_parser: ToolParser | None = None,
         tools: list[dict[str, Any]] | None = None,
+        prefix_str_for_chat: str = "",
     ) -> None:
         super().__init__(string_processors=string_processors, tools=tools)
         self.model_name = model
@@ -141,6 +146,7 @@ class VLLM(LanguageModel):
         self.llm: LLM | None = None
         self.model_limit_tokens = model_limit_tokens
         self.tool_parser = tool_parser
+        self.prefix_str_for_chat = prefix_str_for_chat
 
     @staticmethod
     def load_model(method: Callable) -> Callable:
@@ -259,9 +265,13 @@ class VLLM(LanguageModel):
                 chat_template=self.custom_chat_template,
                 **self.chat_template_kwargs,
             )
+            + self.prefix_str_for_chat
             for chat_messages, tools in zip(chat_messages_list, tools_list)
         ]
         lm_outputs = self._batch_complete_text(chat_messages_as_string, **kwargs)
+        for lm_output in lm_outputs:
+            lm_output.text = self.prefix_str_for_chat + lm_output.text
+
         if self.tool_parser:
             for lm_output, tools in zip(lm_outputs, tools_list):
                 if tools is None:

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -525,6 +525,12 @@ def test_prefix_str_for_chat(chat_lm: HuggingFaceLM) -> None:
     prefix = "1 2 3 4"
     original_prefix = chat_lm.prefix_str_for_chat
     chat_lm.prefix_str_for_chat = prefix
-    output = chat_lm.generate_chat_response(chat_messages, max_new_tokens=10)
+
+    def _mock_batch_complete_text(text_list: list[str], **_: object) -> list[LMOutput]:
+        assert text_list[0].endswith(prefix)
+        return [LMOutput(text=" 5", finish_reason="stop")]
+
+    with patch.object(chat_lm, "_batch_complete_text", side_effect=_mock_batch_complete_text):
+        output = chat_lm.generate_chat_response(chat_messages, max_new_tokens=10)
     chat_lm.prefix_str_for_chat = original_prefix
-    assert output.text.startswith(prefix + " 5")
+    assert output.text == prefix + " 5"

--- a/tests/core/language_model/test_hf_lm.py
+++ b/tests/core/language_model/test_hf_lm.py
@@ -518,3 +518,13 @@ def test_system_message_prepended_to_batch_chat_messages(chat_lm_with_system_mes
 def test_set_random_seed(lm: HuggingFaceLM) -> None:
     # check that method is implemented
     assert lm.set_random_seed(42) is None
+
+
+def test_prefix_str_for_chat(chat_lm: HuggingFaceLM) -> None:
+    chat_messages = [{"role": "user", "content": "Please output the numbers from 1 to 5, separated by spaces."}]
+    prefix = "1 2 3 4"
+    original_prefix = chat_lm.prefix_str_for_chat
+    chat_lm.prefix_str_for_chat = prefix
+    output = chat_lm.generate_chat_response(chat_messages, max_new_tokens=10)
+    chat_lm.prefix_str_for_chat = original_prefix
+    assert output.text.startswith(prefix + " 5")

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -264,3 +264,14 @@ def test_system_message_prepended_to_batch_chat_messages(chat_lm_with_system_mes
 def test_set_random_seed(chat_lm: VLLM) -> None:
     chat_lm.set_random_seed(42)
     assert chat_lm.default_gen_kwargs["seed"] == 42
+
+
+@pytest.mark.skipif(not is_vllm_enabled(), reason="vllm library is not installed")
+def test_prefix_str_for_chat(chat_lm: VLLM) -> None:
+    chat_messages = [{"role": "user", "content": "Please output the numbers from 1 to 5, separated by spaces."}]
+    prefix = "1 2 3 4"
+    original_prefix = chat_lm.prefix_str_for_chat
+    chat_lm.prefix_str_for_chat = prefix
+    output = chat_lm.generate_chat_response(chat_messages, max_new_tokens=10)
+    chat_lm.prefix_str_for_chat = original_prefix
+    assert output.text.startswith(prefix + " 5")

--- a/tests/core/language_model/vllm/test_vllm_specific.py
+++ b/tests/core/language_model/vllm/test_vllm_specific.py
@@ -9,6 +9,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from flexeval.core.language_model import VLLM, HuggingFaceLM
+from flexeval.core.language_model.base import LMOutput
 from tests.conftest import is_vllm_enabled
 from tests.dummy_modules.tool_parser import DummyToolParser
 
@@ -272,6 +273,12 @@ def test_prefix_str_for_chat(chat_lm: VLLM) -> None:
     prefix = "1 2 3 4"
     original_prefix = chat_lm.prefix_str_for_chat
     chat_lm.prefix_str_for_chat = prefix
-    output = chat_lm.generate_chat_response(chat_messages, max_new_tokens=10)
+
+    def _mock_batch_complete_text(text_list: list[str], **_: object) -> list[LMOutput]:
+        assert text_list[0].endswith(prefix)
+        return [LMOutput(text=" 5", finish_reason="stop")]
+
+    with patch.object(chat_lm, "_batch_complete_text", side_effect=_mock_batch_complete_text):
+        output = chat_lm.generate_chat_response(chat_messages, max_new_tokens=10)
     chat_lm.prefix_str_for_chat = original_prefix
-    assert output.text.startswith(prefix + " 5")
+    assert output.text == prefix + " 5"


### PR DESCRIPTION
Add a feature to `VLLM` and `HuggingFaceLM` that forces a prefix for the assistant's responses.

Example
```python
from flexeval import VLLM

lm = VLLM(model="/path/to/model", prefix_str_for_chat="<think></think>")
output = lm.generate_chat_response(["role": "user", "content": "hogehoge"])
print(output.text)
# <think></think>fugafuga
```