### PR TITLE
Fix `VLLMServeLM` ignoring a hyphenated `tensor-parallel-size` in `model_kwargs`

### DIFF
--- a/flexeval/core/language_model/vllm_serve_lm.py
+++ b/flexeval/core/language_model/vllm_serve_lm.py
@@ -193,7 +193,7 @@ class VLLMServeLM(OpenAIChatAPI):
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)
         model_kwargs = model_kwargs or {}
-        if "tensor_parallel_size" not in model_kwargs:
+        if "tensor_parallel_size" not in model_kwargs and "tensor-parallel-size" not in model_kwargs:
             model_kwargs["tensor_parallel_size"] = torch.cuda.device_count()
         self.manager = VLLMServerManager(model=model, model_kwargs=model_kwargs, timeout=booting_timeout)
         if api_headers is None:


### PR DESCRIPTION

## 関連する Issue / PR

なし

## 目的

`VLLMServeLM` に `model_kwargs={"tensor-parallel-size": 1}` のようにハイフン区切りで `tensor_parallel_size` を渡すと、指定値が黙って `torch.cuda.device_count()` に上書きされる不具合を修正する。

`tensor_parallel_size` が `model_kwargs` に含まれない場合、 `model_kwargs["tensor_parallel_size"] = device_count()` が自動注入されるが、ユーザーが `-`を使う `tensor-parallel-size` (例えば`1`)を渡す場合、`vllm serve` には `--tensor-parallel-size 1 --tensor-parallel-size <device_count()>` が二重に渡り、argparse の後勝ちで ユーザー指定の`tensor-parallel-size`がサイレントに無視される。

## 実装の詳細

`VLLMServeLM.__init__` の自動注入ガードを、`tensor_parallel_size` と `tensor-parallel-size` のどちらの表記も「指定済み」とみなすように修正する。

- どちらの表記も含まれていなければ、従来どおり `tensor_parallel_size` に `torch.cuda.device_count()` を注入する
- どちらか一方でも指定されていれば、その値を尊重して自動注入しない（二重フラグを防ぐ）

```python
model_kwargs = model_kwargs or {}
if "tensor_parallel_size" not in model_kwargs and "tensor-parallel-size" not in model_kwargs:
    model_kwargs["tensor_parallel_size"] = torch.cuda.device_count()
```

## 動作確認

- [x] テストに通ることを確認した
- [x] `ruff check` / `ruff format --check` 通過
- [x] 既存挙動への影響なし（underscore 形キーは従来どおり）

## 追記事項

なし
