### PR TITLE
Fix/fix finish reason in empty response

### DIFF
--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -226,7 +226,7 @@ class OpenAIChatAPI(LanguageModel):
             LMOutput(
                 text=res.choices[0].message.content,
                 reasoning_text=get_reasoning_text(res.choices[0].message),
-                finish_reason="error" if res is self.empty_response else res.choices[0].finish_reason,
+                finish_reason="empty" if res is self.empty_response else res.choices[0].finish_reason,
             )
             for res in api_responses
         ]
@@ -246,7 +246,7 @@ class OpenAIChatAPI(LanguageModel):
             LMOutput(
                 text=res.choices[0].message.content,
                 reasoning_text=get_reasoning_text(res.choices[0].message),
-                finish_reason="error" if res is self.empty_response else res.choices[0].finish_reason,
+                finish_reason="empty" if res is self.empty_response else res.choices[0].finish_reason,
                 tool_calls=[tool_call.to_dict() for tool_call in res.choices[0].message.tool_calls]
                 if res.choices[0].message.tool_calls
                 else None,
@@ -455,7 +455,7 @@ class OpenAICompletionAPI(LanguageModel):
         )
 
         return [
-            LMOutput(text="", finish_reason="error")
+            LMOutput(text="", finish_reason="empty")
             if res is self.empty_response
             else LMOutput(text=res.choices[0].text, finish_reason=res.choices[0].finish_reason)
             for res in api_responses

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -226,7 +226,7 @@ class OpenAIChatAPI(LanguageModel):
             LMOutput(
                 text=res.choices[0].message.content,
                 reasoning_text=get_reasoning_text(res.choices[0].message),
-                finish_reason=res.choices[0].finish_reason,
+                finish_reason="error" if res is self.empty_response else res.choices[0].finish_reason,
             )
             for res in api_responses
         ]
@@ -246,7 +246,7 @@ class OpenAIChatAPI(LanguageModel):
             LMOutput(
                 text=res.choices[0].message.content,
                 reasoning_text=get_reasoning_text(res.choices[0].message),
-                finish_reason=res.choices[0].finish_reason,
+                finish_reason="error" if res is self.empty_response else res.choices[0].finish_reason,
                 tool_calls=[tool_call.to_dict() for tool_call in res.choices[0].message.tool_calls]
                 if res.choices[0].message.tool_calls
                 else None,
@@ -450,7 +450,12 @@ class OpenAICompletionAPI(LanguageModel):
             **kwargs,
         )
 
-        return [LMOutput(text=res.choices[0].text, finish_reason=res.choices[0].finish_reason) for res in api_responses]
+        return [
+            LMOutput(text="", finish_reason="error")
+            if res is self.empty_response
+            else LMOutput(text=res.choices[0].text, finish_reason=res.choices[0].finish_reason)
+            for res in api_responses
+        ]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(model={self.model})"

--- a/flexeval/core/language_model/openai_api.py
+++ b/flexeval/core/language_model/openai_api.py
@@ -295,17 +295,21 @@ class OpenAIChatAPI(LanguageModel):
         )
 
         log_probs = []
-        top_logprobs_list = [res.choices[0].logprobs.content[0].top_logprobs for res in api_responses]
+        top_logprobs_list = [
+            None if res is self.empty_response else res.choices[0].logprobs.content[0].top_logprobs
+            for res in api_responses
+        ]
         for index, prompt in enumerate(prompt_list):
             target_token = response_contents[index]
             index_in_unique = unique_prompt_list.index(prompt)
 
-            log_prob = None  # if target token not in top_logprobs, return None for log_prob of the token
+            log_prob = None  # if target token not in top_logprobs, or the request errored, return None
             top_logprobs = top_logprobs_list[index_in_unique]
-            for token_logprob in top_logprobs:
-                if token_logprob.token == target_token:
-                    log_prob = token_logprob.logprob
-                    break
+            if top_logprobs is not None:
+                for token_logprob in top_logprobs:
+                    if token_logprob.token == target_token:
+                        log_prob = token_logprob.logprob
+                        break
             log_probs.append(log_prob)
 
         return log_probs

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -257,7 +257,9 @@ class OpenAIChatBatchAPI(LanguageModel):
             **kwargs,
         )
         return [
-            LMOutput(text=res["choices"][0]["message"]["content"], finish_reason=res["choices"][0]["finish_reason"])
+            LMOutput(text="", finish_reason="error")
+            if isinstance(res, str)
+            else LMOutput(text=res["choices"][0]["message"]["content"], finish_reason=res["choices"][0]["finish_reason"])
             for res in api_responses
         ]
 
@@ -273,7 +275,9 @@ class OpenAIChatBatchAPI(LanguageModel):
             **kwargs,
         )
         return [
-            LMOutput(
+            LMOutput(text="", finish_reason="error")
+            if isinstance(res, str)
+            else LMOutput(
                 text=res["choices"][0]["message"]["content"],
                 finish_reason=res["choices"][0]["finish_reason"],
                 tool_calls=res["choices"][0]["message"].get("tool_calls", None),

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -259,7 +259,10 @@ class OpenAIChatBatchAPI(LanguageModel):
         return [
             LMOutput(text="", finish_reason="error")
             if isinstance(res, str)
-            else LMOutput(text=res["choices"][0]["message"]["content"], finish_reason=res["choices"][0]["finish_reason"])
+            else LMOutput(
+                text=res["choices"][0]["message"]["content"],
+                finish_reason=res["choices"][0]["finish_reason"],
+            )
             for res in api_responses
         ]
 

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -323,17 +323,21 @@ class OpenAIChatBatchAPI(LanguageModel):
         )
 
         log_probs = []
-        top_logprobs_list = [res["choices"][0]["logprobs"]["content"][0]["top_logprobs"] for res in api_responses]
+        top_logprobs_list = [
+            None if isinstance(res, str) else res["choices"][0]["logprobs"]["content"][0]["top_logprobs"]
+            for res in api_responses
+        ]
         for index, prompt in enumerate(prompt_list):
             target_token = response_contents[index]
             index_in_unique = unique_prompt_list.index(prompt)
 
-            log_prob = None  # if target token not in top_logprobs, return None for log_prob of the token
+            log_prob = None  # if target token not in top_logprobs, or the request errored, return None
             top_logprobs = top_logprobs_list[index_in_unique]
-            for token_logprob in top_logprobs:
-                if token_logprob["token"] == target_token:
-                    log_prob = token_logprob["logprob"]
-                    break
+            if top_logprobs is not None:
+                for token_logprob in top_logprobs:
+                    if token_logprob["token"] == target_token:
+                        log_prob = token_logprob["logprob"]
+                        break
             log_probs.append(log_prob)
 
         return log_probs

--- a/flexeval/core/language_model/openai_batch_api.py
+++ b/flexeval/core/language_model/openai_batch_api.py
@@ -257,7 +257,7 @@ class OpenAIChatBatchAPI(LanguageModel):
             **kwargs,
         )
         return [
-            LMOutput(text="", finish_reason="error")
+            LMOutput(text="", finish_reason="empty")
             if isinstance(res, str)
             else LMOutput(
                 text=res["choices"][0]["message"]["content"],
@@ -278,7 +278,7 @@ class OpenAIChatBatchAPI(LanguageModel):
             **kwargs,
         )
         return [
-            LMOutput(text="", finish_reason="error")
+            LMOutput(text="", finish_reason="empty")
             if isinstance(res, str)
             else LMOutput(
                 text=res["choices"][0]["message"]["content"],


### PR DESCRIPTION


## 概要

`LanguageModel`で、APIリトライを使い果たした際のダミーレスポンス（`empty_response`）が、`finish_reason`が`"stop"`になっており、正常応答と見分けがつかない形で下流に流れてしまっていた問題を修正
- `OpenAICompletionAPI`と`OpenAIChatBatchAPI`では、上記に加えてダミーレスポンスの形が実際のレスポンス型と一致しておらず、失敗時に`AttributeError`/`TypeError`でクラッシュする経路も存在（by claude）

## 変更

### `flexeval/core/language_model/openai_api.py`

- `OpenAIChatAPI._batch_complete_text` / `_batch_generate_chat_response`: 応答が`self.empty_response`（＝リトライを使い果たした結果）の場合、`finish_reason`を`"error"`にするよう変更
- `OpenAICompletionAPI._batch_complete_text`: 同様に`finish_reason="error"`を設定
  - 加えて、`empty_response`がchat API用の形（`message`のみで`text`属性を持たない）で構築されているため、そのまま`res.choices[0].text`にアクセスすると`AttributeError`になっていたバグを修正
- `OpenAIChatAPI._batch_compute_chat_log_probs`: `empty_response`は`logprobs=None`のまま構築されているため、`res.choices[0].logprobs.content[0]`で`AttributeError`になっていたバグを修正。

### `flexeval/core/language_model/openai_batch_api.py`

- `OpenAIChatBatchAPI._batch_complete_text` / `_batch_generate_chat_response`: Batch APIでリクエストが失敗した項目は`""`（空文字列）のまま残る実装になっており、`res["choices"]`でインデックスアクセスすると`TypeError: string indices must be integers`になっていたバグを修正。`isinstance(res, str)`で失敗分を判定し、`LMOutput(text="", finish_reason="error")`を返すよう変更
- `OpenAIChatBatchAPI._batch_compute_chat_log_probs`: 同様に失敗分（`""`）へのインデックスアクセスによる`TypeError`を修正し、`log_prob=None`にフォールバックするよう変更