### PR TITLE
MultipleChoice評価でfew-shotリーク検査が機能しない問題を修正

### DIFF
--- a/flexeval/core/evaluate_multiple_choice.py
+++ b/flexeval/core/evaluate_multiple_choice.py
@@ -37,7 +37,9 @@ def evaluate_multiple_choice(
                 template_inputs = {**eval_instance.inputs, "choices": eval_instance.choices}
 
                 if few_shot_generator is not None:
-                    few_shot_instances = few_shot_generator(template_inputs)
+                    # Pass the raw inputs (without the injected "choices" key) so that
+                    # the data-leak check can compare them against the sampled instances' inputs.
+                    few_shot_instances = few_shot_generator(eval_instance.inputs)
                     few_shot_item_list: list[dict[str, Any]] = []
                     for few_shot_instance in few_shot_instances:
                         if isinstance(few_shot_instance, MultipleChoiceInstance):

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -79,6 +79,26 @@ def test_evaluate_multiple_choice(use_few_shot: bool, max_instances: int) -> Non
     assert set(metrics.keys()) == {"accuracy", "byte_norm_accuracy", "macro_f1_score", "micro_f1_score"}
 
 
+def test_evaluate_multiple_choice_detects_few_shot_leak() -> None:
+    # Sampling all instances of the dataset used as both the evaluation dataset and the
+    # few-shot pool guarantees the evaluation instance is always among the sampled shots.
+    few_shot_generator = RandomFewShotGenerator(
+        dataset=DummyMultipleChoiceDataset(),
+        num_shots=len(DummyMultipleChoiceDataset()),
+        num_trials_to_avoid_leak=3,
+    )
+
+    with pytest.raises(ValueError, match="data leak"):
+        evaluate_multiple_choice(
+            language_model=DummyLanguageModel(),
+            eval_dataset=DummyMultipleChoiceDataset(),
+            prompt_template=Jinja2PromptTemplate("{{text}}"),
+            few_shot_generator=few_shot_generator,
+            batch_size=1,
+            max_instances=1,
+        )
+
+
 @pytest.mark.parametrize(
     "max_instances",
     [None, 1],


### PR DESCRIPTION
## 概要

MultipleChoice 評価で few-shot リーク検査（`num_trials_to_avoid_leak`）が構造的に無効になっていた問題を修正します。

## 問題

`FewShotGenerator.__call__`（`few_shot_generator/base.py`）は、サンプルした few-shot 例の `inputs` が評価インスタンスの `eval_inputs` と一致した場合に再サンプリング・最終的に `ValueError` を発生させるリーク検査を持っています。

しかし `evaluate_multiple_choice.py` だけは、プロンプト埋め込み用に `"choices"` キーを注入した後の `template_inputs` を検査に渡していました:

```python
template_inputs = {**eval_instance.inputs, "choices": eval_instance.choices}
few_shot_instances = few_shot_generator(template_inputs)  # ← "choices" 入りの dict
```

比較相手の `sampled.inputs` は `"choices"` キーを含まないため、**同一インスタンスでも dict の等価比較が絶対に成立せず、リーク検査は常に「リークなし」を返す no-op になっていました**。評価インスタンスと同じ問題（正解付き）が few-shot 例としてプロンプトに混入しても、エラーにも警告にもならず精度が水増しされ得ます。

`evaluate_generation.py` / `evaluate_chat_response.py` は未加工の `inputs` を渡しており、この問題は MultipleChoice 経路のみです。

## 修正

few-shot 生成器には `"choices"` 注入前の `eval_instance.inputs` を渡すようにしました（`evaluate_generation.py` と同じ構造）。`"choices"` の注入はプロンプトテンプレート用の `template_inputs` 構築時のみ行います。

## 再現確認方法

リークが必ず発生する状況（few-shot プール＝評価データセット、`num_shots` = データセット全件）を作ると:

```python
few_shot_generator = RandomFewShotGenerator(
    dataset=DummyMultipleChoiceDataset(),
    num_shots=len(DummyMultipleChoiceDataset()),  # 評価インスタンスが必ず shots に含まれる
    num_trials_to_avoid_leak=3,
)
evaluate_multiple_choice(..., few_shot_generator=few_shot_generator, ...)
```

- **修正前**: `ValueError` にならず評価が最後まで「成功」する（リーク未検出。答えがプロンプトに含まれるため accuracy は 1.0 になる）
- **修正後**: `Few-shot instance has the same inputs as the evaluation instance, which indicates a data leak.` の `ValueError` が発生する

この検証をそのまま回帰テスト `test_evaluate_multiple_choice_detects_few_shot_leak` として追加しています（修正コミットを外すと failed になることを確認済み）。

## 影響範囲

- **評価値への影響**: リークが実際に起きていない設定では、few-shot 例の選択・プロンプト内容とも一切変わらず、**評価結果の数値は変化しません**（`_sample_instances` は `eval_inputs` をサンプリングに使用していないため）。
- **挙動変化**: few-shot プールと評価セットが実際に重複している設定は、これまで黙って完走していたものが `ValueError` で失敗するようになります。これは `num_trials_to_avoid_leak` 本来の設計通りの挙動です。
- **同梱プリセットへの影響**: なし。`preset_configs/EvalSetup/*multiple_choice/` の全プリセットは few-shot に `train`、評価に `test`/`validation` を使う分離構成であることを確認済みです。
- **カスタム実装への影響**: `_sample_instances` で `eval_inputs["choices"]` を参照するカスタム `FewShotGenerator` を使っている場合、このキーは渡されなくなります（Generation / ChatResponse 経路は元々未加工 `inputs` のみを渡しており、本修正で全経路の契約が統一されます）。
- Generation / ChatResponse / Perplexity 経路には変更ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
