### PR TITLE
LiteLLMChatAPIのignore_seedがset_random_seed経由のseedを無視しない問題を修正

### DIFF
--- a/flexeval/core/language_model/litellm_api.py
+++ b/flexeval/core/language_model/litellm_api.py
@@ -75,9 +75,13 @@ class LiteLLMChatAPI(OpenAIChatAPI):
             model_response_object=ModelResponse(),
         )
         self.ignore_seed = ignore_seed
+        if self.ignore_seed and "seed" in self.default_gen_kwargs:
+            self.default_gen_kwargs.pop("seed")
         self.api_call_func = completion
 
     def set_random_seed(self, seed: int) -> None:
+        if self.ignore_seed:
+            return
         self.default_gen_kwargs["seed"] = seed
 
     def _batch_complete_text(

--- a/tests/core/language_model/test_litellm_api.py
+++ b/tests/core/language_model/test_litellm_api.py
@@ -115,3 +115,28 @@ def test_if_not_ignore_seed() -> None:
 def test_set_random_seed(chat_lm: OpenAIChatAPI) -> None:
     chat_lm.set_random_seed(42)
     assert chat_lm.default_gen_kwargs["seed"] == 42
+
+
+@pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
+def test_set_random_seed_is_noop_when_ignore_seed() -> None:
+    chat_lm = LiteLLMChatAPI(MODEL_NAME, ignore_seed=True)
+    chat_lm.set_random_seed(42)
+    assert "seed" not in chat_lm.default_gen_kwargs
+
+
+@pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
+def test_ignore_seed_removes_seed_from_default_gen_kwargs() -> None:
+    chat_lm = LiteLLMChatAPI(MODEL_NAME, default_gen_kwargs={"seed": 42, "temperature": 0.0}, ignore_seed=True)
+    assert "seed" not in chat_lm.default_gen_kwargs
+    assert chat_lm.default_gen_kwargs["temperature"] == 0.0
+
+
+@pytest.mark.skipif(not is_openai_enabled(), reason="OpenAI is not installed")
+def test_if_ignore_seed_after_set_random_seed() -> None:
+    chat_lm = LiteLLMChatAPI(MODEL_NAME, ignore_seed=True)
+    chat_lm.set_random_seed(42)
+    chat_messages = [{"role": "user", "content": "Hello"}]
+    with patch.object(OpenAIChatAPI, "_batch_generate_chat_response", return_value=[LMOutput("Hello!")]) as mock_method:
+        chat_lm.generate_chat_response(chat_messages, temperature=0.7)
+        # `seed` should not be passed even though set_random_seed() was called
+        mock_method.assert_called_once_with([chat_messages], [None], temperature=0.7)


### PR DESCRIPTION
## 問題

`LiteLLMChatAPI` の `ignore_seed` オプションは docstring で「default_gen_kwargs に指定された seed を無視する」と明言していますが、実装は per-call の `kwargs` から seed を除去するだけで、以下の2経路が漏れていました。

1. `set_random_seed(seed)` が `ignore_seed` を無視して無条件に `default_gen_kwargs["seed"]` を書き込む
2. コンストラクタの `default_gen_kwargs` に最初から `"seed"` が入っている場合も除去されない

flexeval の標準評価経路（`eval_setups.py`）は必ず `language_model.set_random_seed()` を呼ぶため、seed 非対応プロバイダ（docstring が名指しする anthropic/claude など）では `ignore_seed=True` を指定していても全 API コールがエラーになります。リトライ枯渇後は `EMPTY_RESPONSE` にフォールバックするため、**全出力が空文字列のまま評価が「成功」してしまう**危険がありました。

## 修正内容

- `set_random_seed()` を `ignore_seed=True` のとき no-op に変更
- `__init__` で `ignore_seed=True` のとき `default_gen_kwargs` から `"seed"` を除去
- 既存の per-call kwargs からの除去処理はそのまま維持

## テスト

以下の3テストを追加しました（既存の `test_if_ignore_seed` と同じ mock パターン）。

- `ignore_seed=True` のとき `set_random_seed(42)` が no-op であること
- コンストラクタの `default_gen_kwargs` の seed が除去されること
- `set_random_seed()` 呼び出し後の `generate_chat_response()` で seed が API に渡らないこと

```
6 passed（seed 関連テスト全件）、ruff check / format パス
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)