### PR TITLE
XERのinstance_detailsのWERがトークナイザ未適用で計算される問題を修正

### DIFF
--- a/flexeval/core/metric/xer.py
+++ b/flexeval/core/metric/xer.py
@@ -66,8 +66,10 @@ class XER(Metric):
             instance_details=[
                 {
                     "cer_score": cer(reference, lm_output),
-                    "wer_score": wer(reference, lm_output),
+                    "wer_score": wer(tokenized_reference, tokenized_lm_output),
                 }
-                for lm_output, reference in zip(lm_outputs, references)
+                for lm_output, reference, tokenized_lm_output, tokenized_reference in zip(
+                    lm_outputs, references, tokenized_lm_outputs, tokenized_references
+                )
             ],
         )

--- a/tests/core/metric/test_xer.py
+++ b/tests/core/metric/test_xer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from flexeval.core.metric import XER
-from flexeval.core.tokenizer import WhitespaceTokenizer
+from flexeval.core.tokenizer import SacreBleuTokenizer, WhitespaceTokenizer
 
 
 @pytest.mark.parametrize(
@@ -29,3 +29,40 @@ def test_rouge(lm_outputs: list[str], expected_outputs: list[list[str]], cer_sco
     assert key in metric_result.summary
     assert isinstance(metric_result.summary[key], float)
     assert metric_result.summary[key] == pytest.approx(wer_score, abs=0.05)
+
+
+@pytest.mark.parametrize(
+    ("lm_outputs", "expected_outputs"),
+    [
+        (["これは テスト"], [["これは テスト"]]),
+        (["こんにちは 世界"], [["こんばんわ 地方"]]),
+    ],
+    indirect=["lm_outputs"],
+)
+def test_instance_wer_score_matches_summary_with_tokenizer(
+    lm_outputs: list[str], expected_outputs: list[list[str]]
+) -> None:
+    # With a single instance, the summary wer_score (computed over tokenized text) must equal
+    # instance_details[0]["wer_score"], since the corpus-level WER over one pair is the same
+    # ratio as the instance-level WER for that pair.
+    xer = XER(tokenizer=WhitespaceTokenizer())
+    metric_result = xer.evaluate(lm_outputs=lm_outputs, references_list=expected_outputs)
+
+    assert metric_result.instance_details[0]["wer_score"] == pytest.approx(metric_result.summary["wer_score"])
+
+
+def test_instance_wer_score_for_unsegmented_language() -> None:
+    # Japanese has no whitespace between words, so wer() on the raw, untokenized text treats
+    # each entire sentence as a single "word": any mismatch forces the instance-level wer_score
+    # to exactly 1.0, regardless of how similar the sentences actually are.
+    # "今日は晴天です" and "今日は雨天です" tokenize (via MeCab) to 4 tokens each, differing only in
+    # one token ("晴天"/"雨天"), so the correct token-level WER is 1/4 = 0.25 -- neither 0.0 nor 1.0.
+    lm_outputs = ["今日は晴天です"]
+    expected_outputs = [["今日は雨天です"]]
+
+    xer = XER(tokenizer=SacreBleuTokenizer(name="ja-mecab"))
+    metric_result = xer.evaluate(lm_outputs=lm_outputs, references_list=expected_outputs)
+
+    instance_wer_score = metric_result.instance_details[0]["wer_score"]
+    assert instance_wer_score == pytest.approx(metric_result.summary["wer_score"])
+    assert instance_wer_score == pytest.approx(0.25)


### PR DESCRIPTION
## 問題

`XER` メトリクスで tokenizer を指定した場合、summary の `wer_score` はトークナイズ済みテキストで計算される一方、`instance_details` の `wer_score` は生の `reference` / `lm_output` で計算されていました。

日本語のようにスペースで単語が区切られない言語では、jiwer のデフォルト分割により文全体が1単語として扱われるため、インスタンス単位の WER が「完全一致なら 0.0、少しでも違えば 1.0」というデタラメな値になり、summary と矛盾していました。

## 修正内容

`instance_details` の `wer_score` を summary と同じトークナイズ済みテキスト（`tokenized_references` / `tokenized_lm_outputs`）で計算するように修正しました。

- `cer_score` は文字単位の計算でトークナイズ不要のため、summary 側と同様に生文字列のまま維持（挙動変更なし）
- tokenizer 未指定時はトークナイズ済みリスト＝生リストなので挙動変更なし（docstring の doctest も影響なし）

## テスト

- `WhitespaceTokenizer` 指定時に単一インスタンスの `instance_details[0]["wer_score"]` が summary と一致することを検証
- 回帰テスト: 日本語文（`SacreBleuTokenizer(name="ja-mecab")`、4トークン中1トークン違い）で、修正前は 1.0 になっていた WER が正しく 0.25 になることを検証

```
9 passed（既存含む全件）、ruff check / format パス
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)