### PR TITLE
num_repeats実行時にfew-shot生成器のRNG状態が全リピートで共有される問題を修正

### DIFF
--- a/flexeval/core/few_shot_generator/balanced.py
+++ b/flexeval/core/few_shot_generator/balanced.py
@@ -29,6 +29,7 @@ class BalancedFewShotGenerator(FewShotGenerator):
 
         self.dataset = dataset
         self.num_shots = num_shots
+        self._seed = seed
         self._rnd = random.Random(seed)
 
         # Separate instances by label
@@ -62,6 +63,14 @@ class BalancedFewShotGenerator(FewShotGenerator):
         self._rnd.shuffle(sampled_indices)
 
         return [self.dataset[i] for i in sampled_indices]
+
+    def with_seed_increment(self, seed_increment: int) -> BalancedFewShotGenerator:
+        return BalancedFewShotGenerator(
+            dataset=self.dataset,
+            num_shots=self.num_shots,
+            seed=self._seed + seed_increment,
+            num_trials_to_avoid_leak=self._num_trials_to_avoid_leak,
+        )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(dataset={self.dataset}, num_shots={self.num_shots})"

--- a/flexeval/core/few_shot_generator/base.py
+++ b/flexeval/core/few_shot_generator/base.py
@@ -23,6 +23,26 @@ class FewShotGenerator(ABC):
         """
         raise NotImplementedError
 
+    def with_seed_increment(self, seed_increment: int) -> FewShotGenerator:
+        """
+        Return a new `FewShotGenerator` instance to be used for a repeated evaluation run.
+
+        The default implementation simply returns `self`, which is appropriate for
+        generators that do not hold any sampling state (e.g., no internal RNG).
+        Subclasses that hold a stateful RNG (e.g., `self._rnd = random.Random(seed)`)
+        should override this method to return a new instance constructed with
+        `seed + seed_increment`, so that each repeat's few-shot examples are
+        reproducible from the seed alone, independent of how many times the
+        original instance has already been sampled from.
+
+        Args:
+            seed_increment: The value to add to the original seed for the new instance.
+
+        Returns:
+            A `FewShotGenerator` instance to use for the repeated run.
+        """
+        return self
+
     def __call__(self, eval_inputs: list[dict[str, Any]] | dict[str, Any] | None = None) -> list[Instance]:
         """
         Sample instances for few-shot learning.

--- a/flexeval/core/few_shot_generator/rand.py
+++ b/flexeval/core/few_shot_generator/rand.py
@@ -25,11 +25,20 @@ class RandomFewShotGenerator(FewShotGenerator):
 
         self.dataset = dataset
         self.num_shots = num_shots
+        self._seed = seed
         self._rnd = random.Random(seed)
 
     def _sample_instances(self, eval_inputs: list[dict[str, Any]] | dict[str, Any] | None = None) -> list[Instance]:
         sampled_indices = self._rnd.sample(range(len(self.dataset)), self.num_shots)
         return [self.dataset[i] for i in sampled_indices]
+
+    def with_seed_increment(self, seed_increment: int) -> RandomFewShotGenerator:
+        return RandomFewShotGenerator(
+            dataset=self.dataset,
+            num_shots=self.num_shots,
+            seed=self._seed + seed_increment,
+            num_trials_to_avoid_leak=self._num_trials_to_avoid_leak,
+        )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(dataset={self.dataset}, num_shots={self.num_shots})"

--- a/flexeval/scripts/flexeval_lm.py
+++ b/flexeval/scripts/flexeval_lm.py
@@ -61,6 +61,23 @@ def maybe_replace_random_seed(
         new_eval_setup = dataclasses.replace(eval_setup, random_seed=new_random_seed)
         new_config_content = copy.deepcopy(config_content)
         new_config_content["init_args"]["random_seed"] = new_random_seed
+
+        # Replace the few-shot generator with a new instance derived from the seed increment,
+        # so that each repeat's few-shot examples are reproducible from the seed alone,
+        # instead of depending on the shared generator's prior sampling history.
+        few_shot_generator = getattr(eval_setup, "few_shot_generator", None)
+        if few_shot_generator is not None:
+            new_eval_setup = dataclasses.replace(
+                new_eval_setup,
+                few_shot_generator=few_shot_generator.with_seed_increment(seed_increment),
+            )
+
+            fsg_config = new_config_content["init_args"].get("few_shot_generator")
+            if isinstance(fsg_config, dict):
+                fsg_init_args = fsg_config.get("init_args")
+                if isinstance(fsg_init_args, dict) and "seed" in fsg_init_args:
+                    fsg_init_args["seed"] += seed_increment
+
         return new_eval_setup, new_config_content
     return eval_setup, config_content
 

--- a/tests/core/few_show_generator/test_balanced.py
+++ b/tests/core/few_show_generator/test_balanced.py
@@ -81,3 +81,39 @@ def test_if_few_show_sampler_avoids_leak() -> None:
     with pytest.raises(ValueError):  # noqa: PT012
         for _ in range(100):
             few_shot_generator(eval_inputs=eval_inputs)
+
+
+def test_with_seed_increment_returns_new_instance_with_shared_dataset() -> None:
+    dataset = DummyGenerationDataset()
+    few_shot_generator = BalancedFewShotGenerator(dataset=dataset, num_shots=2, seed=42)
+    new_few_shot_generator = few_shot_generator.with_seed_increment(1)
+
+    assert new_few_shot_generator is not few_shot_generator
+    assert isinstance(new_few_shot_generator, BalancedFewShotGenerator)
+    assert new_few_shot_generator.dataset is dataset
+
+
+def test_with_seed_increment_is_reproducible_from_seed_alone() -> None:
+    dataset = DummyGenerationDataset()
+    few_shot_generator = BalancedFewShotGenerator(dataset=dataset, num_shots=2, seed=42)
+    new_few_shot_generator = few_shot_generator.with_seed_increment(1)
+
+    directly_constructed = BalancedFewShotGenerator(dataset=dataset, num_shots=2, seed=43)
+
+    assert new_few_shot_generator() == directly_constructed()
+
+
+def test_with_seed_increment_is_independent_of_prior_sampling() -> None:
+    # Regression test for the bug where a shared, stateful generator's output
+    # for a given repeat depended on how many times it had already been sampled
+    # (i.e., execution order), rather than being determined by the seed alone.
+    dataset = DummyGenerationDataset()
+    few_shot_generator = BalancedFewShotGenerator(dataset=dataset, num_shots=2, seed=42)
+    # Consume some samples from the original generator before deriving a new one.
+    for _ in range(5):
+        few_shot_generator()
+    new_few_shot_generator = few_shot_generator.with_seed_increment(1)
+
+    directly_constructed = BalancedFewShotGenerator(dataset=dataset, num_shots=2, seed=43)
+
+    assert new_few_shot_generator() == directly_constructed()

--- a/tests/core/few_show_generator/test_rand.py
+++ b/tests/core/few_show_generator/test_rand.py
@@ -90,3 +90,60 @@ def test_if_few_show_sampler_avoids_leak(dataset: Dataset) -> None:
     with pytest.raises(ValueError):  # noqa: PT012
         for _ in range(100):
             few_shot_generator(eval_inputs=eval_inputs)
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    [
+        DummyMultipleChoiceDataset(),
+        DummyGenerationDataset(),
+        DummyChatDataset(),
+    ],
+)
+def test_with_seed_increment_returns_new_instance_with_shared_dataset(dataset: Dataset) -> None:
+    few_shot_generator = RandomFewShotGenerator(dataset=dataset, num_shots=2, seed=42)
+    new_few_shot_generator = few_shot_generator.with_seed_increment(1)
+
+    assert new_few_shot_generator is not few_shot_generator
+    assert isinstance(new_few_shot_generator, RandomFewShotGenerator)
+    assert new_few_shot_generator.dataset is dataset
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    [
+        DummyMultipleChoiceDataset(),
+        DummyGenerationDataset(),
+        DummyChatDataset(),
+    ],
+)
+def test_with_seed_increment_is_reproducible_from_seed_alone(dataset: Dataset) -> None:
+    few_shot_generator = RandomFewShotGenerator(dataset=dataset, num_shots=2, seed=42)
+    new_few_shot_generator = few_shot_generator.with_seed_increment(1)
+
+    directly_constructed = RandomFewShotGenerator(dataset=dataset, num_shots=2, seed=43)
+
+    assert new_few_shot_generator() == directly_constructed()
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    [
+        DummyMultipleChoiceDataset(),
+        DummyGenerationDataset(),
+        DummyChatDataset(),
+    ],
+)
+def test_with_seed_increment_is_independent_of_prior_sampling(dataset: Dataset) -> None:
+    # Regression test for the bug where a shared, stateful generator's output
+    # for a given repeat depended on how many times it had already been sampled
+    # (i.e., execution order), rather than being determined by the seed alone.
+    few_shot_generator = RandomFewShotGenerator(dataset=dataset, num_shots=2, seed=42)
+    # Consume some samples from the original generator before deriving a new one.
+    for _ in range(5):
+        few_shot_generator()
+    new_few_shot_generator = few_shot_generator.with_seed_increment(1)
+
+    directly_constructed = RandomFewShotGenerator(dataset=dataset, num_shots=2, seed=43)
+
+    assert new_few_shot_generator() == directly_constructed()

--- a/tests/scripts/test_flexeval_lm.py
+++ b/tests/scripts/test_flexeval_lm.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 
-from flexeval import Generation, Perplexity
+from flexeval import Generation, Perplexity, RandomFewShotGenerator
 from flexeval.core.result_recorder.local_recorder import CONFIG_FILE_NAME, METRIC_FILE_NAME, OUTPUTS_FILE_NAME
 from flexeval.scripts.flexeval_lm import generate_eval_entries, maybe_replace_random_seed
 from tests.dummy_modules import DummyGenerationDataset, DummyTextDataset
@@ -399,6 +399,142 @@ def test_maybe_replace_random_seed() -> None:
     )
     assert id(new_perplexity_config) == id(perplexity_config)
     assert id(new_perplexity_eval_setup) == id(perplexity_eval_setup)
+
+
+def test_maybe_replace_random_seed_replaces_few_shot_generator_with_new_instance() -> None:
+    dataset = DummyGenerationDataset()
+    few_shot_generator = RandomFewShotGenerator(dataset=dataset, num_shots=1, seed=42)
+    generation_eval_setup = Generation(
+        eval_dataset=dataset,
+        gen_kwargs={},
+        prompt_template="dummy",
+        few_shot_generator=few_shot_generator,
+        random_seed=42,
+    )
+    generation_config = {
+        "init_args": {
+            "random_seed": 42,
+            "few_shot_generator": {
+                "class_path": "flexeval.RandomFewShotGenerator",
+                "init_args": {"dataset": "dummy", "num_shots": 1, "seed": 42, "num_trials_to_avoid_leak": 3},
+            },
+        },
+    }
+
+    new_eval_setup, new_config = maybe_replace_random_seed(generation_eval_setup, generation_config, seed_increment=1)
+
+    # a new, distinct few_shot_generator instance is used, but the dataset is shared (not deep-copied)
+    assert new_eval_setup.few_shot_generator is not few_shot_generator
+    assert new_eval_setup.few_shot_generator.dataset is dataset
+
+    # the derived generator's samples are reproducible from seed alone,
+    # matching an independently constructed generator with the incremented seed
+    directly_constructed = RandomFewShotGenerator(dataset=dataset, num_shots=1, seed=43)
+    assert new_eval_setup.few_shot_generator() == directly_constructed()
+
+    # the config's few_shot_generator seed is incremented too, for reproducibility
+    assert new_config["init_args"]["few_shot_generator"]["init_args"]["seed"] == 43
+    # the original config is untouched
+    assert generation_config["init_args"]["few_shot_generator"]["init_args"]["seed"] == 42
+
+
+def test_maybe_replace_random_seed_without_few_shot_generator_seed_key_in_config_is_defensive() -> None:
+    # if the config's few_shot_generator init_args has no "seed" key, nothing should be touched there
+    dataset = DummyGenerationDataset()
+    few_shot_generator = RandomFewShotGenerator(dataset=dataset, num_shots=1, seed=42)
+    generation_eval_setup = Generation(
+        eval_dataset=dataset,
+        gen_kwargs={},
+        prompt_template="dummy",
+        few_shot_generator=few_shot_generator,
+        random_seed=42,
+    )
+    generation_config = {
+        "init_args": {
+            "random_seed": 42,
+            "few_shot_generator": {
+                "class_path": "flexeval.RandomFewShotGenerator",
+                "init_args": {"dataset": "dummy", "num_shots": 1, "num_trials_to_avoid_leak": 3},
+            },
+        },
+    }
+
+    new_eval_setup, new_config = maybe_replace_random_seed(generation_eval_setup, generation_config, seed_increment=1)
+
+    assert new_eval_setup.few_shot_generator is not few_shot_generator
+    assert "seed" not in new_config["init_args"]["few_shot_generator"]["init_args"]
+
+
+def test_maybe_replace_random_seed_with_none_few_shot_generator_does_not_error() -> None:
+    dataset = DummyGenerationDataset()
+    generation_eval_setup = Generation(
+        eval_dataset=dataset,
+        gen_kwargs={},
+        prompt_template="dummy",
+        few_shot_generator=None,
+        random_seed=42,
+    )
+    generation_config = {"init_args": {"random_seed": 42}}
+
+    new_eval_setup, new_config = maybe_replace_random_seed(generation_eval_setup, generation_config, seed_increment=1)
+
+    assert new_eval_setup.few_shot_generator is None
+    assert new_eval_setup.random_seed == 43
+    assert new_config["init_args"]["random_seed"] == 43
+
+
+def test_generate_eval_entries_gives_each_repeat_a_distinct_few_shot_generator() -> None:
+    dataset = DummyGenerationDataset()
+    few_shot_generator = RandomFewShotGenerator(dataset=dataset, num_shots=1, seed=42)
+    generation_eval_setup = Generation(
+        eval_dataset=dataset,
+        gen_kwargs={},
+        prompt_template="dummy",
+        few_shot_generator=few_shot_generator,
+        random_seed=42,
+    )
+    generation_config = {
+        "init_args": {
+            "random_seed": 42,
+            "few_shot_generator": {
+                "class_path": "flexeval.RandomFewShotGenerator",
+                "init_args": {"dataset": "dummy", "num_shots": 1, "seed": 42, "num_trials_to_avoid_leak": 3},
+            },
+        },
+    }
+
+    entries = generate_eval_entries(
+        eval_setup=generation_eval_setup,
+        config_content=generation_config,
+        group="test_group",
+        num_repeats=3,
+    )
+
+    generators = [entry[0].few_shot_generator for entry in entries]
+    # all generators must be distinct objects from each other and from the original
+    assert len({id(g) for g in generators}) == len(generators)
+    assert few_shot_generator not in generators
+
+    # run0 (seed_increment=0) must be reproducible from the original seed alone,
+    # regardless of the fact that it's derived via with_seed_increment(0)
+    directly_constructed = RandomFewShotGenerator(dataset=dataset, num_shots=1, seed=42)
+    assert generators[0]() == directly_constructed()
+
+
+def test_generate_eval_entries_with_perplexity_setup_does_not_error() -> None:
+    # Perplexity has neither `random_seed` nor `few_shot_generator`
+    perplexity_eval_setup = Perplexity(eval_dataset=DummyTextDataset())
+    perplexity_config = {"init_args": {}}
+
+    entries = generate_eval_entries(
+        eval_setup=perplexity_eval_setup,
+        config_content=perplexity_config,
+        group="test_group",
+        num_repeats=3,
+    )
+    assert len(entries) == 3
+    for entry in entries:
+        assert entry[0] is perplexity_eval_setup
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 問題

`flexeval_lm --num_repeats N` 実行時、`maybe_replace_random_seed`（`flexeval/scripts/flexeval_lm.py`）は `dataclasses.replace` の浅いコピーで `random_seed` のみを差し替えるため、`few_shot_generator` は全リピートで**同一オブジェクト**を共有していました。

`RandomFewShotGenerator` / `BalancedFewShotGenerator` は永続的な `random.Random(seed)` を内部に持つため、次の問題が生じます。

- 各リピートの few-shot 例が、シードではなく**実行順序**（それまでに同じ生成器から何回サンプリングしたか）に依存する
- クラッシュ後などに特定のリピートだけ再実行すると、一括実行時と異なる few-shot 文脈（＝異なるスコア）になり、再現性が壊れる

なお `eval_setup.random_seed` は `language_model.set_random_seed()` にのみ流れており、few-shot 生成器の `seed` とは元々独立です。

## 修正内容

「リピート毎に異なる few-shot 例」という現状の観測挙動を保ちつつ、シードのみから再現可能にしました。

- `FewShotGenerator` に `with_seed_increment(seed_increment)` を追加（デフォルトは `return self` で、`FixedFewShotGenerator` のような無状態の生成器はそのまま）
- `RandomFewShotGenerator` / `BalancedFewShotGenerator` でオーバーライドし、`seed + seed_increment` で構築した新インスタンスを返す（`dataset` は参照共有で deepcopy しない）
- `maybe_replace_random_seed` でリピート毎に生成器を差し替え、保存される config の `few_shot_generator.init_args.seed` も同様に increment（`run1/config.json` から単体再実行しても同じ few-shot 例が再現される）

run0 は increment=0 なので、`--num_repeats 1` の実行と few-shot 例が一致します。LM 側の `random_seed + index` と同じ意味論です。

## テスト

テストファーストで実施し、修正前のコードで回帰テストが fail することを確認済みです（例: 3リピートの生成器の distinct id 数が `assert 1 == 3` で fail ＝全リピートが同一オブジェクトを共有）。

- `with_seed_increment` の単体テスト（新インスタンス・dataset 参照共有・シードのみからの再現性・**事前サンプリング回数に非依存**であることの回帰テスト）を rand / balanced 両方に追加
- `maybe_replace_random_seed` / `generate_eval_entries` のテスト（リピート毎に別インスタンス、config の seed increment、config に seed キーが無い場合の防御動作、`few_shot_generator=None` や Perplexity setup で無害であること）を追加
- `tests/core/few_show_generator/` + `tests/scripts/test_flexeval_lm.py`: 81 passed
- `ruff check` / `ruff format --check`: パス

## 影響範囲

- `--num_repeats >= 2` かつ few-shot 生成器（Random / Balanced）を使う評価のみ。run0 以外の各リピートの few-shot 例が変わります（従来は実行順序依存の非再現な値だったため、シード決定的な値への変化は正しい方向の変化です）
- `--num_repeats 1`（デフォルト）の結果は一切変わりません

🤖 Generated with [Claude Code](https://claude.com/claude-code)