### PR TITLE
評価結果の正確性に関する問題を修正

### DIFF
--- a/docs/how_to/evaluate_with_llm_judges.md
+++ b/docs/how_to/evaluate_with_llm_judges.md
@@ -31,6 +31,9 @@ flexeval_presets assistant_eval_en_single_turn
 In this metric, GPT4 is asked to rate the responses with the score from 1 to 10.
 The score is extracted as the last digit found in the evaluator's output.
 
+For multi-turn data such as `mt-en`, this single-turn metric evaluates only the final response, using the last user
+message and the corresponding last reference. It does not average scores over every turn in the conversation.
+
 !!! tip
     To take a closer look at the prompt template, combine pipeline with `jsonnet` and `jq`:
 
@@ -79,6 +82,9 @@ Sometimes, evaluating chat models individually cannot capture a subtle differenc
 In such cases, pairwise evaluation is useful.
 
 The overview of process is generating the responses using `flexeval_lm` and evaluating them with `flexeval_pairwise`.
+
+The `assistant_judge_en_single_turn` preset compares the final response of each conversation. For multi-turn data,
+it does not produce a separate comparison for each turn.
 
 In this example, we will compare the responses from GPT3.5 and GPT-4o.
 

--- a/flexeval/core/chat_dataset/chatbot_bench.py
+++ b/flexeval/core/chat_dataset/chatbot_bench.py
@@ -106,9 +106,13 @@ class ChatbotBench(ChatDataset):
         category = self._id_to_category[i]
         references: list[str] = []
         if category in self.need_ref_categories:
-            references = self._references_dict.get(question_id, [])
+            references_for_turns = self._references_dict.get(question_id, [])
+            num_user_messages = sum(message["role"] == "user" for message in self._messages_dict[question_id])
+            reference_index = num_user_messages - 1
+            if 0 <= reference_index < len(references_for_turns):
+                references = [references_for_turns[reference_index]]
         return ChatInstance(
-            self._messages_dict[question_id],
+            list(self._messages_dict[question_id]),
             tools=self._tools_dict[question_id],
             references=references,
             extra_info={"category": category},

--- a/flexeval/core/evaluate_chat_response.py
+++ b/flexeval/core/evaluate_chat_response.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
@@ -158,7 +159,9 @@ def evaluate_chat_response(  # noqa: C901, PLR0912
     logger.info(f"Evaluate the model with gen_kwargs: {gen_kwargs}")
 
     max_instances = len(eval_dataset) if max_instances is None else min(max_instances, len(eval_dataset))
-    eval_instances: list[ChatInstance] = [eval_dataset[i] for i in range(max_instances)]
+    eval_instances: list[ChatInstance] = [
+        copy.deepcopy(eval_dataset[i]) if few_shot_generator else eval_dataset[i] for i in range(max_instances)
+    ]
 
     if few_shot_generator:
         for eval_instance in eval_instances:

--- a/flexeval/core/evaluate_pairwise.py
+++ b/flexeval/core/evaluate_pairwise.py
@@ -19,6 +19,45 @@ from .pairwise_comparison import (
 from .utils.data_util import batch_iter
 
 
+def _get_item_identity(item: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract model-independent fields used to align outputs from different models."""
+    identity: dict[str, Any] = {}
+    if "references" in item:
+        identity["references"] = item["references"]
+
+    extra_info = item.get("extra_info", item.get("task_inputs"))
+    if isinstance(extra_info, dict):
+        messages = extra_info.get("messages")
+        if isinstance(messages, list):
+            identity["messages"] = [message for message in messages if message.get("role") != "assistant"]
+            other_extra_info = {key: value for key, value in extra_info.items() if key != "messages"}
+            if other_extra_info:
+                identity["extra_info"] = other_extra_info
+        else:
+            identity["extra_info"] = extra_info
+
+    return identity or None
+
+
+def _validate_model_item_alignment(model_items: dict[str, list[dict[str, Any]]]) -> None:
+    model_names = sorted(model_items)
+    if len(model_names) < 2:
+        msg = "Pairwise evaluation requires outputs from at least two models."
+        raise ValueError(msg)
+
+    reference_model = model_names[0]
+    for index in range(len(model_items[reference_model])):
+        reference_identity = _get_item_identity(model_items[reference_model][index])
+        for model_name in model_names[1:]:
+            model_identity = _get_item_identity(model_items[model_name][index])
+            if model_identity != reference_identity:
+                msg = (
+                    f"Model outputs are not aligned at index {index}: "
+                    f"{reference_model!r} and {model_name!r} have different inputs or references."
+                )
+                raise ValueError(msg)
+
+
 def evaluate_pairwise(
     model_items: dict[str, list[dict[str, Any]]],
     judge: PairwiseJudge,
@@ -33,6 +72,7 @@ def evaluate_pairwise(
     if len({len(items) for items in model_items.values()}) != 1:
         msg = "The number of items in the model outputs should be the same."
         raise ValueError(msg)
+    _validate_model_item_alignment(model_items)
 
     # Separate matches: in cache vs. not in cache and perform judge on the latter.
     judged_matches: list[tuple[int, Match]] = []  # Store indices to restore original order.
@@ -66,11 +106,16 @@ def evaluate_pairwise(
 
     match_info_list: list[dict[str, Any]] = [asdict(match) for _, match in sorted(judged_matches)]
 
-    model_scores_dict: dict[str, dict[str, float]] = {
-        scorer.get_name(): scorer.compute_scores(
-            [(i["model1"], i["model2"], i["winner"]) for i in match_info_list],
-        )
-        for scorer in scorers
-    }
+    match_results = [(i["model1"], i["model2"], i["winner"]) for i in match_info_list]
+    model_scores_dict: dict[str, dict[str, float]] = {}
+    for scorer in scorers:
+        scorer_name = scorer.get_name()
+        try:
+            model_scores_dict[scorer_name] = scorer.compute_scores(match_results)
+        except Exception:  # noqa: BLE001 - one scorer must not discard completed judge results
+            logger.opt(exception=True).warning(
+                f"Failed to compute pairwise scores with {scorer_name!r}; "
+                "the scorer result will be omitted, but judged matches will still be returned."
+            )
     logger.info(model_scores_dict)
     return model_scores_dict, match_info_list

--- a/flexeval/core/metric/llm_geval_score.py
+++ b/flexeval/core/metric/llm_geval_score.py
@@ -114,20 +114,28 @@ def generate_evaluation_logprobs(
             evaluator_input_list,
             batch_size=batch_size,
         ):
+            expanded_inputs = [evaluator_input for evaluator_input in evaluator_inputs for _ in valid_labels]
+            expanded_labels = valid_labels * len(evaluator_inputs)
             if all(isinstance(elem, str) for elem in evaluator_inputs):
                 evaluator_logprobs = language_model.compute_log_probs(
-                    valid_labels * batch_size,  # for openai models, len(valid_labels) <= 20 due to constraint
-                    [evaluator_input for evaluator_input in evaluator_inputs for _ in valid_labels],
+                    expanded_labels,  # for openai models, len(valid_labels) <= 20 due to constraint
+                    expanded_inputs,
                     # we have to provide len(valid_labels) same inputs for generate logprob
                 )
             else:
                 evaluator_logprobs = language_model.compute_chat_log_probs(
-                    [evaluator_input for evaluator_input in evaluator_inputs for _ in valid_labels],
-                    [{"role": "assistant", "content": label} for _ in valid_labels for label in valid_labels],
+                    expanded_inputs,
+                    [{"role": "assistant", "content": label} for label in expanded_labels],
                 )
+            if len(evaluator_logprobs) != len(expanded_inputs):
+                msg = (
+                    "The language model returned an unexpected number of log probabilities: "
+                    f"expected {len(expanded_inputs)}, got {len(evaluator_logprobs)}."
+                )
+                raise ValueError(msg)
             for evaluator_logprobs_for_single in batch_iter(evaluator_logprobs, batch_size=len(valid_labels)):
                 evaluator_logprobs_list += [dict(zip(valid_labels, evaluator_logprobs_for_single))]
-            pbar.update(batch_size)
+            pbar.update(len(evaluator_inputs))
     return evaluator_logprobs_list
 
 

--- a/flexeval/core/pairwise_comparison/scorer/bradley_terry.py
+++ b/flexeval/core/pairwise_comparison/scorer/bradley_terry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 
 import numpy as np
@@ -18,14 +19,19 @@ class BradleyTerryScorer(PairwiseScorer):
         self,
         max_iters: int = 1000,
         error_tol: float = 1e-3,
-        eps: float = 1e-8,
+        eps: float | None = None,
         base: float = 10.0,
         scale: float = 400.0,
         init_rating: float = 1000.0,
     ) -> None:
         self.max_iters = max_iters
         self.error_tol = error_tol
-        self.eps = eps
+        if eps is not None:
+            warnings.warn(
+                "The 'eps' argument is deprecated and ignored; it will be removed in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         self.base = base
         self.scale = scale
         self.init_rating = init_rating
@@ -48,6 +54,39 @@ class BradleyTerryScorer(PairwiseScorer):
 
         return matrix
 
+    @staticmethod
+    def _validate_strong_connectivity(
+        model_names: list[str],
+        winloss_matrix: dict[str, dict[str, float]],
+    ) -> None:
+        """Validate that the directed win graph has a finite Bradley-Terry MLE."""
+        if len(model_names) < 2:
+            msg = "Bradley-Terry scoring requires results for at least two models."
+            raise ValueError(msg)
+
+        def reachable(start: str, reverse: bool = False) -> set[str]:
+            visited: set[str] = set()
+            stack = [start]
+            while stack:
+                model = stack.pop()
+                if model in visited:
+                    continue
+                visited.add(model)
+                for other_model in model_names:
+                    weight = winloss_matrix[other_model][model] if reverse else winloss_matrix[model][other_model]
+                    if weight > 0 and other_model not in visited:
+                        stack.append(other_model)
+            return visited
+
+        start = model_names[0]
+        if len(reachable(start)) != len(model_names) or len(reachable(start, reverse=True)) != len(model_names):
+            msg = (
+                "Bradley-Terry maximum-likelihood scores are not finite because the directed win graph is not "
+                "strongly connected. Add comparisons that connect the graph in both directions or use a "
+                "regularized scorer."
+            )
+            raise ValueError(msg)
+
     def compute_scores(
         self,
         match_results: list[tuple[str, str, Winner]],
@@ -57,29 +96,43 @@ class BradleyTerryScorer(PairwiseScorer):
             {m[0] for m in match_results} | {m[1] for m in match_results},
         )
         winloss_matrix = self._gen_winloss_matrix(match_results)
+        self._validate_strong_connectivity(model_names, winloss_matrix)
 
         # https://jmlr.org/papers/volume24/22-1086/22-1086.pdf#page=5.50 (12)
         scores = pd.Series(np.ones(len(model_names)), index=model_names)
         for iters in range(self.max_iters):
             old_scores = scores.copy()
             for target_model in scores.keys():  # noqa: SIM118
+                opponents = [
+                    other_model
+                    for other_model in model_names
+                    if other_model != target_model
+                    and (winloss_matrix[target_model][other_model] > 0 or winloss_matrix[other_model][target_model] > 0)
+                ]
                 numer = sum(
                     [
                         (winloss_matrix[target_model][other_model] * scores[other_model])
                         / (scores[target_model] + scores[other_model])
-                        for other_model in winloss_matrix[target_model]
+                        for other_model in opponents
                     ],
                 )
                 denom = sum(
                     [
                         (winloss_matrix[other_model][target_model]) / (scores[target_model] + scores[other_model])
-                        for other_model in winloss_matrix[target_model]
+                        for other_model in opponents
                     ],
                 )
 
-                scores[target_model] = numer / (denom + self.eps)
+                if numer <= 0 or denom <= 0:
+                    msg = "Bradley-Terry iteration reached a non-finite boundary despite a strongly connected graph."
+                    raise RuntimeError(msg)
+                scores[target_model] = numer / denom
 
-            scores /= np.exp(np.log(scores).sum()) ** (1 / len(scores))
+            scores /= np.exp(np.log(scores).mean())
+
+            if not np.isfinite(scores).all():
+                msg = "Bradley-Terry iteration produced non-finite scores."
+                raise RuntimeError(msg)
 
             if (scores - old_scores).abs().sum() < self.error_tol:
                 logger.info(f" * Converged after {iters} iterations.")

--- a/flexeval/preset_configs/Metric/assistant_eval_en_single_turn.jsonnet
+++ b/flexeval/preset_configs/Metric/assistant_eval_en_single_turn.jsonnet
@@ -13,6 +13,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
       class_path: 'Jinja2PromptTemplate',
       init_args: {
         template: std.stripChars(|||
+          {% set user_messages = messages | selectattr("role", "equalto", "user") | list -%}
           [Instruction]
           {% if references|length > 0 -%}
           Please act as an impartial judge and evaluate the quality of the response provided by an AI assistant to the user question displayed below. Your evaluation should consider correctness and helpfulness. You will be given a reference answer and the assistant's answer. Begin your evaluation by comparing the assistant's answer with the reference answer. Identify and correct any mistakes. Be as objective as possible. After providing your explanation, you must rate the response on a scale of 1 to 10 by strictly following this format: "[[rating]]", for example: "Rating: [[5]]".
@@ -21,7 +22,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
           {%- endif %}
 
           [Question]
-          {{ messages[0]["content"] }}
+          {{ user_messages[-1]["content"] }}
 
           {% if references|length > 0 -%}
           [The Start of Reference Answer]
@@ -29,7 +30,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
           [The End of Reference Answer]
           {% endif -%}
           [The Start of Assistant's Answer]
-          {% if messages|length == 1 %}{{ lm_output }}{% else %}{{ messages[1]["content"] }}{% endif %}
+          {{ lm_output }}
           [The End of Assistant's Answer]
         |||, '\n'),
       },

--- a/flexeval/preset_configs/Metric/assistant_eval_ja_single_turn.jsonnet
+++ b/flexeval/preset_configs/Metric/assistant_eval_ja_single_turn.jsonnet
@@ -13,6 +13,7 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
       class_path: 'Jinja2PromptTemplate',
       init_args: {
         template: std.stripChars(|||
+          {% set user_messages = messages | selectattr("role", "equalto", "user") | list -%}
           [指示]
           {% if references|length > 0 -%}
           以下に表示されるユーザの質問に対するアシスタントの応答の品質を評価してください。評価は正確さと有用性を考慮すべきです。アシスタントの回答の言語は、ユーザが使用している言語と一致しているべきで、そうでない場合は減点されるべきです。参照回答とアシスタントの回答が与えられます。あなたの評価は、アシスタントの回答と参照回答を比較することから始めてください。ミスを特定し、訂正してください。できるだけ客観的であること。評価の説明をした後、"[[rating]]"という形式で、1から10までの整数の評価値を出力してください（例 "rating：[[5]]"）。
@@ -21,7 +22,7 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
           {%- endif %}
 
           [ユーザの質問]
-          {{ messages[0]["content"] }}
+          {{ user_messages[-1]["content"] }}
 
           {% if references|length > 0 -%}
           [参考回答の開始]
@@ -29,7 +30,7 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
           [参考回答の終了]
           {% endif -%}
           [アシスタントの回答開始]
-          {% if messages|length == 1 %}{{ lm_output }}{% else %}{{ messages[1]["content"] }}{% endif %}
+          {{ lm_output }}
           [アシスタントの回答終了]
         |||, '\n'),
       },

--- a/flexeval/preset_configs/PairwiseJudge/assistant_judge_en_single_turn.jsonnet
+++ b/flexeval/preset_configs/PairwiseJudge/assistant_judge_en_single_turn.jsonnet
@@ -12,9 +12,9 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
       class_path: 'Jinja2PromptTemplate',
       init_args: {
         template: std.stripChars(|||
-          {% set question = model1_item["extra_info"]["messages"][0]["content"] -%}
           {% set model1_messages = model1_item["extra_info"]["messages"] -%}
           {% set model2_messages = model2_item["extra_info"]["messages"] -%}
+          {% set model1_user_messages = model1_messages | selectattr("role", "equalto", "user") | list -%}
           [Instruction]
           {% if references|length > 0 -%}
           Please act as an impartial judge and evaluate the quality of the responses provided by two AI assistants to the user question displayed below. Your evaluation should consider correctness and helpfulness. You will be given a reference answer, assistant A's answer, and assistant B's answer. Your job is to evaluate which assistant's answer is better. Begin your evaluation by comparing both assistants' answers with the reference answer. Identify and correct any mistakes. Avoid any position biases and ensure that the order in which the responses were presented does not influence your decision. Do not allow the length of the responses to influence your evaluation. Do not favor certain names of the assistants. Be as objective as possible. After providing your explanation, output your final verdict by strictly following this format: "[[1]]" if assistant 1 is better, "[[2]]" if assistant 2 is better, and "[[3]]" for a tie.
@@ -23,7 +23,7 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
           {%- endif %}
 
           [Question]
-          {{ question }}
+          {{ model1_user_messages[-1]["content"] }}
 
           {% if references|length > 0 -%}
           [The Start of Reference Answer]
@@ -31,10 +31,10 @@ Adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat/blob/main/fast
           [The End of Reference Answer]
           {% endif -%}
           [The Start of Assistant 1's Answer]
-          {% if model1_messages|length == 1 %}{{ model1_item["lm_output"] }}{% else %}{{ model1_messages[1]["content"] }}{% endif %}
+          {{ model1_item["lm_output"] }}
           [The End of Assistant's Answer]
           [The Start of Assistant 2's Answer]
-          {% if model2_messages|length == 1 %}{{ model2_item["lm_output"] }}{% else %}{{ model2_messages[1]["content"] }}{% endif %}
+          {{ model2_item["lm_output"] }}
           [The End of Assistant's Answer]
         |||, '\n'),
       },

--- a/flexeval/preset_configs/PairwiseJudge/assistant_judge_ja_single_turn.jsonnet
+++ b/flexeval/preset_configs/PairwiseJudge/assistant_judge_ja_single_turn.jsonnet
@@ -12,12 +12,12 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
       class_path: 'Jinja2PromptTemplate',
       init_args: {
         template: std.stripChars(|||
-          {% set question = model1_item["extra_info"]["messages"][0]["content"] -%}
           {% set model1_messages = model1_item["extra_info"]["messages"] -%}
           {% set model2_messages = model2_item["extra_info"]["messages"] -%}
+          {% set model1_user_messages = model1_messages | selectattr("role", "equalto", "user") | list -%}
 
           [ユーザの質問]
-          {{ question }}
+          {{ model1_user_messages[-1]["content"] }}
 
           {% if references|length > 0 -%}
           [参考回答の開始]
@@ -25,10 +25,10 @@ Translated and adapted from [lm-sys/FastChat](https://github.com/lm-sys/FastChat
           [参考回答の終了]
           {% endif -%}
           [アシスタント1の回答開始]
-          {% if model1_messages|length == 1 %}{{ model1_item["lm_output"] }}{% else %}{{ model1_messages[1]["content"] }}{% endif %}
+          {{ model1_item["lm_output"] }}
           [アシスタント1の回答終了]
           [アシスタント2の回答開始]
-          {% if model2_messages|length == 1 %}{{ model2_item["lm_output"] }}{% else %}{{ model2_messages[1]["content"] }}{% endif %}
+          {{ model2_item["lm_output"] }}
           [アシスタント2の回答終了]
         |||, '\n'),
       },

--- a/tests/core/chat_dataset/test_chatbot_bench.py
+++ b/tests/core/chat_dataset/test_chatbot_bench.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from flexeval.core.chat_dataset import ChatbotBench, ChatInstance
+from flexeval.core.chat_dataset.chatbot_bench import resolve_path_or_name
 
 
 @pytest.mark.parametrize(
@@ -35,3 +38,29 @@ def test_only_first_n() -> None:
     # mt-en (MT-Bench) should have multiple messages by default
     dataset = ChatbotBench(path_or_name="mt-en", load_only_first_n=1)
     assert all(len(instance.messages) == 1 for instance in dataset)
+
+
+def test_messages_list_is_not_shared_between_instances() -> None:
+    dataset = ChatbotBench(path_or_name="mt-en")
+    original_messages = list(dataset[0].messages)
+
+    dataset[0].messages.append({"role": "assistant", "content": "mutation"})
+
+    assert dataset[0].messages == original_messages
+
+
+def test_references_correspond_to_last_user_turn() -> None:
+    dataset = ChatbotBench(
+        path_or_name="mt-en",
+        ref_path_or_name="mt-en-ref-gpt4",
+        need_ref_categories=["writing", "roleplay", "reasoning", "math", "coding", "extraction", "stem", "humanities"],
+    )
+    with open(resolve_path_or_name("mt-en")) as f:
+        questions = [json.loads(line) for line in f]
+    with open(resolve_path_or_name("mt-en-ref-gpt4")) as f:
+        references_by_id = {item["question_id"]: item["choices"][0]["turns"] for item in map(json.loads, f)}
+
+    for instance, question in zip(dataset, questions):
+        references_for_turns = references_by_id.get(question["question_id"], [])
+        expected = [references_for_turns[len(question["turns"]) - 1]] if references_for_turns else []
+        assert instance.references == expected

--- a/tests/core/metric/test_llm_geval_score.py
+++ b/tests/core/metric/test_llm_geval_score.py
@@ -6,7 +6,12 @@ import pytest
 
 from flexeval import Jinja2PromptTemplate, LanguageModel
 from flexeval.core.language_model.base import LMOutput
-from flexeval.core.metric.llm_geval_score import ChatLLMGEvalScore, LLMGEvalScore, calculate_weighted_average
+from flexeval.core.metric.llm_geval_score import (
+    ChatLLMGEvalScore,
+    LLMGEvalScore,
+    calculate_weighted_average,
+    generate_evaluation_logprobs,
+)
 from flexeval.core.metric.utils import extract_text_from_outputs
 
 
@@ -43,6 +48,26 @@ class EchoBackLanguageModel(LanguageModel):
         )
 
 
+class StrictLengthLanguageModel(LanguageModel):
+    def compute_log_probs(
+        self,
+        text_list: list[str],
+        prefix_list: list[str] | None = None,
+        stride: int | None = None,
+    ) -> list[float]:
+        assert prefix_list is not None
+        assert len(text_list) == len(prefix_list)
+        return [float(text) for text in text_list]
+
+    def compute_chat_log_probs(
+        self,
+        prompt_list: list[list[dict[str, str]]],
+        response_list: list[dict[str, str]],
+    ) -> list[float]:
+        assert len(prompt_list) == len(response_list)
+        return [float(response["content"]) for response in response_list]
+
+
 @pytest.mark.parametrize(
     ("evaluator_logprobs", "valid_score_range", "prob_threshold", "expected_score"),
     [
@@ -61,6 +86,47 @@ def test_calculate_weighted_average(
 ) -> None:
     score, _ = calculate_weighted_average(evaluator_logprobs, valid_score_range, prob_threshold)
     assert score == expected_score
+
+
+@pytest.mark.parametrize("use_chat_inputs", [False, True])
+@pytest.mark.parametrize(("num_inputs", "batch_size"), [(3, 4), (6, 6)])
+def test_generate_evaluation_logprobs_uses_actual_batch_length(
+    use_chat_inputs: bool,
+    num_inputs: int,
+    batch_size: int,
+) -> None:
+    text_inputs = [f"input-{i}" for i in range(num_inputs)]
+    evaluator_inputs = [[{"role": "user", "content": text}] for text in text_inputs] if use_chat_inputs else text_inputs
+    valid_labels = ["1", "2", "3", "4", "5"]
+
+    results = generate_evaluation_logprobs(
+        evaluator_input_list=evaluator_inputs,
+        language_model=StrictLengthLanguageModel(),
+        valid_labels=valid_labels,
+        batch_size=batch_size,
+        disable_tqdm=True,
+    )
+
+    assert results == [{label: float(label) for label in valid_labels} for _ in range(num_inputs)]
+
+
+def test_generate_evaluation_logprobs_rejects_wrong_output_length() -> None:
+    class ShortOutputLanguageModel(StrictLengthLanguageModel):
+        def compute_log_probs(
+            self,
+            text_list: list[str],
+            prefix_list: list[str] | None = None,
+            stride: int | None = None,
+        ) -> list[float]:
+            return super().compute_log_probs(text_list, prefix_list, stride)[:-1]
+
+    with pytest.raises(ValueError, match="unexpected number of log probabilities"):
+        generate_evaluation_logprobs(
+            evaluator_input_list=["input"],
+            language_model=ShortOutputLanguageModel(),
+            valid_labels=["1", "2"],
+            disable_tqdm=True,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/core/pairwise_comparison/scorer/test_bradley_terry.py
+++ b/tests/core/pairwise_comparison/scorer/test_bradley_terry.py
@@ -1,5 +1,8 @@
 import math
 
+import numpy as np
+import pytest
+
 from flexeval.core.pairwise_comparison import BradleyTerryScorer
 from flexeval.core.pairwise_comparison.judge.base import Winner
 
@@ -34,3 +37,42 @@ def test_bradley_terry_scorer() -> None:
 
     model_scores = scorer.compute_scores(match_results)
     assert model_scores["モデルD"] > model_scores["モデルB"] > model_scores["モデルC"] > model_scores["モデルA"]
+
+
+@pytest.mark.parametrize(
+    "match_results",
+    [
+        [("A", "B", Winner.MODEL1)],
+        [
+            ("A", "B", Winner.MODEL1),
+            ("B", "C", Winner.MODEL1),
+            ("C", "A", Winner.MODEL2),
+            ("A", "D", Winner.MODEL1),
+            ("B", "D", Winner.MODEL1),
+            ("C", "D", Winner.MODEL1),
+        ],
+    ],
+)
+def test_bradley_terry_rejects_non_strongly_connected_results(
+    match_results: list[tuple[str, str, Winner]],
+) -> None:
+    with pytest.raises(ValueError, match="not strongly connected"):
+        BradleyTerryScorer().compute_scores(match_results)
+
+
+def test_bradley_terry_returns_finite_scores_for_strongly_connected_results() -> None:
+    match_results = [
+        ("A", "B", Winner.MODEL1),
+        ("B", "C", Winner.MODEL1),
+        ("C", "A", Winner.MODEL1),
+    ]
+
+    model_scores = BradleyTerryScorer().compute_scores(match_results)
+
+    assert set(model_scores) == {"A", "B", "C"}
+    assert all(np.isfinite(score) for score in model_scores.values())
+
+
+def test_bradley_terry_deprecates_eps_argument() -> None:
+    with pytest.warns(FutureWarning, match="deprecated and ignored"):
+        BradleyTerryScorer(eps=1e-8)

--- a/tests/core/test_evaluate_chat_response.py
+++ b/tests/core/test_evaluate_chat_response.py
@@ -11,7 +11,7 @@ from flexeval.core.evaluate_chat_response import (
     evaluate_chat_response,
     execute_conversation_flow,
 )
-from flexeval.core.few_shot_generator import RandomFewShotGenerator
+from flexeval.core.few_shot_generator import FixedFewShotGenerator, RandomFewShotGenerator
 from flexeval.core.metric import FinishReasonCount, ToolCallCount
 from flexeval.core.string_processor import StringProcessor
 from tests.dummy_modules import (
@@ -181,6 +181,41 @@ def test_add_few_shot_messages_to_chat_instance() -> None:
     # Original user message should still be present at the end
     assert chat_instance.messages[-1]["role"] == "user"
     assert chat_instance.messages[-1]["content"] == "Hello"
+
+
+def test_evaluate_chat_response_does_not_mutate_cached_instances_with_few_shot() -> None:
+    cached_instance = ChatInstance(messages=[{"role": "user", "content": "Hello"}], references=["Hi"])
+    eval_dataset = [cached_instance]
+    few_shot_generator = FixedFewShotGenerator(
+        instance_class="ChatInstance",
+        instance_params=[
+            {
+                "messages": [{"role": "user", "content": "Example question"}],
+                "references": ["Example answer"],
+            }
+        ],
+    )
+
+    first_metrics, first_outputs = evaluate_chat_response(
+        language_model=DummyLanguageModel(),
+        gen_kwargs={},
+        eval_dataset=eval_dataset,
+        few_shot_generator=few_shot_generator,
+        metrics=[FinishReasonCount()],
+        batch_size=1,
+    )
+    second_metrics, second_outputs = evaluate_chat_response(
+        language_model=DummyLanguageModel(),
+        gen_kwargs={},
+        eval_dataset=eval_dataset,
+        few_shot_generator=few_shot_generator,
+        metrics=[FinishReasonCount()],
+        batch_size=1,
+    )
+
+    assert cached_instance.messages == [{"role": "user", "content": "Hello"}]
+    assert first_metrics == second_metrics
+    assert first_outputs == second_outputs
 
 
 @pytest.mark.parametrize("batch_size", [1, 2])

--- a/tests/core/test_evaluate_functions.py
+++ b/tests/core/test_evaluate_functions.py
@@ -15,6 +15,7 @@ from flexeval.core.few_shot_generator import RandomFewShotGenerator
 from flexeval.core.language_model.base import LMOutput
 from flexeval.core.metric import ExactMatch, FinishReasonCount
 from flexeval.core.metric.base import Metric, MetricResult
+from flexeval.core.pairwise_comparison import PairwiseScorer, Winner, WinRateScorer
 from flexeval.core.prompt_template import Jinja2PromptTemplate
 from flexeval.core.reward_model.pairwise_judge_reward_model import PairwiseJudgeRewardModel
 from tests.dummy_modules import (
@@ -226,6 +227,93 @@ def test_evaluate_pairwise(cached_matches: list[Match] | None) -> None:
     assert len(match_info_list) == 2 * num_items
     if cached_matches:
         assert match_info_list[0]["rationale"] == "cache test"
+
+
+class FailingPairwiseScorer(PairwiseScorer):
+    name = "failing"
+
+    def compute_scores(self, match_results: list[tuple[str, str, Winner]]) -> dict[str, float]:
+        msg = "scoring failed"
+        raise ValueError(msg)
+
+
+def test_evaluate_pairwise_returns_matches_when_a_scorer_fails() -> None:
+    model_scores_dict, match_info_list = evaluate_pairwise(
+        model_items={
+            "model1": [{"lm_output": "answer1"}],
+            "model2": [{"lm_output": "answer2"}],
+        },
+        judge=DummyPairwiseJudge(),
+        scorers=[WinRateScorer(), FailingPairwiseScorer()],
+    )
+
+    assert set(model_scores_dict) == {"win_rate"}
+    assert len(match_info_list) == 2
+
+
+def test_evaluate_pairwise_rejects_misaligned_items() -> None:
+    with pytest.raises(ValueError, match="not aligned at index 0"):
+        evaluate_pairwise(
+            model_items={
+                "model1": [
+                    {"lm_output": "answer1", "references": ["ref1"], "extra_info": {"id": 1}},
+                    {"lm_output": "answer2", "references": ["ref2"], "extra_info": {"id": 2}},
+                ],
+                "model2": [
+                    {"lm_output": "answer2", "references": ["ref2"], "extra_info": {"id": 2}},
+                    {"lm_output": "answer1", "references": ["ref1"], "extra_info": {"id": 1}},
+                ],
+            },
+            judge=DummyPairwiseJudge(),
+        )
+
+
+def test_evaluate_pairwise_rejects_missing_identity_on_one_side() -> None:
+    with pytest.raises(ValueError, match="not aligned at index 0"):
+        evaluate_pairwise(
+            model_items={
+                "model1": [{"lm_output": "answer1", "references": ["reference"]}],
+                "model2": [{"lm_output": "answer2"}],
+            },
+            judge=DummyPairwiseJudge(),
+        )
+
+
+def test_evaluate_pairwise_allows_different_assistant_history() -> None:
+    model_scores_dict, match_info_list = evaluate_pairwise(
+        model_items={
+            "model1": [
+                {
+                    "lm_output": "final answer 1",
+                    "references": ["reference"],
+                    "extra_info": {
+                        "messages": [
+                            {"role": "user", "content": "question 1"},
+                            {"role": "assistant", "content": "model 1 answer"},
+                            {"role": "user", "content": "question 2"},
+                        ]
+                    },
+                }
+            ],
+            "model2": [
+                {
+                    "lm_output": "final answer 2",
+                    "references": ["reference"],
+                    "extra_info": {
+                        "messages": [
+                            {"role": "user", "content": "question 1"},
+                            {"role": "assistant", "content": "model 2 answer"},
+                            {"role": "user", "content": "question 2"},
+                        ]
+                    },
+                }
+            ],
+        },
+        judge=DummyPairwiseJudge(),
+    )
+
+    assert set(model_scores_dict) == {"win_rate", "bradley_terry"}
+    assert len(match_info_list) == 2
 
 
 def test_evaluate_reward_model() -> None:

--- a/tests/test_preset_configs.py
+++ b/tests/test_preset_configs.py
@@ -1,13 +1,16 @@
+import json
 import os
 from pathlib import Path
 from unittest.mock import patch
 
+import _jsonnet
 import datasets
 import pytest
 from pytest_mock import MockerFixture
 
 from flexeval.core.metric import Metric
 from flexeval.core.pairwise_comparison import PairwiseJudge
+from flexeval.core.utils.jinja2_utils import JINJA2_ENV
 from flexeval.scripts.flexeval_lm import EvalSetup
 from flexeval.utils import instantiate_from_config
 
@@ -69,3 +72,86 @@ def test_if_there_is_no_duplicates_in_preset_configs() -> None:
     for file in preset_config_files:
         assert file.name not in seen_file_names, f"{file.name} is duplicated."
         seen_file_names.add(file.name)
+
+
+def _load_prompt_template(config_path: str) -> str:
+    config = json.loads(_jsonnet.evaluate_file(config_path))
+    return config["init_args"]["prompt_template"]["init_args"]["template"]
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    [
+        "flexeval/preset_configs/Metric/assistant_eval_en_single_turn.jsonnet",
+        "flexeval/preset_configs/Metric/assistant_eval_ja_single_turn.jsonnet",
+    ],
+)
+def test_single_judge_preset_selects_final_turn(config_path: str) -> None:
+    template = JINJA2_ENV.from_string(_load_prompt_template(config_path))
+    output = template.render(
+        messages=[
+            {"role": "system", "content": "SYSTEM_SENTINEL"},
+            {"role": "user", "content": "FIRST_QUESTION_SENTINEL"},
+            {"role": "assistant", "content": "FIRST_ANSWER_SENTINEL"},
+            {"role": "user", "content": "FINAL_QUESTION_SENTINEL"},
+        ],
+        lm_output="FINAL_ANSWER_SENTINEL",
+        references=["FINAL_REFERENCE_SENTINEL"],
+    )
+
+    assert "FINAL_QUESTION_SENTINEL" in output
+    assert "FINAL_ANSWER_SENTINEL" in output
+    assert "FINAL_REFERENCE_SENTINEL" in output
+    assert "SYSTEM_SENTINEL" not in output
+    assert "FIRST_QUESTION_SENTINEL" not in output
+    assert "FIRST_ANSWER_SENTINEL" not in output
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    [
+        "flexeval/preset_configs/PairwiseJudge/assistant_judge_en_single_turn.jsonnet",
+        "flexeval/preset_configs/PairwiseJudge/assistant_judge_ja_single_turn.jsonnet",
+    ],
+)
+def test_pairwise_judge_preset_selects_final_turn(config_path: str) -> None:
+    template = JINJA2_ENV.from_string(_load_prompt_template(config_path))
+    messages = [
+        {"role": "system", "content": "SYSTEM_SENTINEL"},
+        {"role": "user", "content": "FIRST_QUESTION_SENTINEL"},
+        {"role": "assistant", "content": "FIRST_ANSWER_SENTINEL"},
+        {"role": "user", "content": "FINAL_QUESTION_SENTINEL"},
+    ]
+    output = template.render(
+        model1_item={"extra_info": {"messages": messages}, "lm_output": "MODEL1_FINAL_ANSWER_SENTINEL"},
+        model2_item={"extra_info": {"messages": messages}, "lm_output": "MODEL2_FINAL_ANSWER_SENTINEL"},
+        references=["FINAL_REFERENCE_SENTINEL"],
+    )
+
+    assert "FINAL_QUESTION_SENTINEL" in output
+    assert "MODEL1_FINAL_ANSWER_SENTINEL" in output
+    assert "MODEL2_FINAL_ANSWER_SENTINEL" in output
+    assert "FINAL_REFERENCE_SENTINEL" in output
+    assert "SYSTEM_SENTINEL" not in output
+    assert "FIRST_QUESTION_SENTINEL" not in output
+    assert "FIRST_ANSWER_SENTINEL" not in output
+
+
+def test_single_judge_preset_keeps_first_reference_for_single_turn() -> None:
+    template = JINJA2_ENV.from_string(
+        _load_prompt_template("flexeval/preset_configs/Metric/assistant_eval_en_single_turn.jsonnet")
+    )
+    output = template.render(
+        messages=[
+            {"role": "system", "content": "SYSTEM_SENTINEL"},
+            {"role": "user", "content": "QUESTION_SENTINEL"},
+        ],
+        lm_output="ANSWER_SENTINEL",
+        references=["PRIMARY_REFERENCE_SENTINEL", "ALTERNATIVE_REFERENCE_SENTINEL"],
+    )
+
+    assert "QUESTION_SENTINEL" in output
+    assert "ANSWER_SENTINEL" in output
+    assert "PRIMARY_REFERENCE_SENTINEL" in output
+    assert "ALTERNATIVE_REFERENCE_SENTINEL" not in output
+    assert "SYSTEM_SENTINEL" not in output


### PR DESCRIPTION
## 概要

評価結果の正確性や再現性に影響する5件の問題を修正します。単なるリファクタリングではなく、誤った応答を評価する、入力件数と出力件数がずれる、集計値がNaNになる、異なる問題同士を比較する、といった評価結果そのものに影響する不具合が対象です。

## 1. LLM Judgeプリセットが最終回答を評価していない

### 問題

単一ターン用のLLM Judgeプリセットが `messages[0]` / `messages[1]` を固定参照していました。

`evaluate_chat_response` が最終回答を除いた会話履歴を `extra_info` に渡すため、system prompt付きデータではsystem文が「質問」、最初のuser発話が「回答」として扱われます。また複数ターンのデータでは、実際の最終生成結果 `lm_output` が評価対象になりませんでした。

### 修正

- userロールのメッセージを抽出し、最後のuser発話を質問として使用
- 回答には常に実際の最終生成結果 `lm_output` を使用
- Pairwise Judgeでは各モデルの `lm_output` をそれぞれ使用
- ChatbotBenchのreferenceも、最後のuserターンに対応するものを選択
- 複数ターン入力では「最終回答のみを評価する」仕様をドキュメントに明記

### 主な対象

- `flexeval/preset_configs/Metric/assistant_eval_*_single_turn.jsonnet`
- `flexeval/preset_configs/PairwiseJudge/assistant_judge_*_single_turn.jsonnet`
- `flexeval/core/chat_dataset/chatbot_bench.py`
- `docs/how_to/evaluate_with_llm_judges.md`

### テスト

system prompt、過去のuser/assistantターン、最終ターンにそれぞれsentinel文字列を入れ、レンダリング結果に最終質問・最終回答だけが含まれることを確認しています。

## 2. G-Evalの入力件数とラベル展開数が一致しない

### 問題

G-Evalは、各入力について有効ラベルごとのlog probabilityを取得します。しかしtext版は実際の端数バッチではなく設定値 `batch_size` を使って入力を展開していました。chat版は入力件数を参照せず、ラベル数を基準に展開していました。

その結果、端数バッチや「バッチ件数 > ラベル数」の場合に件数不一致が発生し、バックエンドによっては `IndexError` でクラッシュします。緩いテストスタブでは `zip` によって余分な要素が切り捨てられ、問題が検出されませんでした。

### 修正

- 実際の `evaluator_inputs` 件数を基準に入力とラベルを展開
- 入力ごとに全ラベルを一巡する順序へ統一
- LMが返したlog probability件数が期待値と異なる場合は `ValueError`
- progress barを設定上のバッチサイズではなく実処理件数で更新

### 主な対象

- `flexeval/core/metric/llm_geval_score.py`

### テスト

text/chatの両方について、端数バッチ、バッチ件数がラベル数を上回るケース、LMが不正な件数を返すケースを追加しています。

## 3. Bradley-TerryスコアがNaNになる

### 問題

旧実装には次の2つの問題がありました。

- 分母計算で「対象モデルが勝った相手」しか走査しておらず、負けた相手が欠落する
- 0を含むスコアを幾何平均で正規化し、`log(0)` からNaNが全モデルへ伝播する

さらに、全敗モデルを含む場合など、勝敗の有向グラフが強連結でなければBradley-Terryの有限MLE自体が存在しません。このケースを数値計算だけで処理しようとしていたため、無効なスコアが正常結果として返っていました。

### 修正

- 対戦相手を勝ち・負け双方の辺の和集合から取得
- 推定前に勝敗グラフの強連結性を検証
- iteration中の0以下の値と非有限値を明示的に検出
- 有限MLEが存在しない場合はBradley-Terryスコアを生成しない
- スコアラーごとに例外を隔離し、失敗したスコアだけを警告付きで省略
- `win_rate` と完了済みのjudge結果は返すため、高額なLLM judge呼び出し結果を失わない
- 旧 `eps` 引数は後方互換のため受理しつつ、指定時に `FutureWarning` を出す非動作パラメータとして非推奨化

### 主な対象

- `flexeval/core/pairwise_comparison/scorer/bradley_terry.py`
- `flexeval/core/evaluate_pairwise.py`

### テスト

1勝のみの2モデル、正常な相互対戦に全敗モデルを追加したケースを拒否し、強連結なサイクルでは有限スコアを返すことを確認しています。また、1つのスコアラーが失敗しても他のスコアと対戦結果が返ることを確認しています。

## 4. Pairwise評価が行番号だけで出力を対応付ける

### 問題

モデル間で出力件数だけを確認し、各行が同じ問題に対応しているかを検証していませんでした。並び順が異なるJSONLを渡しても評価が正常終了し、異なる問題の回答同士から無意味なスコアが生成されます。

フレームワーク全体には共通のinstance IDがないため、完全なID照合ではなく、利用可能な入力情報を使った検証が必要です。

### 修正

- judge実行前に各行の `references` と `extra_info` / `task_inputs` をモデル間で比較
- chat履歴ではモデル固有になりうるassistantロールを比較対象から除外
- 一方にidentity情報があり、他方にないケースも不整合として拒否
- 両方にidentity情報がない古い形式は、後方互換のため従来どおり行順を信頼

### 主な対象

- `flexeval/core/evaluate_pairwise.py`

### テスト

行順が異なるケース、片方だけidentity情報がないケースを拒否し、assistant履歴だけが異なる正当なケースは許可することを確認しています。

## 5. Few-shot適用時にキャッシュ済み会話が破壊的に変更される

### 問題

few-shotメッセージを追加する際、datasetが返した `ChatInstance.messages` をin-placeで置換していました。同じインスタンスをキャッシュして返すdatasetでは、評価を繰り返すたびにメッセージが累積します。`--num_repeats` は浅いコピーを使うため、この問題の影響を受けます。

### 修正

- few-shotを適用する場合だけ `ChatInstance` をdeep copyしてからメッセージを追加
- ChatbotBenchも内部のmessagesリストを直接渡さず、`__getitem__` で防御的にコピー

### 主な対象

- `flexeval/core/evaluate_chat_response.py`
- `flexeval/core/chat_dataset/chatbot_bench.py`

### テスト

同じキャッシュ済みインスタンスを使って評価を2回実行し、元のmessagesが変更されず、2回の出力も一致することを確認しています。ChatbotBenchについても、取得したインスタンスのリスト変更が次回取得へ残らないことを確認しています。
