### PR TITLE
Fix VLLMServeLM: fail fast when serve process exits during startup

### DIFF
--- a/flexeval/core/language_model/vllm_serve_lm.py
+++ b/flexeval/core/language_model/vllm_serve_lm.py
@@ -106,6 +106,17 @@ class VLLMServerManager:
 
         interval_second = 1
         for _ in range(self.timeout // interval_second):
+            # Fail fast if the vLLM process disappears or exits while the server is starting.
+            if self.process is None:
+                msg = "vLLM server process is not initialized."
+                raise RuntimeError(msg)
+
+            returncode = self.process.poll()
+            if returncode is not None:
+                self.stop()
+                msg = f"vLLM server process terminated unexpectedly. {returncode=}"
+                raise RuntimeError(msg)
+
             if self.is_ready():
                 logger.info(f"vLLM server is ready at {self.base_url}")
                 return self.host, self.port

--- a/tests/core/language_model/vllm/test_vllm_serve_lm.py
+++ b/tests/core/language_model/vllm/test_vllm_serve_lm.py
@@ -72,6 +72,41 @@ def test_start_invokes_subprocess_and_waits_for_http() -> None:
         mock_get.assert_called_with(f"http://localhost:{port}/v1/models", timeout=1)
 
 
+def test_start_raises_immediately_when_process_exits_and_can_retry() -> None:
+    failed_process = mock.Mock()
+    failed_process.stdout = DummyStream([""])
+    failed_process.stderr = DummyStream([""])
+    failed_process.poll.return_value = 1
+
+    running_process = mock.Mock()
+    running_process.stdout = DummyStream([""])
+    running_process.stderr = DummyStream([""])
+    running_process.poll.return_value = None
+    running_process.wait.return_value = 0
+
+    with (
+        mock.patch("subprocess.Popen", side_effect=[failed_process, running_process]) as mock_popen,
+        mock.patch("requests.get") as mock_get,
+        mock.patch("time.sleep") as mock_sleep,
+    ):
+        mock_get.return_value.status_code = 200
+        manager = VLLMServerManager(model="dummy")
+
+        with pytest.raises(RuntimeError, match="returncode=1"):
+            manager.start()
+
+        assert manager.process is None
+        mock_sleep.assert_not_called()
+        mock_get.assert_not_called()
+
+        host, port = manager.start()
+        manager.stop()
+
+        assert host == "localhost"
+        assert isinstance(port, int)
+        assert mock_popen.call_count == 2
+
+
 def test_stop_terminates_process() -> None:
     mock_process = mock.Mock()
     mock_process.poll.return_value = None


### PR DESCRIPTION
## 概要

`VLLMServeLM ` でvllmを起動後、vllmがAPIリクエスト待ち受け可能になる前にクラッシュした際、flexeval側がそれを検知できずに待ち受けタイムアウト(デフォルト3600秒)まで待機し続ける不具合を修正する。

現在の実装は A. [ここ](https://github.com/sbintuitions/flexeval/blob/8a07c3cad7449e4407860af100b3a57fbdda888a/flexeval/core/language_model/vllm_serve_lm.py#L109)で待ち受け待機ループを、B. [ここ](https://github.com/sbintuitions/flexeval/blob/8a07c3cad7449e4407860af100b3a57fbdda888a/flexeval/core/language_model/vllm_serve_lm.py#L138)でAPIのreadiness監視を行っている。

vllmが起動中にクラッシュした場合、Bのチェックで利用している `self.process.poll()` がintのreturncodeを返す[仕様](vllmが起動中にクラッシュした場合)となっているために、必ず`if self.process is None or self.process.poll() is not None:`の判定がTrueとなってしまう。
結果、Aの待受ループから抜けられずにタイムアウトまで無限待機が発生しているものと思われる。

## 変更

- `flexeval/core/language_model/vllm_serve_lm.py`
  - Aの待ち受けループ内に `self.process.poll()` が `returncode` を返していないかチェックする処理を追加
  - Bに元々あった`self.process.poll()`は削除せず残している。Aの待機ループ外でもBは利用されており、そちらではこのチェックが必要と思われるため

- `tests/core/language_model/vllm/test_vllm_serve_lm.py`
  - 単体テスト追加。vllmのmockが即座にreturncodeを返した場合に想定した挙動になっているかチェック

