### PR TITLE
outputs.jsonl へ judgeのreasoning_textを出力するオプションを追加

### DIFF
--- a/docs/how_to/evaluate_with_llm_judges.md
+++ b/docs/how_to/evaluate_with_llm_judges.md
@@ -58,7 +58,7 @@ You can check the output of the evaluator LLM in the `llm_score_output` field.
 head -n 1 results/mt-en-gpt3.5-turbo/eval_by_gpt/outputs.jsonl | jq -r ".llm_output"
 ```
 
-If the judge model returns reasoning content (e.g., by setting `--reasoning-parser` in vLLM serve, or `reasoning_parser` in `HuggingFaceLM` and `VLLM`), it is stored in the `llm_score_reasoning_text` field.
+To also save the judge's reasoning content, set `output_reasoning_text` to `true` in the metric config. The reasoning is then stored in the `llm_score_reasoning_text` field. This requires a judge that returns reasoning content, e.g., by setting `--reasoning-parser` in vLLM serve, or `reasoning_parser` in `HuggingFaceLM` and `VLLM`.
 
 !!! info
     `flexeval_file` just runs the same evaluation as `flexeval_lm` but with the given file.

--- a/docs/how_to/evaluate_with_llm_judges.md
+++ b/docs/how_to/evaluate_with_llm_judges.md
@@ -58,6 +58,8 @@ You can check the output of the evaluator LLM in the `llm_score_output` field.
 head -n 1 results/mt-en-gpt3.5-turbo/eval_by_gpt/outputs.jsonl | jq -r ".llm_output"
 ```
 
+If the judge model returns reasoning content (e.g., by setting `--reasoning-parser` in vLLM serve, or `reasoning_parser` in `HuggingFaceLM` and `VLLM`), it is stored in the `llm_score_reasoning_text` field.
+
 !!! info
     `flexeval_file` just runs the same evaluation as `flexeval_lm` but with the given file.
     So, theoretically, you can perform the same evaluation with `flexeval_lm` in one go:

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -93,7 +93,6 @@ class LLMLabel(Metric):
     The last label value found in the output of the evaluator is used to compute the evaluation score.
     You can assign a score to each label.
     The final output is the average score and the distribution of the labels.
-    If the evaluator returns reasoning content, it is stored as `llm_label_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -105,6 +104,8 @@ class LLMLabel(Metric):
         category_key: A key to create category-wise mean score.
             The category key is expected to be in extra_info.
         metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
+        output_reasoning_text: If True, store the evaluator's reasoning content
+            as `llm_label_reasoning_text` in the instance details.
 
     Examples:
         >>> from flexeval import OpenAIChatAPI, Jinja2PromptTemplate, LLMLabel
@@ -147,6 +148,7 @@ class LLMLabel(Metric):
         valid_score_range: tuple[int, int] | None = None,
         category_key: str | None = None,
         metric_prefix: str | None = None,
+        output_reasoning_text: bool = False,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -167,6 +169,7 @@ class LLMLabel(Metric):
         self.valid_score_range = valid_score_range
         self.category_key = category_key
         self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
+        self.output_reasoning_text = output_reasoning_text
 
     def evaluate(
         self,
@@ -221,7 +224,7 @@ class LLMLabel(Metric):
                 }
                 | (
                     {f"{self.metric_prefix}llm_label_reasoning_text": eval_out.reasoning_text}
-                    if eval_out.reasoning_text
+                    if self.output_reasoning_text
                     else {}
                 )
                 for eval_label, eval_score, eval_in, eval_out in zip(
@@ -245,7 +248,6 @@ class LLMLabel(Metric):
 class ChatLLMLabel(Metric):
     """
     A metric that evaluates the output of `LanguageModel.batch_generate_chat_response`.
-    If the evaluator returns reasoning content, it is stored as `llm_label_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -258,6 +260,8 @@ class ChatLLMLabel(Metric):
         category_key: A key to create category-wise mean score.
             The category key is expected to be in extra_info.
         metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
+        output_reasoning_text: If True, store the evaluator's reasoning content
+            as `llm_label_reasoning_text` in the instance details.
 
     Examples:
         >>> from flexeval import ChatLLMScore, OpenAIChatAPI, Jinja2PromptTemplate
@@ -301,6 +305,7 @@ class ChatLLMLabel(Metric):
         disable_tqdm: bool = False,
         category_key: str | None = None,
         metric_prefix: str | None = None,
+        output_reasoning_text: bool = False,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -321,6 +326,7 @@ class ChatLLMLabel(Metric):
         self.disable_tqdm = disable_tqdm
         self.category_key = category_key
         self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
+        self.output_reasoning_text = output_reasoning_text
 
     def evaluate(
         self,
@@ -376,7 +382,7 @@ class ChatLLMLabel(Metric):
                 }
                 | (
                     {f"{self.metric_prefix}llm_label_reasoning_text": eval_out.reasoning_text}
-                    if eval_out.reasoning_text
+                    if self.output_reasoning_text
                     else {}
                 )
                 for eval_label, eval_score, eval_in, eval_out in zip(

--- a/flexeval/core/metric/llm_label.py
+++ b/flexeval/core/metric/llm_label.py
@@ -93,6 +93,7 @@ class LLMLabel(Metric):
     The last label value found in the output of the evaluator is used to compute the evaluation score.
     You can assign a score to each label.
     The final output is the average score and the distribution of the labels.
+    If the evaluator returns reasoning content, it is stored as `llm_label_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -218,6 +219,11 @@ class LLMLabel(Metric):
                     f"{self.metric_prefix}llm_label_input": eval_in,
                     f"{self.metric_prefix}llm_label_output": eval_out.text,
                 }
+                | (
+                    {f"{self.metric_prefix}llm_label_reasoning_text": eval_out.reasoning_text}
+                    if eval_out.reasoning_text
+                    else {}
+                )
                 for eval_label, eval_score, eval_in, eval_out in zip(
                     evaluator_label_list,
                     evaluator_score_list,
@@ -239,6 +245,7 @@ class LLMLabel(Metric):
 class ChatLLMLabel(Metric):
     """
     A metric that evaluates the output of `LanguageModel.batch_generate_chat_response`.
+    If the evaluator returns reasoning content, it is stored as `llm_label_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -367,6 +374,11 @@ class ChatLLMLabel(Metric):
                     f"{self.metric_prefix}llm_label_input": eval_in,
                     f"{self.metric_prefix}llm_label_output": eval_out.text,
                 }
+                | (
+                    {f"{self.metric_prefix}llm_label_reasoning_text": eval_out.reasoning_text}
+                    if eval_out.reasoning_text
+                    else {}
+                )
                 for eval_label, eval_score, eval_in, eval_out in zip(
                     evaluator_label_list,
                     evaluator_score_list,

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -184,7 +184,6 @@ class LLMScore(Metric):
 
     You can specify the evaluation criteria in `PromptTemplate`.
     The last integer value in the output of the evaluator is used as the evaluation score.
-    If the evaluator returns reasoning content, it is stored as `llm_score_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -197,6 +196,8 @@ class LLMScore(Metric):
             The category keys are expected to be in extra_info.
         metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
         regex_to_parse_score: A regular expression to parse score.
+        output_reasoning_text: If True, store the evaluator's reasoning content
+            as `llm_score_reasoning_text` in the instance details.
 
     Examples:
         >>> from flexeval import LLMScore, OpenAIChatAPI, Jinja2PromptTemplate
@@ -232,6 +233,7 @@ class LLMScore(Metric):
         category_key: str | list[str] | None = None,
         metric_prefix: str | None = None,
         regex_to_parse_score: str = r"(\d+)",
+        output_reasoning_text: bool = False,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -241,6 +243,7 @@ class LLMScore(Metric):
         self.category_key = category_key
         self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
         self.regex_to_parse_score = regex_to_parse_score
+        self.output_reasoning_text = output_reasoning_text
 
     def evaluate(
         self,
@@ -290,7 +293,7 @@ class LLMScore(Metric):
                 }
                 | (
                     {f"{self.metric_prefix}llm_score_reasoning_text": eval_out.reasoning_text}
-                    if eval_out.reasoning_text
+                    if self.output_reasoning_text
                     else {}
                 )
                 for eval_score, eval_in, eval_out in zip(
@@ -313,7 +316,6 @@ class LLMScore(Metric):
 class ChatLLMScore(Metric):
     """
     A metric that evaluates the output of `LanguageModel.batch_generate_chat_response`.
-    If the evaluator returns reasoning content, it is stored as `llm_score_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -327,6 +329,8 @@ class ChatLLMScore(Metric):
             The category keys are expected to be in extra_info.
         metric_prefix: A prefix to be added to the metric keys in the summary and instance details.
         regex_to_parse_score: A regular expression to parse score.
+        output_reasoning_text: If True, store the evaluator's reasoning content
+            as `llm_score_reasoning_text` in the instance details.
 
     Examples:
         >>> from flexeval import ChatLLMScore, OpenAIChatAPI, Jinja2PromptTemplate
@@ -364,6 +368,7 @@ class ChatLLMScore(Metric):
         category_key: str | list[str] | None = None,
         metric_prefix: str | None = None,
         regex_to_parse_score: str = r"(\d+)",
+        output_reasoning_text: bool = False,
     ) -> None:
         self.language_model = language_model
         self.prompt_template = prompt_template
@@ -374,6 +379,7 @@ class ChatLLMScore(Metric):
         self.category_key = category_key
         self.metric_prefix = f"{metric_prefix}-" if metric_prefix else ""
         self.regex_to_parse_score = regex_to_parse_score
+        self.output_reasoning_text = output_reasoning_text
 
     def evaluate(
         self,
@@ -421,7 +427,7 @@ class ChatLLMScore(Metric):
                 }
                 | (
                     {f"{self.metric_prefix}llm_score_reasoning_text": eval_out.reasoning_text}
-                    if eval_out.reasoning_text
+                    if self.output_reasoning_text
                     else {}
                 )
                 for eval_score, eval_in, eval_out in zip(

--- a/flexeval/core/metric/llm_score.py
+++ b/flexeval/core/metric/llm_score.py
@@ -161,7 +161,7 @@ def generate_evaluations(
         disable=disable_tqdm,
         desc=desc_for_tqdm,
     ) as pbar:
-        evaluator_output_list: list[str] = []
+        evaluator_output_list: list[LMOutput] = []
         for batch_inputs in batch_iter(
             evaluator_input_list,
             batch_size=batch_size,
@@ -184,6 +184,7 @@ class LLMScore(Metric):
 
     You can specify the evaluation criteria in `PromptTemplate`.
     The last integer value in the output of the evaluator is used as the evaluation score.
+    If the evaluator returns reasoning content, it is stored as `llm_score_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -287,6 +288,11 @@ class LLMScore(Metric):
                     f"{self.metric_prefix}llm_score_input": eval_in,
                     f"{self.metric_prefix}llm_score_output": eval_out.text,
                 }
+                | (
+                    {f"{self.metric_prefix}llm_score_reasoning_text": eval_out.reasoning_text}
+                    if eval_out.reasoning_text
+                    else {}
+                )
                 for eval_score, eval_in, eval_out in zip(
                     evaluator_score_list,
                     evaluator_input_list,
@@ -307,6 +313,7 @@ class LLMScore(Metric):
 class ChatLLMScore(Metric):
     """
     A metric that evaluates the output of `LanguageModel.batch_generate_chat_response`.
+    If the evaluator returns reasoning content, it is stored as `llm_score_reasoning_text` in the instance details.
 
     Args:
         language_model: An instance of `LanguageModel` to evaluate the output of the model.
@@ -412,6 +419,11 @@ class ChatLLMScore(Metric):
                     f"{self.metric_prefix}llm_score_input": eval_in,
                     f"{self.metric_prefix}llm_score_output": eval_out.text,
                 }
+                | (
+                    {f"{self.metric_prefix}llm_score_reasoning_text": eval_out.reasoning_text}
+                    if eval_out.reasoning_text
+                    else {}
+                )
                 for eval_score, eval_in, eval_out in zip(
                     evaluator_score_list,
                     evaluator_input_list,

--- a/flexeval/core/reward_model/pairwise_judge_reward_model.py
+++ b/flexeval/core/reward_model/pairwise_judge_reward_model.py
@@ -4,7 +4,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any
 
-from flexeval.core.language_model.base import LanguageModel
+from flexeval.core.language_model.base import LanguageModel, LMOutput
 from flexeval.core.prompt_template.base import PromptTemplate
 from flexeval.core.reward_bench_dataset import RewardBenchInstance
 from flexeval.core.reward_model.base import RewardModel
@@ -40,7 +40,7 @@ def evaluate_model_output(model_output: str, gold_label: PairwiseChoice) -> bool
 
 def aggregate_judge_results(
     outputs: list[dict],
-    judge_outputs: list,
+    judge_outputs: list[LMOutput],
     chosen_is_better_list: list[bool],
 ) -> tuple[list[bool], list[dict]]:
     """
@@ -50,28 +50,32 @@ def aggregate_judge_results(
     Returns:
         final_results: list[bool]
             A list indicating whether each instance is ultimately judged as correct.
+        aggregated_outputs: list[dict]
+            A list of per-instance details.
+            `llm_reasoning_texts` is added only when the judge returns reasoning content.
     """
     aggregated_results: list[bool] = []
     aggregated_outputs: list[dict] = []
 
     for i, output in enumerate(outputs):
-        ab_output_text = judge_outputs[i * 2].text
-        ba_output_text = judge_outputs[i * 2 + 1].text
+        ab_output = judge_outputs[i * 2]
+        ba_output = judge_outputs[i * 2 + 1]
         ab_eval = chosen_is_better_list[i * 2]
         ba_eval = chosen_is_better_list[i * 2 + 1]
 
         consistent = ab_eval == ba_eval
         is_correct = consistent and ab_eval
 
-        aggregated_outputs.append(
-            {
-                "llm_outputs": [ab_output_text, ba_output_text],
-                "evaluation_results": [ab_eval, ba_eval],
-                "consistent": consistent,
-                "is_correct": is_correct,
-                **output,
-            }
-        )
+        aggregated_output = {
+            "llm_outputs": [ab_output.text, ba_output.text],
+            "evaluation_results": [ab_eval, ba_eval],
+            "consistent": consistent,
+            "is_correct": is_correct,
+            **output,
+        }
+        if ab_output.reasoning_text or ba_output.reasoning_text:
+            aggregated_output["llm_reasoning_texts"] = [ab_output.reasoning_text, ba_output.reasoning_text]
+        aggregated_outputs.append(aggregated_output)
         aggregated_results.append(is_correct)
 
     return aggregated_results, aggregated_outputs

--- a/flexeval/core/reward_model/pairwise_judge_reward_model.py
+++ b/flexeval/core/reward_model/pairwise_judge_reward_model.py
@@ -42,17 +42,23 @@ def aggregate_judge_results(
     outputs: list[dict],
     judge_outputs: list[LMOutput],
     chosen_is_better_list: list[bool],
+    output_reasoning_text: bool = False,
 ) -> tuple[list[bool], list[dict]]:
     """
     Aggregates the doubled-length `judge_outputs` and `chosen_is_better_list`
     into final results for each individual instance.
+
+    Args:
+        outputs: Per-instance details to merge into the aggregated outputs.
+        judge_outputs: Judge outputs, twice the length of `outputs`.
+        chosen_is_better_list: Whether the chosen answer won, twice the length of `outputs`.
+        output_reasoning_text: If True, add `llm_reasoning_texts` to the aggregated outputs.
 
     Returns:
         final_results: list[bool]
             A list indicating whether each instance is ultimately judged as correct.
         aggregated_outputs: list[dict]
             A list of per-instance details.
-            `llm_reasoning_texts` is added only when the judge returns reasoning content.
     """
     aggregated_results: list[bool] = []
     aggregated_outputs: list[dict] = []
@@ -73,7 +79,7 @@ def aggregate_judge_results(
             "is_correct": is_correct,
             **output,
         }
-        if ab_output.reasoning_text or ba_output.reasoning_text:
+        if output_reasoning_text:
             aggregated_output["llm_reasoning_texts"] = [ab_output.reasoning_text, ba_output.reasoning_text]
         aggregated_outputs.append(aggregated_output)
         aggregated_results.append(is_correct)
@@ -106,6 +112,8 @@ class PairwiseJudgeRewardModel(RewardModel):
                          Be sure to include {{prompt}}, {{answer_a}}, and {{answer_b}}.
         system_message: The system message to prepend to the chat messages.
         gen_kwargs: Generation kwargs for the language model.
+        output_reasoning_text: If True, store the judge's reasoning content
+            as `llm_reasoning_texts` in the outputs.
     """
 
     def __init__(
@@ -114,6 +122,7 @@ class PairwiseJudgeRewardModel(RewardModel):
         prompt_template: PromptTemplate,
         system_message: str | PromptTemplate | None = None,
         gen_kwargs: dict[str, Any] | None = None,
+        output_reasoning_text: bool = False,
     ) -> None:
         if gen_kwargs is None:
             gen_kwargs = {}
@@ -121,6 +130,7 @@ class PairwiseJudgeRewardModel(RewardModel):
         self.prompt_template = prompt_template
         self.system_message = system_message
         self.gen_kwargs = gen_kwargs
+        self.output_reasoning_text = output_reasoning_text
 
     def _create_input_chat_messages_list(self, pairwise_instance: PairwiseInstance) -> list[dict[str, str]]:
         pairwise_instance_asdict = asdict(pairwise_instance)
@@ -186,6 +196,8 @@ class PairwiseJudgeRewardModel(RewardModel):
             msg = "The number of outputs should be twice the number of inputs."
             raise ValueError(msg)
 
-        aggregated_results, aggregated_outputs = aggregate_judge_results(outputs, judge_outputs, chosen_is_better_list)
+        aggregated_results, aggregated_outputs = aggregate_judge_results(
+            outputs, judge_outputs, chosen_is_better_list, self.output_reasoning_text
+        )
 
         return aggregated_results, aggregated_outputs

--- a/tests/core/metric/test_llm_label.py
+++ b/tests/core/metric/test_llm_label.py
@@ -124,6 +124,7 @@ def test_llm_label_with_reasoning(metric_prefix: str) -> None:
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],
         metric_prefix=metric_prefix,
+        output_reasoning_text=True,
     )
     metric_output = metric.evaluate(
         lm_outputs=["This is Good."],
@@ -136,8 +137,9 @@ def test_llm_label_with_reasoning(metric_prefix: str) -> None:
 
 
 def test_llm_label_without_reasoning() -> None:
+    """Reasoning is not stored unless `output_reasoning_text` is enabled."""
     metric = LLMLabel(
-        language_model=EchoBackLanguageModel(),
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],
@@ -219,6 +221,7 @@ def test_chat_llm_label_with_reasoning(metric_prefix: str) -> None:
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],
         metric_prefix=metric_prefix,
+        output_reasoning_text=True,
     )
     metric_output = metric.evaluate(
         lm_outputs=["This is Good."],
@@ -231,8 +234,9 @@ def test_chat_llm_label_with_reasoning(metric_prefix: str) -> None:
 
 
 def test_chat_llm_label_without_reasoning() -> None:
+    """Reasoning is not stored unless `output_reasoning_text` is enabled."""
     metric = ChatLLMLabel(
-        language_model=EchoBackLanguageModel(),
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         label_names=["Good", "Neutral", "Bad"],
         label_points=[1.0, 0.5, 0.0],

--- a/tests/core/metric/test_llm_label.py
+++ b/tests/core/metric/test_llm_label.py
@@ -9,6 +9,15 @@ from flexeval.core.metric.utils import extract_text_from_outputs
 
 
 class EchoBackLanguageModel(LanguageModel):
+    """Echo back the input as the output.
+
+    Args:
+        reasoning_text: If given, returned as the reasoning content of every output.
+    """
+
+    def __init__(self, reasoning_text: str | None = None) -> None:
+        self.reasoning_text = reasoning_text
+
     def complete_text(
         self,
         text_list: list[str],
@@ -16,14 +25,17 @@ class EchoBackLanguageModel(LanguageModel):
         max_new_tokens: int | None = None,
         **kwargs,
     ) -> list[LMOutput]:
-        return [LMOutput(text=text, finish_reason="length") for text in text_list]
+        return [LMOutput(text=text, reasoning_text=self.reasoning_text, finish_reason="length") for text in text_list]
 
     def generate_chat_response(
         self,
         chat_messages_list: list[list[dict[str, str]]],
         **kwargs,
     ) -> list[LMOutput]:
-        return [LMOutput(text=mes[-1]["content"], finish_reason="length") for mes in chat_messages_list]
+        return [
+            LMOutput(text=mes[-1]["content"], reasoning_text=self.reasoning_text, finish_reason="length")
+            for mes in chat_messages_list
+        ]
 
 
 @pytest.mark.parametrize(
@@ -104,6 +116,39 @@ def test_llm_label(
         assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output
 
 
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_llm_label_with_reasoning(metric_prefix: str) -> None:
+    metric = LLMLabel(
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+        metric_prefix=metric_prefix,
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This is Good."],
+    )
+
+    if metric_prefix:
+        metric_prefix += "-"
+    instance_detail = metric_output.instance_details[0]
+    assert instance_detail[f"{metric_prefix}llm_label_reasoning_text"] == "reasoning"
+
+
+def test_llm_label_without_reasoning() -> None:
+    metric = LLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This is Good."],
+    )
+
+    assert "llm_label_reasoning_text" not in metric_output.instance_details[0]
+
+
 @pytest.mark.parametrize(
     ("lm_outputs", "extra_info_list", "expected_summary"),
     [
@@ -164,6 +209,39 @@ def test_chat_llm_label(
     for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_label_input"] == [{"role": "user", "content": lm_output}]
         assert instance_detail[f"{metric_prefix}llm_label_output"] == lm_output
+
+
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_chat_llm_label_with_reasoning(metric_prefix: str) -> None:
+    metric = ChatLLMLabel(
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+        metric_prefix=metric_prefix,
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This is Good."],
+    )
+
+    if metric_prefix:
+        metric_prefix += "-"
+    instance_detail = metric_output.instance_details[0]
+    assert instance_detail[f"{metric_prefix}llm_label_reasoning_text"] == "reasoning"
+
+
+def test_chat_llm_label_without_reasoning() -> None:
+    metric = ChatLLMLabel(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        label_names=["Good", "Neutral", "Bad"],
+        label_points=[1.0, 0.5, 0.0],
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This is Good."],
+    )
+
+    assert "llm_label_reasoning_text" not in metric_output.instance_details[0]
 
 
 def test_llm_label_reasoning() -> None:

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -272,6 +272,7 @@ def test_llm_score_with_reasoning(metric_prefix: str) -> None:
         language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         metric_prefix=metric_prefix,
+        output_reasoning_text=True,
     )
     metric_output = metric.evaluate(
         lm_outputs=["This score is 1."],
@@ -284,8 +285,9 @@ def test_llm_score_with_reasoning(metric_prefix: str) -> None:
 
 
 def test_llm_score_without_reasoning() -> None:
+    """Reasoning is not stored unless `output_reasoning_text` is enabled."""
     metric = LLMScore(
-        language_model=EchoBackLanguageModel(),
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
     )
     metric_output = metric.evaluate(
@@ -529,6 +531,7 @@ def test_chat_llm_score_with_reasoning(metric_prefix: str) -> None:
         language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
         metric_prefix=metric_prefix,
+        output_reasoning_text=True,
     )
     metric_output = metric.evaluate(
         lm_outputs=["This score is 1."],
@@ -541,8 +544,9 @@ def test_chat_llm_score_with_reasoning(metric_prefix: str) -> None:
 
 
 def test_chat_llm_score_without_reasoning() -> None:
+    """Reasoning is not stored unless `output_reasoning_text` is enabled."""
     metric = ChatLLMScore(
-        language_model=EchoBackLanguageModel(),
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
         prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
     )
     metric_output = metric.evaluate(

--- a/tests/core/metric/test_llm_score.py
+++ b/tests/core/metric/test_llm_score.py
@@ -14,6 +14,15 @@ from flexeval.core.metric.utils import extract_text_from_outputs
 
 
 class EchoBackLanguageModel(LanguageModel):
+    """Echo back the input as the output.
+
+    Args:
+        reasoning_text: If given, returned as the reasoning content of every output.
+    """
+
+    def __init__(self, reasoning_text: str | None = None) -> None:
+        self.reasoning_text = reasoning_text
+
     def complete_text(
         self,
         text_list: list[str],
@@ -21,7 +30,7 @@ class EchoBackLanguageModel(LanguageModel):
         max_new_tokens: int | None = None,
         **kwargs,
     ) -> list[LMOutput]:
-        return [LMOutput(text=text, finish_reason="length") for text in text_list]
+        return [LMOutput(text=text, reasoning_text=self.reasoning_text, finish_reason="length") for text in text_list]
 
     def generate_chat_response(
         self,
@@ -29,7 +38,12 @@ class EchoBackLanguageModel(LanguageModel):
         **kwargs,
     ) -> list[LMOutput]:
         return [
-            LMOutput(text=chat_messages[-1]["content"], finish_reason="length") for chat_messages in chat_messages_list
+            LMOutput(
+                text=chat_messages[-1]["content"],
+                reasoning_text=self.reasoning_text,
+                finish_reason="length",
+            )
+            for chat_messages in chat_messages_list
         ]
 
 
@@ -250,6 +264,35 @@ def test_llm_score_metric_prefix(lm_outputs: list[str | LMOutput], metric_prefix
     for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_score_input"] == lm_output
         assert instance_detail[f"{metric_prefix}llm_score_output"] == lm_output
+
+
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_llm_score_with_reasoning(metric_prefix: str) -> None:
+    metric = LLMScore(
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        metric_prefix=metric_prefix,
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This score is 1."],
+    )
+
+    if metric_prefix:
+        metric_prefix += "-"
+    instance_detail = metric_output.instance_details[0]
+    assert instance_detail[f"{metric_prefix}llm_score_reasoning_text"] == "reasoning"
+
+
+def test_llm_score_without_reasoning() -> None:
+    metric = LLMScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This score is 1."],
+    )
+
+    assert "llm_score_reasoning_text" not in metric_output.instance_details[0]
 
 
 @pytest.mark.parametrize(
@@ -478,6 +521,35 @@ def test_chat_llm_score_metric_prefix(lm_outputs: list[str | LMOutput], metric_p
     for lm_output, instance_detail in zip(extract_text_from_outputs(lm_outputs), metric_output.instance_details):
         assert instance_detail[f"{metric_prefix}llm_score_input"] == [{"role": "user", "content": lm_output}]
         assert instance_detail[f"{metric_prefix}llm_score_output"] == lm_output
+
+
+@pytest.mark.parametrize("metric_prefix", ["", "prefix"])
+def test_chat_llm_score_with_reasoning(metric_prefix: str) -> None:
+    metric = ChatLLMScore(
+        language_model=EchoBackLanguageModel(reasoning_text="reasoning"),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+        metric_prefix=metric_prefix,
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This score is 1."],
+    )
+
+    if metric_prefix:
+        metric_prefix += "-"
+    instance_detail = metric_output.instance_details[0]
+    assert instance_detail[f"{metric_prefix}llm_score_reasoning_text"] == "reasoning"
+
+
+def test_chat_llm_score_without_reasoning() -> None:
+    metric = ChatLLMScore(
+        language_model=EchoBackLanguageModel(),
+        prompt_template=Jinja2PromptTemplate("{{ lm_output }}"),
+    )
+    metric_output = metric.evaluate(
+        lm_outputs=["This score is 1."],
+    )
+
+    assert "llm_score_reasoning_text" not in metric_output.instance_details[0]
 
 
 def test_prepare_chat_input_for_evaluator() -> None:

--- a/tests/core/reward_model/test_pairwise_judge_reward_model.py
+++ b/tests/core/reward_model/test_pairwise_judge_reward_model.py
@@ -1,6 +1,7 @@
 import pytest
 
 from flexeval import Jinja2PromptTemplate
+from flexeval.core.language_model.base import LMOutput
 from flexeval.core.reward_bench_dataset import RewardBenchInstance
 from flexeval.core.reward_model.pairwise_judge_reward_model import (
     PairwiseChoice,
@@ -54,13 +55,6 @@ def test_pairwise_judge_reward_model(num_samples: int) -> None:
     assert not any(final_results), "All evaluation results should be False"
 
 
-class _MockOut:
-    """dummy judge_output element with text field"""
-
-    def __init__(self, text: str) -> None:
-        self.text = text
-
-
 @pytest.mark.parametrize(
     ("pairs", "expected_finals", "expected_consistencies"),
     [
@@ -83,8 +77,8 @@ def test_aggregate_multiple_instances(pairs: list, expected_finals: list, expect
     judge_outputs = []
     chosen_is_better_list = []
     for i, (ab_eval, ba_eval) in enumerate(pairs):
-        judge_outputs.append(_MockOut(f"ab_text_{i}"))
-        judge_outputs.append(_MockOut(f"ba_text_{i}"))
+        judge_outputs.append(LMOutput(text=f"ab_text_{i}"))
+        judge_outputs.append(LMOutput(text=f"ba_text_{i}"))
         chosen_is_better_list.extend([ab_eval, ba_eval])
 
     final_results, final_outputs = aggregate_judge_results(outputs, judge_outputs, chosen_is_better_list)
@@ -95,3 +89,16 @@ def test_aggregate_multiple_instances(pairs: list, expected_finals: list, expect
         assert final_outputs[i]["is_correct"] == expected_finals[i]
         assert final_outputs[i]["llm_outputs"] == [f"ab_text_{i}", f"ba_text_{i}"]
         assert final_outputs[i]["evaluation_results"] == list(pairs[i])
+        assert "llm_reasoning_texts" not in final_outputs[i]
+
+
+def test_aggregate_judge_results_with_reasoning() -> None:
+    outputs = [{"llm_inputs": ["ab", "ba"]}]
+    judge_outputs = [
+        LMOutput(text="ab_text", reasoning_text="ab_reasoning"),
+        LMOutput(text="ba_text"),
+    ]
+
+    _, final_outputs = aggregate_judge_results(outputs, judge_outputs, [True, True])
+
+    assert final_outputs[0]["llm_reasoning_texts"] == ["ab_reasoning", None]

--- a/tests/core/reward_model/test_pairwise_judge_reward_model.py
+++ b/tests/core/reward_model/test_pairwise_judge_reward_model.py
@@ -99,6 +99,19 @@ def test_aggregate_judge_results_with_reasoning() -> None:
         LMOutput(text="ba_text"),
     ]
 
-    _, final_outputs = aggregate_judge_results(outputs, judge_outputs, [True, True])
+    _, final_outputs = aggregate_judge_results(outputs, judge_outputs, [True, True], output_reasoning_text=True)
 
     assert final_outputs[0]["llm_reasoning_texts"] == ["ab_reasoning", None]
+
+
+def test_aggregate_judge_results_without_reasoning() -> None:
+    """Reasoning is not stored unless `output_reasoning_text` is enabled."""
+    outputs = [{"llm_inputs": ["ab", "ba"]}]
+    judge_outputs = [
+        LMOutput(text="ab_text", reasoning_text="ab_reasoning"),
+        LMOutput(text="ba_text", reasoning_text="ba_reasoning"),
+    ]
+
+    _, final_outputs = aggregate_judge_results(outputs, judge_outputs, [True, True])
+
+    assert "llm_reasoning_texts" not in final_outputs[0]


### PR DESCRIPTION
## 概要
- Judgeのreasoning_textをoutputs.jsonlへ出力できるオプションを追加
- デフォルトはFalse（=出力しない）なので、すでに存在するMetricへの影響はない

## 使用方法

### VLLMServeLM

例えば以下のように `elyza_tasks_100.jsonnet` のファイルの`init_args`に`output_reasoning_text: true`を追加すればreasonig_textが出力されるようになる。

```jsonnet
{
  class_path: 'ChatLLMScore',
  init_args: {
    ...
    output_reasoning_text: true,
      },
    },
  },
}
// setup-command: export VLLM_USE_V1=1
```

`OpenAIChatAPI` と `LiteLLMChatAPI` も同様に、Metric 側に `output_reasoning_text: true` を足すだけでよい。これらはレスポンスの `reasoning` / `reasoning_content` をそのまま読むため、LanguageModel 側の追加設定は不要（`VLLMServeLM` と `LiteLLMChatAPI` は `OpenAIChatAPI` を継承している）。

### VLLM / HuggingFaceLM

こちらは Metric 側だけでは不十分で、LanguageModel 側に `reasoning_parser` を指定する必要がある。指定しないと `LMOutput.reasoning_text` が `None` のままになり、キーは出力されても値が `null` になる。

```jsonnet
{
  class_path: 'ChatLLMScore',
  init_args: {
    output_reasoning_text: true,
    language_model: {
      class_path: 'VLLM',
      init_args: {
        model: '/path/to/model,
        reasoning_parser: {
          class_path: 'SeparatedRegexReasoningParser',
          init_args: {
            pattern_for_content: '^(?:.*</think>\\s*)?(.*)$',
            pattern_for_reasoning_content: '<think>(.*?)</think>',
          },
        },
      },
    },
  },
}
```

reasoning を残すには `reasoning_parser` を使用する。

`UnifiedRegexReasoningParser` ではなく `SeparatedRegexReasoningParser` を使うと、`</think>` が出力されなかった場合（思考が max tokens で打ち切られた等）でも本文が空にならない。

| 出力 | text | reasoning_text |
| --- | --- | --- |
| `<think>...</think>4` | `4` | 思考部分 |
| `4`（think なし） | `4` | `null` |
| `<think>切れた思考...`（閉じタグなし） | 出力全体 | `null` |

## 注意点

- `output_reasoning_text: true` にすると、judge が reasoning を返さなかった場合もキー自体は `null` で出力される（インスタンス間でスキーマを揃えるため）。

## 出力
outputs.jsonl は以下のような出力になります。
```json
{
  "llm_label_output": "Yes",
  "llm_label_reasoning_text": "We need to decide if the ..
}
```